### PR TITLE
feat: block standard import for controlled packages

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -100,7 +100,8 @@
           "deleteModel": "Are you sure you want to delete this model?",
           "importSuccess": "Imported Successfully",
           "clickOrDragToImport": "Click or drag here to import",
-          "importing": "Importing {current}/{total}"
+          "importing": "Importing {current}/{total}",
+          "alreadyImported": "Model already imported"
         },
         "tooltips": {
           "createModel": "Create Model",
@@ -119,6 +120,11 @@
             "mutualExclusionRules": "Mutual exclusion rules",
             "ruleIndex": "Rule {index}"
           }
+        },
+        "controlledImport": {
+          "title": "Controlled packages cannot be imported here",
+          "content": "Detected controlled package {packageId}. Please use the dedicated controlled import flow.",
+          "unknownPackage": "unknown"
         }
       },
       "shortcut": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -100,7 +100,8 @@
           "deleteModel": "Tem certeza de que deseja excluir este modelo?",
           "importSuccess": "Importação bem-sucedida",
           "clickOrDragToImport": "Clique ou arraste para importar",
-          "importing": "Importando {current}/{total}"
+          "importing": "Importando {current}/{total}",
+          "alreadyImported": "Modelo j? importado"
         },
         "tooltips": {
           "createModel": "Criar modelo",
@@ -119,6 +120,11 @@
             "mutualExclusionRules": "Mutual exclusion rules",
             "ruleIndex": "Rule {index}"
           }
+        },
+        "controlledImport": {
+          "title": "Pacotes controlados n?o podem ser importados aqui",
+          "content": "Pacote controlado {packageId} detectado. Use o fluxo dedicado de importa??o controlada.",
+          "unknownPackage": "desconhecido"
         }
       },
       "shortcut": {

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -100,7 +100,8 @@
           "deleteModel": "Bạn chắc muốn xóa mô hình này?",
           "importSuccess": "Nhập thành công",
           "clickOrDragToImport": "Nhấp hoặc kéo tệp vào đây",
-          "importing": "Đang nhập {current}/{total}"
+          "importing": "Đang nhập {current}/{total}",
+          "alreadyImported": "M? h?nh ?? ???c nh?p"
         },
         "tooltips": {
           "createModel": "Tạo mô hình",
@@ -119,6 +120,11 @@
             "mutualExclusionRules": "Mutual exclusion rules",
             "ruleIndex": "Rule {index}"
           }
+        },
+        "controlledImport": {
+          "title": "Kh?ng th? nh?p g?i c? ki?m so?t t?i ??y",
+          "content": "Ph?t hi?n g?i c? ki?m so?t {packageId}. Vui l?ng d?ng lu?ng nh?p chuy?n d?ng.",
+          "unknownPackage": "kh?ng r?"
         }
       },
       "shortcut": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -100,7 +100,8 @@
           "deleteModel": "你确定要删除此模型吗？",
           "importSuccess": "导入成功",
           "clickOrDragToImport": "点击或拖动至此区域导入",
-          "importing": "正在导入 {current}/{total}"
+          "importing": "正在导入 {current}/{total}",
+          "alreadyImported": "?????"
         },
         "tooltips": {
           "createModel": "制作模型",
@@ -119,6 +120,11 @@
             "mutualExclusionRules": "互斥规则",
             "ruleIndex": "规则 {index}"
           }
+        },
+        "controlledImport": {
+          "title": "???????????",
+          "content": "???????? {packageId}???????????????",
+          "unknownPackage": "???"
         }
       },
       "shortcut": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -100,7 +100,8 @@
           "deleteModel": "您確定要刪除此模型嗎？",
           "importSuccess": "匯入成功",
           "clickOrDragToImport": "點擊或拖曳至此區域匯入",
-          "importing": "正在匯入 {current}/{total}"
+          "importing": "正在匯入 {current}/{total}",
+          "alreadyImported": "?????"
         },
         "tooltips": {
           "createModel": "製作模型",
@@ -119,6 +120,11 @@
             "mutualExclusionRules": "互斥規則",
             "ruleIndex": "規則 {index}"
           }
+        },
+        "controlledImport": {
+          "title": "???????????",
+          "content": "???????? {packageId}?????????????",
+          "unknownPackage": "???"
         }
       },
       "shortcut": {

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -14,6 +14,7 @@ import type { ModelMode } from '@/stores/model'
 
 import { INVOKE_KEY } from '@/constants'
 import { useModelStore } from '@/stores/model'
+import { readNearestControlledRelease } from '@/utils/controlledRelease'
 import { join } from '@/utils/path'
 
 interface LegacyPetConfig {
@@ -167,6 +168,19 @@ const GAMEPAD_BUTTON_NAMES = [
   'DPadRight',
 ]
 
+interface ImportResult {
+  status: 'imported' | 'duplicate' | 'blocked-controlled'
+  models?: Array<{
+    id: string
+    path: string
+    mode: ModelMode
+    isPreset: boolean
+    fingerprint?: string
+    importKind?: 'standard' | 'controlled'
+  }>
+  packageId?: string
+}
+
 onMounted(() => {
   const appWindow = getCurrentWebviewWindow()
 
@@ -235,15 +249,26 @@ watch(selectPaths, async (paths) => {
     importProgress.value = { current: index + 1, total: paths.length }
 
     try {
-      const importedModels = await importFromPath(fromPath)
+      const result = await importFromPath(fromPath)
 
-      if (!importedModels.length) {
-        message.info('Model already imported')
+      if (result.status === 'blocked-controlled') {
+        Modal.warning({
+          title: t('pages.preference.model.controlledImport.title'),
+          content: t('pages.preference.model.controlledImport.content', {
+            packageId: result.packageId ?? t('pages.preference.model.controlledImport.unknownPackage'),
+          }),
+        })
 
         continue
       }
 
-      for (const model of importedModels) {
+      if (result.status === 'duplicate') {
+        message.info(t('pages.preference.model.hints.alreadyImported'))
+
+        continue
+      }
+
+      for (const model of result.models ?? []) {
         modelStore.models.push(model)
       }
 
@@ -260,20 +285,21 @@ watch(selectPaths, async (paths) => {
 
 async function importFromPath(fromPath: string) {
   const sourcePath = await prepareImportSource(fromPath)
-  const controlledRelease = await readControlledRelease(sourcePath)
-
-  if (controlledRelease) {
-    Modal.warning({
-      title: '受控包暂不支持普通导入',
-      content: `检测到受控发行包 ${controlledRelease.packageId ?? ''}。请后续改用专用受控导入链路。`,
-    })
-    return []
-  }
-
   const variants = await discoverImportVariants(sourcePath)
 
   if (!variants.length) {
     throw new Error('No model3.json found')
+  }
+
+  const controlledVariant = variants.find(variant => variant.importKind === 'controlled')
+
+  if (controlledVariant) {
+    const release = await readNearestControlledRelease(controlledVariant.modelPath, sourcePath)
+
+    return {
+      status: 'blocked-controlled',
+      packageId: release?.packageId,
+    } satisfies ImportResult
   }
 
   const models = []
@@ -304,7 +330,11 @@ async function importFromPath(fromPath: string) {
     importedFingerprints.add(variant.fingerprint)
   }
 
-  return models
+  if (!models.length) {
+    return { status: 'duplicate' } satisfies ImportResult
+  }
+
+  return { status: 'imported', models } satisfies ImportResult
 }
 
 async function prepareImportSource(fromPath: string) {
@@ -352,13 +382,14 @@ async function discoverLegacyVariants(sourcePath: string) {
       const modelPath = join(rootPath, 'cat_model')
 
       if (!await exists(join(modelPath, 'cat.model3.json'))) continue
+      const controlledRelease = await readNearestControlledRelease(modelPath, sourcePath)
 
       variants.push({
         mode,
         rootPath,
         modelPath,
         fingerprint: await getModelFingerprint(modelPath, mode),
-        importKind: 'standard',
+        importKind: controlledRelease ? 'controlled' : 'standard',
       })
     }
   }
@@ -371,33 +402,16 @@ async function discoverCubismVariants(sourcePath: string) {
 
   return await Promise.all(modelPaths.map(async (modelPath): Promise<ImportVariant> => {
     const mode = await inferMode(modelPath)
+    const controlledRelease = await readNearestControlledRelease(modelPath, sourcePath)
 
     return {
       mode,
       rootPath: modelPath,
       modelPath,
       fingerprint: await getModelFingerprint(modelPath, mode),
-      importKind: 'standard',
+      importKind: controlledRelease ? 'controlled' : 'standard',
     }
   }))
-}
-
-async function readControlledRelease(sourcePath: string) {
-  const releasePath = join(sourcePath, 'mochi-control', 'release.json')
-
-  if (!await exists(releasePath)) return null
-
-  try {
-    return JSON5.parse(await readTextFile(releasePath)) as {
-      packageId?: string
-      releaseCode?: string
-    }
-  } catch {
-    return {
-      packageId: undefined,
-      releaseCode: undefined,
-    }
-  }
 }
 
 async function findDirectoriesNamed(rootPath: string, name: string) {

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -4,7 +4,7 @@ import { appDataDir } from '@tauri-apps/api/path'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { open } from '@tauri-apps/plugin-dialog'
 import { copyFile, exists, mkdir, readDir, readFile, readTextFile, stat } from '@tauri-apps/plugin-fs'
-import { message } from 'antdv-next'
+import { message, Modal } from 'antdv-next'
 import JSON5 from 'json5'
 import { nanoid } from 'nanoid'
 import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
@@ -56,6 +56,7 @@ interface ImportVariant {
   rootPath: string
   modelPath: string
   fingerprint: string
+  importKind: 'standard' | 'controlled'
 }
 
 interface KeyImageRef {
@@ -259,6 +260,16 @@ watch(selectPaths, async (paths) => {
 
 async function importFromPath(fromPath: string) {
   const sourcePath = await prepareImportSource(fromPath)
+  const controlledRelease = await readControlledRelease(sourcePath)
+
+  if (controlledRelease) {
+    Modal.warning({
+      title: '受控包暂不支持普通导入',
+      content: `检测到受控发行包 ${controlledRelease.packageId ?? ''}。请后续改用专用受控导入链路。`,
+    })
+    return []
+  }
+
   const variants = await discoverImportVariants(sourcePath)
 
   if (!variants.length) {
@@ -287,6 +298,7 @@ async function importFromPath(fromPath: string) {
       mode: variant.mode,
       isPreset: false,
       fingerprint: variant.fingerprint,
+      importKind: variant.importKind,
     })
 
     importedFingerprints.add(variant.fingerprint)
@@ -346,6 +358,7 @@ async function discoverLegacyVariants(sourcePath: string) {
         rootPath,
         modelPath,
         fingerprint: await getModelFingerprint(modelPath, mode),
+        importKind: 'standard',
       })
     }
   }
@@ -364,8 +377,27 @@ async function discoverCubismVariants(sourcePath: string) {
       rootPath: modelPath,
       modelPath,
       fingerprint: await getModelFingerprint(modelPath, mode),
+      importKind: 'standard',
     }
   }))
+}
+
+async function readControlledRelease(sourcePath: string) {
+  const releasePath = join(sourcePath, 'mochi-control', 'release.json')
+
+  if (!await exists(releasePath)) return null
+
+  try {
+    return JSON5.parse(await readTextFile(releasePath)) as {
+      packageId?: string
+      releaseCode?: string
+    }
+  } catch {
+    return {
+      packageId: undefined,
+      releaseCode: undefined,
+    }
+  }
 }
 
 async function findDirectoriesNamed(rootPath: string, name: string) {

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -8,6 +8,7 @@ import { reactive, ref } from 'vue'
 import { join } from '@/utils/path'
 
 export type ModelMode = 'standard' | 'keyboard' | 'gamepad'
+export type ModelImportKind = 'standard' | 'controlled'
 
 export interface Model {
   id: string
@@ -15,6 +16,7 @@ export interface Model {
   mode: ModelMode
   isPreset: boolean
   fingerprint?: string
+  importKind?: ModelImportKind
 }
 
 export interface ModelSupportKeyLayer {

--- a/src/utils/controlledRelease.ts
+++ b/src/utils/controlledRelease.ts
@@ -1,0 +1,61 @@
+import { exists, readTextFile } from '@tauri-apps/plugin-fs'
+import JSON5 from 'json5'
+
+import { join } from '@/utils/path'
+
+export interface ControlledRelease {
+  packageId?: string
+  releaseCode?: string
+}
+
+export async function readNearestControlledRelease(startPath: string, stopPath?: string) {
+  let currentPath = startPath
+  const normalizedStopPath = stopPath ? normalizePath(stopPath) : undefined
+
+  while (currentPath) {
+    const release = await readControlledRelease(currentPath)
+
+    if (release) return release
+
+    const normalizedCurrentPath = normalizePath(currentPath)
+
+    if (normalizedStopPath && normalizedCurrentPath === normalizedStopPath) {
+      return null
+    }
+
+    const parentPath = getParentPath(currentPath)
+
+    if (!parentPath || normalizePath(parentPath) === normalizedCurrentPath) {
+      return null
+    }
+
+    currentPath = parentPath
+  }
+
+  return null
+}
+
+async function readControlledRelease(sourcePath: string): Promise<ControlledRelease | null> {
+  const releasePath = join(sourcePath, 'mochi-control', 'release.json')
+
+  if (!await exists(releasePath)) return null
+
+  try {
+    return JSON5.parse(await readTextFile(releasePath)) as ControlledRelease
+  } catch {
+    return {}
+  }
+}
+
+function getParentPath(path: string) {
+  const separator = path.includes('\\') ? '\\' : '/'
+  const parts = path.split(/[\\/]/)
+
+  parts.pop()
+
+  return parts.join(separator)
+}
+
+function normalizePath(path: string) {
+  return path.replace(/[\\/]+/g, '/').replace(/\/$/, '').toLowerCase()
+}


### PR DESCRIPTION
## Summary
Block controlled-release packages from the standard import flow.

## Changes
- detect mochi-control/release.json during standard import
- show a warning modal when a controlled package is detected
- stop the normal import path for controlled packages
- persist model importKind metadata for imported models

## Testing
- verify standard packages still import normally
- verify controlled packages are detected and rejected from the standard import entry