### PR TITLE
feat: show model proof metadata and improve manifest discovery

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -99,8 +99,34 @@
           "deleteSuccess": "Deleted Successfully",
           "deleteModel": "Are you sure you want to delete this model?",
           "importSuccess": "Imported Successfully",
+          "alreadyImported": "Model already imported",
           "clickOrDragToImport": "Click or drag here to import",
           "importing": "Importing {current}/{total}"
+        },
+        "controlledImport": {
+          "title": "Controlled packages cannot be imported here",
+          "content": "Detected controlled package {packageId}. Please use the dedicated controlled import flow.",
+          "unknownPackage": "unknown"
+        },
+        "proof": {
+          "controlled": "Controlled",
+          "signed": "Signed",
+          "standard": "Standard"
+        },
+        "meta": {
+          "author": "Author",
+          "packageId": "Package",
+          "policy": "Policy",
+          "homepage": "Homepage",
+          "contact": "Contact",
+          "community": "Community",
+          "source": "Source",
+          "collaborators": "Collaborators"
+        },
+        "policy": {
+          "reimportRestricted": "Restricted re-import",
+          "runtimeTelemetryRequired": "Telemetry required",
+          "offlineLeaseAllowed": "Offline lease"
         },
         "tooltips": {
           "createModel": "Create Model",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -100,7 +100,8 @@
           "deleteModel": "Tem certeza de que deseja excluir este modelo?",
           "importSuccess": "Importação bem-sucedida",
           "clickOrDragToImport": "Clique ou arraste para importar",
-          "importing": "Importando {current}/{total}"
+          "importing": "Importando {current}/{total}",
+          "alreadyImported": "Modelo j? importado"
         },
         "tooltips": {
           "createModel": "Criar modelo",
@@ -119,6 +120,31 @@
             "mutualExclusionRules": "Mutual exclusion rules",
             "ruleIndex": "Rule {index}"
           }
+        },
+        "controlledImport": {
+          "title": "Pacotes controlados n?o podem ser importados aqui",
+          "content": "Pacote controlado {packageId} detectado. Use o fluxo dedicado de importa??o controlada.",
+          "unknownPackage": "desconhecido"
+        },
+        "proof": {
+          "controlled": "Controlado",
+          "signed": "Assinado",
+          "standard": "Padr?o"
+        },
+        "meta": {
+          "author": "Autor",
+          "packageId": "Pacote",
+          "policy": "Pol?tica",
+          "homepage": "P?gina inicial",
+          "contact": "Contato",
+          "community": "Comunidade",
+          "source": "Fonte",
+          "collaborators": "Colaboradores"
+        },
+        "policy": {
+          "reimportRestricted": "Reimporta??o restrita",
+          "runtimeTelemetryRequired": "Telemetria obrigat?ria",
+          "offlineLeaseAllowed": "Licen?a offline"
         }
       },
       "shortcut": {

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -100,7 +100,8 @@
           "deleteModel": "Bạn chắc muốn xóa mô hình này?",
           "importSuccess": "Nhập thành công",
           "clickOrDragToImport": "Nhấp hoặc kéo tệp vào đây",
-          "importing": "Đang nhập {current}/{total}"
+          "importing": "Đang nhập {current}/{total}",
+          "alreadyImported": "M? h?nh ?? ???c nh?p"
         },
         "tooltips": {
           "createModel": "Tạo mô hình",
@@ -119,6 +120,31 @@
             "mutualExclusionRules": "Mutual exclusion rules",
             "ruleIndex": "Rule {index}"
           }
+        },
+        "controlledImport": {
+          "title": "Kh?ng th? nh?p g?i c? ki?m so?t t?i ??y",
+          "content": "Ph?t hi?n g?i c? ki?m so?t {packageId}. Vui l?ng d?ng lu?ng nh?p chuy?n d?ng.",
+          "unknownPackage": "kh?ng r?"
+        },
+        "proof": {
+          "controlled": "C? ki?m so?t",
+          "signed": "?? k?",
+          "standard": "Ti?u chu?n"
+        },
+        "meta": {
+          "author": "T?c gi?",
+          "packageId": "G?i",
+          "policy": "Ch?nh s?ch",
+          "homepage": "Trang ch?",
+          "contact": "Li?n h?",
+          "community": "C?ng ??ng",
+          "source": "Ngu?n",
+          "collaborators": "C?ng t?c vi?n"
+        },
+        "policy": {
+          "reimportRestricted": "H?n ch? nh?p l?i",
+          "runtimeTelemetryRequired": "Y?u c?u telemetry",
+          "offlineLeaseAllowed": "Cho ph?p lease ngo?i tuy?n"
         }
       },
       "shortcut": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -100,7 +100,8 @@
           "deleteModel": "你确定要删除此模型吗？",
           "importSuccess": "导入成功",
           "clickOrDragToImport": "点击或拖动至此区域导入",
-          "importing": "正在导入 {current}/{total}"
+          "importing": "正在导入 {current}/{total}",
+          "alreadyImported": "?????"
         },
         "tooltips": {
           "createModel": "制作模型",
@@ -119,6 +120,31 @@
             "mutualExclusionRules": "互斥规则",
             "ruleIndex": "规则 {index}"
           }
+        },
+        "controlledImport": {
+          "title": "???????????",
+          "content": "???????? {packageId}???????????????",
+          "unknownPackage": "???"
+        },
+        "proof": {
+          "controlled": "???",
+          "signed": "???",
+          "standard": "???"
+        },
+        "meta": {
+          "author": "??",
+          "packageId": "??",
+          "policy": "??",
+          "homepage": "??",
+          "contact": "??",
+          "community": "??",
+          "source": "??",
+          "collaborators": "??"
+        },
+        "policy": {
+          "reimportRestricted": "??????",
+          "runtimeTelemetryRequired": "????",
+          "offlineLeaseAllowed": "????"
         }
       },
       "shortcut": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -100,7 +100,8 @@
           "deleteModel": "您確定要刪除此模型嗎？",
           "importSuccess": "匯入成功",
           "clickOrDragToImport": "點擊或拖曳至此區域匯入",
-          "importing": "正在匯入 {current}/{total}"
+          "importing": "正在匯入 {current}/{total}",
+          "alreadyImported": "?????"
         },
         "tooltips": {
           "createModel": "製作模型",
@@ -119,6 +120,31 @@
             "mutualExclusionRules": "互斥規則",
             "ruleIndex": "規則 {index}"
           }
+        },
+        "controlledImport": {
+          "title": "???????????",
+          "content": "???????? {packageId}?????????????",
+          "unknownPackage": "???"
+        },
+        "proof": {
+          "controlled": "???",
+          "signed": "???",
+          "standard": "???"
+        },
+        "meta": {
+          "author": "??",
+          "packageId": "??",
+          "policy": "??",
+          "homepage": "??",
+          "contact": "??",
+          "community": "??",
+          "source": "??",
+          "collaborators": "??"
+        },
+        "policy": {
+          "reimportRestricted": "??????",
+          "runtimeTelemetryRequired": "????",
+          "offlineLeaseAllowed": "????"
         }
       },
       "shortcut": {

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -10,7 +10,12 @@ import { nanoid } from 'nanoid'
 import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import type { ModelMode } from '@/stores/model'
+import type {
+  ModelAuthorProfile,
+  ModelControlledRelease,
+  ModelMode,
+  ModelProofStatus,
+} from '@/stores/model'
 
 import { INVOKE_KEY } from '@/constants'
 import { useModelStore } from '@/stores/model'
@@ -57,6 +62,15 @@ interface ImportVariant {
   modelPath: string
   fingerprint: string
   importKind: 'standard' | 'controlled'
+  proofStatus: ModelProofStatus
+  packageId?: string
+  author?: ModelAuthorProfile
+  controlledRelease?: ModelControlledRelease
+}
+
+interface ProofManifest {
+  packageId?: string
+  author?: ModelAuthorProfile
 }
 
 interface KeyImageRef {
@@ -299,6 +313,10 @@ async function importFromPath(fromPath: string) {
       isPreset: false,
       fingerprint: variant.fingerprint,
       importKind: variant.importKind,
+      proofStatus: variant.proofStatus,
+      packageId: variant.packageId,
+      author: variant.author,
+      controlledRelease: variant.controlledRelease,
     })
 
     importedFingerprints.add(variant.fingerprint)
@@ -345,6 +363,7 @@ async function discoverImportVariants(sourcePath: string) {
 async function discoverLegacyVariants(sourcePath: string) {
   const imgDirs = await findDirectoriesNamed(sourcePath, 'img')
   const variants: ImportVariant[] = []
+  const proofManifest = await readProofManifest(sourcePath)
 
   for (const imgDir of imgDirs) {
     for (const mode of LEGACY_MODELS) {
@@ -359,6 +378,9 @@ async function discoverLegacyVariants(sourcePath: string) {
         modelPath,
         fingerprint: await getModelFingerprint(modelPath, mode),
         importKind: 'standard',
+        proofStatus: proofManifest ? 'manifest-detected' : 'unsigned',
+        packageId: proofManifest?.packageId,
+        author: proofManifest?.author,
       })
     }
   }
@@ -368,6 +390,7 @@ async function discoverLegacyVariants(sourcePath: string) {
 
 async function discoverCubismVariants(sourcePath: string) {
   const modelPaths = await findModelDirectories(sourcePath)
+  const proofManifest = await readProofManifest(sourcePath)
 
   return await Promise.all(modelPaths.map(async (modelPath): Promise<ImportVariant> => {
     const mode = await inferMode(modelPath)
@@ -378,8 +401,23 @@ async function discoverCubismVariants(sourcePath: string) {
       modelPath,
       fingerprint: await getModelFingerprint(modelPath, mode),
       importKind: 'standard',
+      proofStatus: proofManifest ? 'manifest-detected' : 'unsigned',
+      packageId: proofManifest?.packageId,
+      author: proofManifest?.author,
     }
   }))
+}
+
+async function readProofManifest(sourcePath: string): Promise<ProofManifest | null> {
+  const manifestPath = join(sourcePath, 'mochi-proof', 'manifest.json')
+
+  if (!await exists(manifestPath)) return null
+
+  try {
+    return JSON5.parse(await readTextFile(manifestPath)) as ProofManifest
+  } catch {
+    return null
+  }
 }
 
 async function readControlledRelease(sourcePath: string) {
@@ -388,10 +426,7 @@ async function readControlledRelease(sourcePath: string) {
   if (!await exists(releasePath)) return null
 
   try {
-    return JSON5.parse(await readTextFile(releasePath)) as {
-      packageId?: string
-      releaseCode?: string
-    }
+    return JSON5.parse(await readTextFile(releasePath)) as ModelControlledRelease
   } catch {
     return {
       packageId: undefined,

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -19,6 +19,7 @@ import type {
 
 import { INVOKE_KEY } from '@/constants'
 import { useModelStore } from '@/stores/model'
+import { readNearestControlledRelease, readNearestProofManifest } from '@/utils/modelMetadata'
 import { join } from '@/utils/path'
 
 interface LegacyPetConfig {
@@ -66,11 +67,6 @@ interface ImportVariant {
   packageId?: string
   author?: ModelAuthorProfile
   controlledRelease?: ModelControlledRelease
-}
-
-interface ProofManifest {
-  packageId?: string
-  author?: ModelAuthorProfile
 }
 
 interface KeyImageRef {
@@ -181,6 +177,11 @@ const GAMEPAD_BUTTON_NAMES = [
   'DPadRight',
 ]
 
+type ImportFromPathResult =
+  | { status: 'imported', models: Array<ReturnType<typeof createImportedModel>> }
+  | { status: 'duplicate' }
+  | { status: 'blocked-controlled', release: ModelControlledRelease }
+
 onMounted(() => {
   const appWindow = getCurrentWebviewWindow()
 
@@ -249,15 +250,26 @@ watch(selectPaths, async (paths) => {
     importProgress.value = { current: index + 1, total: paths.length }
 
     try {
-      const importedModels = await importFromPath(fromPath)
+      const result = await importFromPath(fromPath)
 
-      if (!importedModels.length) {
-        message.info('Model already imported')
+      if (result.status === 'blocked-controlled') {
+        Modal.warning({
+          title: t('pages.preference.model.controlledImport.title'),
+          content: t('pages.preference.model.controlledImport.content', {
+            packageId: result.release.packageId ?? t('pages.preference.model.controlledImport.unknownPackage'),
+          }),
+        })
 
         continue
       }
 
-      for (const model of importedModels) {
+      if (result.status === 'duplicate') {
+        message.info(t('pages.preference.model.hints.alreadyImported'))
+
+        continue
+      }
+
+      for (const model of result.models) {
         modelStore.models.push(model)
       }
 
@@ -274,20 +286,19 @@ watch(selectPaths, async (paths) => {
 
 async function importFromPath(fromPath: string) {
   const sourcePath = await prepareImportSource(fromPath)
-  const controlledRelease = await readControlledRelease(sourcePath)
-
-  if (controlledRelease) {
-    Modal.warning({
-      title: '受控包暂不支持普通导入',
-      content: `检测到受控发行包 ${controlledRelease.packageId ?? ''}。请后续改用专用受控导入链路。`,
-    })
-    return []
-  }
-
   const variants = await discoverImportVariants(sourcePath)
 
   if (!variants.length) {
     throw new Error('No model3.json found')
+  }
+
+  const controlledVariant = variants.find(variant => variant.controlledRelease)
+
+  if (controlledVariant?.controlledRelease) {
+    return {
+      status: 'blocked-controlled',
+      release: controlledVariant.controlledRelease,
+    } satisfies ImportFromPathResult
   }
 
   const models = []
@@ -306,7 +317,7 @@ async function importFromPath(fromPath: string) {
 
     await normalizeResources(variant, toPath)
 
-    models.push({
+    models.push(createImportedModel({
       id,
       path: toPath,
       mode: variant.mode,
@@ -317,12 +328,31 @@ async function importFromPath(fromPath: string) {
       packageId: variant.packageId,
       author: variant.author,
       controlledRelease: variant.controlledRelease,
-    })
+    }))
 
     importedFingerprints.add(variant.fingerprint)
   }
 
-  return models
+  if (!models.length) {
+    return { status: 'duplicate' } satisfies ImportFromPathResult
+  }
+
+  return { status: 'imported', models } satisfies ImportFromPathResult
+}
+
+function createImportedModel(model: {
+  id: string
+  path: string
+  mode: ModelMode
+  isPreset: boolean
+  fingerprint?: string
+  importKind?: 'standard' | 'controlled'
+  proofStatus?: ModelProofStatus
+  packageId?: string
+  author?: ModelAuthorProfile
+  controlledRelease?: ModelControlledRelease
+}) {
+  return model
 }
 
 async function prepareImportSource(fromPath: string) {
@@ -368,19 +398,22 @@ async function discoverLegacyVariants(sourcePath: string) {
     for (const mode of LEGACY_MODELS) {
       const rootPath = join(imgDir, mode)
       const modelPath = join(rootPath, 'cat_model')
-      const proofManifest = await readNearestProofManifest(modelPath, sourcePath)
 
       if (!await exists(join(modelPath, 'cat.model3.json'))) continue
+
+      const proofManifest = await readNearestProofManifest(modelPath, sourcePath)
+      const controlledRelease = await readNearestControlledRelease(modelPath, sourcePath)
 
       variants.push({
         mode,
         rootPath,
         modelPath,
         fingerprint: await getModelFingerprint(modelPath, mode),
-        importKind: 'standard',
-        proofStatus: proofManifest ? 'manifest-detected' : 'unsigned',
-        packageId: proofManifest?.packageId,
+        importKind: controlledRelease ? 'controlled' : 'standard',
+        proofStatus: controlledRelease ? 'controlled-release' : proofManifest ? 'manifest-detected' : 'unsigned',
+        packageId: proofManifest?.packageId ?? controlledRelease?.packageId,
         author: proofManifest?.author,
+        controlledRelease,
       })
     }
   }
@@ -394,72 +427,20 @@ async function discoverCubismVariants(sourcePath: string) {
   return await Promise.all(modelPaths.map(async (modelPath): Promise<ImportVariant> => {
     const mode = await inferMode(modelPath)
     const proofManifest = await readNearestProofManifest(modelPath, sourcePath)
+    const controlledRelease = await readNearestControlledRelease(modelPath, sourcePath)
 
     return {
       mode,
       rootPath: modelPath,
       modelPath,
       fingerprint: await getModelFingerprint(modelPath, mode),
-      importKind: 'standard',
-      proofStatus: proofManifest ? 'manifest-detected' : 'unsigned',
-      packageId: proofManifest?.packageId,
+      importKind: controlledRelease ? 'controlled' : 'standard',
+      proofStatus: controlledRelease ? 'controlled-release' : proofManifest ? 'manifest-detected' : 'unsigned',
+      packageId: proofManifest?.packageId ?? controlledRelease?.packageId,
       author: proofManifest?.author,
+      controlledRelease,
     }
   }))
-}
-
-async function readProofManifest(sourcePath: string): Promise<ProofManifest | null> {
-  const manifestPath = join(sourcePath, 'mochi-proof', 'manifest.json')
-
-  if (!await exists(manifestPath)) return null
-
-  try {
-    return JSON5.parse(await readTextFile(manifestPath)) as ProofManifest
-  } catch {
-    return null
-  }
-}
-
-async function readNearestProofManifest(startPath: string, stopPath?: string): Promise<ProofManifest | null> {
-  let currentPath = startPath
-  const normalizedStopPath = stopPath ? normalizePath(stopPath) : undefined
-
-  while (currentPath) {
-    const manifest = await readProofManifest(currentPath)
-
-    if (manifest) return manifest
-
-    const normalizedCurrentPath = normalizePath(currentPath)
-
-    if (normalizedStopPath && normalizedCurrentPath === normalizedStopPath) {
-      return null
-    }
-
-    const parentPath = getParentPath(currentPath)
-
-    if (!parentPath || normalizePath(parentPath) === normalizedCurrentPath) {
-      return null
-    }
-
-    currentPath = parentPath
-  }
-
-  return null
-}
-
-async function readControlledRelease(sourcePath: string) {
-  const releasePath = join(sourcePath, 'mochi-control', 'release.json')
-
-  if (!await exists(releasePath)) return null
-
-  try {
-    return JSON5.parse(await readTextFile(releasePath)) as ModelControlledRelease
-  } catch {
-    return {
-      packageId: undefined,
-      releaseCode: undefined,
-    }
-  }
 }
 
 async function findDirectoriesNamed(rootPath: string, name: string) {
@@ -655,10 +636,6 @@ function getParentPath(path: string) {
   parts.pop()
 
   return parts.join(separator)
-}
-
-function normalizePath(path: string) {
-  return path.replace(/[\\/]+/g, '/').replace(/\/$/, '').toLowerCase()
 }
 
 function getKeyImageRefs(variant: ImportVariant, config: LegacyPetConfig) {

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -4,7 +4,7 @@ import { appDataDir } from '@tauri-apps/api/path'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { open } from '@tauri-apps/plugin-dialog'
 import { copyFile, exists, mkdir, readDir, readFile, readTextFile, stat } from '@tauri-apps/plugin-fs'
-import { message } from 'antdv-next'
+import { message, Modal } from 'antdv-next'
 import JSON5 from 'json5'
 import { nanoid } from 'nanoid'
 import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
@@ -56,6 +56,7 @@ interface ImportVariant {
   rootPath: string
   modelPath: string
   fingerprint: string
+  importKind: 'standard' | 'controlled'
 }
 
 interface KeyImageRef {
@@ -259,6 +260,16 @@ watch(selectPaths, async (paths) => {
 
 async function importFromPath(fromPath: string) {
   const sourcePath = await prepareImportSource(fromPath)
+  const controlledRelease = await readControlledRelease(sourcePath)
+
+  if (controlledRelease) {
+    Modal.warning({
+      title: '受控包暂不支持普通导入',
+      content: `检测到受控发行包 ${controlledRelease.packageId ?? ''}。请后续改用专用受控导入链路。`,
+    })
+    return []
+  }
+
   const variants = await discoverImportVariants(sourcePath)
 
   if (!variants.length) {
@@ -287,6 +298,7 @@ async function importFromPath(fromPath: string) {
       mode: variant.mode,
       isPreset: false,
       fingerprint: variant.fingerprint,
+      importKind: variant.importKind,
     })
 
     importedFingerprints.add(variant.fingerprint)
@@ -346,6 +358,7 @@ async function discoverLegacyVariants(sourcePath: string) {
         rootPath,
         modelPath,
         fingerprint: await getModelFingerprint(modelPath, mode),
+        importKind: 'standard',
       })
     }
   }
@@ -364,8 +377,27 @@ async function discoverCubismVariants(sourcePath: string) {
       rootPath: modelPath,
       modelPath,
       fingerprint: await getModelFingerprint(modelPath, mode),
+      importKind: 'standard',
     }
   }))
+}
+
+async function readControlledRelease(sourcePath: string) {
+  const releasePath = join(sourcePath, 'mochi-control', 'release.json')
+
+  if (!await exists(releasePath)) return null
+
+  try {
+    return JSON5.parse(await readTextFile(releasePath)) as {
+      packageId?: string
+      releaseCode?: string
+    }
+  } catch {
+    return {
+      packageId: undefined,
+      releaseCode: undefined,
+    }
+  }
 }
 
 async function findDirectoriesNamed(rootPath: string, name: string) {

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -363,12 +363,12 @@ async function discoverImportVariants(sourcePath: string) {
 async function discoverLegacyVariants(sourcePath: string) {
   const imgDirs = await findDirectoriesNamed(sourcePath, 'img')
   const variants: ImportVariant[] = []
-  const proofManifest = await readProofManifest(sourcePath)
 
   for (const imgDir of imgDirs) {
     for (const mode of LEGACY_MODELS) {
       const rootPath = join(imgDir, mode)
       const modelPath = join(rootPath, 'cat_model')
+      const proofManifest = await readNearestProofManifest(modelPath, sourcePath)
 
       if (!await exists(join(modelPath, 'cat.model3.json'))) continue
 
@@ -390,10 +390,10 @@ async function discoverLegacyVariants(sourcePath: string) {
 
 async function discoverCubismVariants(sourcePath: string) {
   const modelPaths = await findModelDirectories(sourcePath)
-  const proofManifest = await readProofManifest(sourcePath)
 
   return await Promise.all(modelPaths.map(async (modelPath): Promise<ImportVariant> => {
     const mode = await inferMode(modelPath)
+    const proofManifest = await readNearestProofManifest(modelPath, sourcePath)
 
     return {
       mode,
@@ -418,6 +418,33 @@ async function readProofManifest(sourcePath: string): Promise<ProofManifest | nu
   } catch {
     return null
   }
+}
+
+async function readNearestProofManifest(startPath: string, stopPath?: string): Promise<ProofManifest | null> {
+  let currentPath = startPath
+  const normalizedStopPath = stopPath ? normalizePath(stopPath) : undefined
+
+  while (currentPath) {
+    const manifest = await readProofManifest(currentPath)
+
+    if (manifest) return manifest
+
+    const normalizedCurrentPath = normalizePath(currentPath)
+
+    if (normalizedStopPath && normalizedCurrentPath === normalizedStopPath) {
+      return null
+    }
+
+    const parentPath = getParentPath(currentPath)
+
+    if (!parentPath || normalizePath(parentPath) === normalizedCurrentPath) {
+      return null
+    }
+
+    currentPath = parentPath
+  }
+
+  return null
 }
 
 async function readControlledRelease(sourcePath: string) {
@@ -628,6 +655,10 @@ function getParentPath(path: string) {
   parts.pop()
 
   return parts.join(separator)
+}
+
+function normalizePath(path: string) {
+  return path.replace(/[\\/]+/g, '/').replace(/\/$/, '').toLowerCase()
 }
 
 function getKeyImageRefs(variant: ImportVariant, config: LegacyPetConfig) {

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -23,6 +23,30 @@ const { height } = useElementSize(firstCardRef)
 const { t } = useI18n()
 const openBehaviorModal = ref(false)
 
+function proofLabel(model: Model) {
+  if (model.importKind === 'controlled') return '受控包'
+  if (model.proofStatus === 'manifest-detected') return '签名包'
+  return '普通包'
+}
+
+function authorSummary(model: Model) {
+  return model.author?.displayName?.trim() ?? ''
+}
+
+function packageSummary(model: Model) {
+  return model.packageId?.trim() ?? model.controlledRelease?.packageId?.trim() ?? ''
+}
+
+function policySummary(model: Model) {
+  if (!model.controlledRelease) return ''
+
+  const parts = []
+  if (model.controlledRelease.reimportRestricted) parts.push('限制二次导入')
+  if (model.controlledRelease.runtimeTelemetryRequired) parts.push('持续上报')
+  if (model.controlledRelease.offlineLeaseAllowed) parts.push('离线租约')
+  return parts.join(' / ')
+}
+
 function waitForFrames(count = 2) {
   return new Promise<void>((resolve) => {
     const wait = () => {
@@ -117,6 +141,43 @@ async function handleDelete(item: Model) {
           <ModelPreview :model="data" />
         </template>
 
+        <template #title>
+          <div class="model-card-title">
+            <span>{{ data.id }}</span>
+            <span class="model-proof-pill">{{ proofLabel(data) }}</span>
+          </div>
+        </template>
+
+        <div class="model-card-meta">
+          <div
+            v-if="authorSummary(data)"
+            class="meta-line"
+          >
+            <strong>作者</strong>
+            <span>{{ authorSummary(data) }}</span>
+          </div>
+          <div
+            v-if="packageSummary(data)"
+            class="meta-line"
+          >
+            <strong>包号</strong>
+            <span>{{ packageSummary(data) }}</span>
+          </div>
+          <div
+            v-if="policySummary(data)"
+            class="meta-line"
+          >
+            <strong>策略</strong>
+            <span>{{ policySummary(data) }}</span>
+          </div>
+          <div
+            v-if="data.author?.statement"
+            class="meta-statement"
+          >
+            {{ data.author.statement }}
+          </div>
+        </div>
+
         <template #actions>
           <i
             class="i-lucide:circle-check"
@@ -159,3 +220,62 @@ async function handleDelete(item: Model) {
     v-model="openBehaviorModal"
   />
 </template>
+
+<style scoped lang="scss">
+.model-card-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.model-proof-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: rgba(24, 144, 255, 0.12);
+  color: #1677ff;
+  font-size: 11px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.model-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 8px;
+}
+
+.meta-line {
+  display: flex;
+  gap: 6px;
+  font-size: 12px;
+  line-height: 1.4;
+
+  strong {
+    flex-shrink: 0;
+    color: rgba(0, 0, 0, 0.88);
+  }
+
+  span {
+    min-width: 0;
+    color: rgba(0, 0, 0, 0.58);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.meta-statement {
+  font-size: 12px;
+  line-height: 1.45;
+  color: rgba(0, 0, 0, 0.58);
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+</style>

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -33,6 +33,20 @@ function authorSummary(model: Model) {
   return model.author?.displayName?.trim() ?? ''
 }
 
+function authorMetaLines(model: Model) {
+  const author = model.author
+
+  if (!author) return []
+
+  return [
+    { label: '主页', value: author.homepage?.trim() ?? '' },
+    { label: '联系', value: author.contact?.trim() ?? '' },
+    { label: '社区', value: author.community?.trim() ?? '' },
+    { label: '来源', value: author.source?.trim() ?? '' },
+    { label: '协作', value: author.collaborators?.filter(Boolean).join(', ') ?? '' },
+  ].filter(item => item.value)
+}
+
 function packageSummary(model: Model) {
   return model.packageId?.trim() ?? model.controlledRelease?.packageId?.trim() ?? ''
 }
@@ -176,6 +190,14 @@ async function handleDelete(item: Model) {
           >
             {{ data.author.statement }}
           </div>
+          <div
+            v-for="item in authorMetaLines(data)"
+            :key="item.label"
+            class="meta-line"
+          >
+            <strong>{{ item.label }}</strong>
+            <span>{{ item.value }}</span>
+          </div>
         </div>
 
         <template #actions>
@@ -257,12 +279,12 @@ async function handleDelete(item: Model) {
 
   strong {
     flex-shrink: 0;
-    color: rgba(0, 0, 0, 0.88);
+    color: var(--ant-color-text);
   }
 
   span {
     min-width: 0;
-    color: rgba(0, 0, 0, 0.58);
+    color: var(--ant-color-text-secondary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -272,7 +294,7 @@ async function handleDelete(item: Model) {
 .meta-statement {
   font-size: 12px;
   line-height: 1.45;
-  color: rgba(0, 0, 0, 0.58);
+  color: var(--ant-color-text-secondary);
   display: -webkit-box;
   overflow: hidden;
   -webkit-box-orient: vertical;

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -24,9 +24,9 @@ const { t } = useI18n()
 const openBehaviorModal = ref(false)
 
 function proofLabel(model: Model) {
-  if (model.importKind === 'controlled') return '受控包'
-  if (model.proofStatus === 'manifest-detected') return '签名包'
-  return '普通包'
+  if (model.importKind === 'controlled') return t('pages.preference.model.proof.controlled')
+  if (model.proofStatus === 'manifest-detected') return t('pages.preference.model.proof.signed')
+  return t('pages.preference.model.proof.standard')
 }
 
 function authorSummary(model: Model) {
@@ -39,11 +39,11 @@ function authorMetaLines(model: Model) {
   if (!author) return []
 
   return [
-    { label: '主页', value: author.homepage?.trim() ?? '' },
-    { label: '联系', value: author.contact?.trim() ?? '' },
-    { label: '社区', value: author.community?.trim() ?? '' },
-    { label: '来源', value: author.source?.trim() ?? '' },
-    { label: '协作', value: author.collaborators?.filter(Boolean).join(', ') ?? '' },
+    { label: t('pages.preference.model.meta.homepage'), value: author.homepage?.trim() ?? '' },
+    { label: t('pages.preference.model.meta.contact'), value: author.contact?.trim() ?? '' },
+    { label: t('pages.preference.model.meta.community'), value: author.community?.trim() ?? '' },
+    { label: t('pages.preference.model.meta.source'), value: author.source?.trim() ?? '' },
+    { label: t('pages.preference.model.meta.collaborators'), value: author.collaborators?.filter(Boolean).join(', ') ?? '' },
   ].filter(item => item.value)
 }
 
@@ -55,9 +55,9 @@ function policySummary(model: Model) {
   if (!model.controlledRelease) return ''
 
   const parts = []
-  if (model.controlledRelease.reimportRestricted) parts.push('限制二次导入')
-  if (model.controlledRelease.runtimeTelemetryRequired) parts.push('持续上报')
-  if (model.controlledRelease.offlineLeaseAllowed) parts.push('离线租约')
+  if (model.controlledRelease.reimportRestricted) parts.push(t('pages.preference.model.policy.reimportRestricted'))
+  if (model.controlledRelease.runtimeTelemetryRequired) parts.push(t('pages.preference.model.policy.runtimeTelemetryRequired'))
+  if (model.controlledRelease.offlineLeaseAllowed) parts.push(t('pages.preference.model.policy.offlineLeaseAllowed'))
   return parts.join(' / ')
 }
 
@@ -167,21 +167,21 @@ async function handleDelete(item: Model) {
             v-if="authorSummary(data)"
             class="meta-line"
           >
-            <strong>作者</strong>
+            <strong>{{ $t('pages.preference.model.meta.author') }}</strong>
             <span>{{ authorSummary(data) }}</span>
           </div>
           <div
             v-if="packageSummary(data)"
             class="meta-line"
           >
-            <strong>包号</strong>
+            <strong>{{ $t('pages.preference.model.meta.packageId') }}</strong>
             <span>{{ packageSummary(data) }}</span>
           </div>
           <div
             v-if="policySummary(data)"
             class="meta-line"
           >
-            <strong>策略</strong>
+            <strong>{{ $t('pages.preference.model.meta.policy') }}</strong>
             <span>{{ policySummary(data) }}</span>
           </div>
           <div

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -5,6 +5,7 @@ import { filter, find } from 'es-toolkit/compat'
 import { defineStore } from 'pinia'
 import { reactive, ref } from 'vue'
 
+import { readNearestControlledRelease, readNearestProofManifest } from '@/utils/modelMetadata'
 import { join } from '@/utils/path'
 
 export type ModelMode = 'standard' | 'keyboard' | 'gamepad'
@@ -120,6 +121,8 @@ export const useModelStore = defineStore('model', () => {
     const nextModels = filter(models.value, { isPreset: false })
     const presetModels = filter(models.value, { isPreset: true })
 
+    await Promise.all(nextModels.map(fillModelProofMetadata))
+
     for (const preset of [...PRESET_MODELS].reverse()) {
       const matched = find(presetModels, {
         id: preset.id,
@@ -162,3 +165,14 @@ export const useModelStore = defineStore('model', () => {
     filterKeys: ['supportKeys', 'pressedKeys', 'activeKeys'],
   },
 })
+
+async function fillModelProofMetadata(model: Model) {
+  const proofManifest = await readNearestProofManifest(model.path)
+  const controlledRelease = await readNearestControlledRelease(model.path)
+
+  model.importKind = controlledRelease ? 'controlled' : model.importKind ?? 'standard'
+  model.proofStatus = controlledRelease ? 'controlled-release' : proofManifest ? 'manifest-detected' : 'unsigned'
+  model.packageId = proofManifest?.packageId ?? controlledRelease?.packageId ?? model.packageId
+  model.author = proofManifest?.author ?? model.author
+  model.controlledRelease = controlledRelease ?? model.controlledRelease
+}

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -8,6 +8,7 @@ import { reactive, ref } from 'vue'
 import { join } from '@/utils/path'
 
 export type ModelMode = 'standard' | 'keyboard' | 'gamepad'
+export type ModelImportKind = 'standard' | 'controlled'
 
 export interface Model {
   id: string
@@ -15,6 +16,7 @@ export interface Model {
   mode: ModelMode
   isPreset: boolean
   fingerprint?: string
+  importKind?: ModelImportKind
 }
 
 export interface ModelSupportKeyLayer {

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -9,6 +9,26 @@ import { join } from '@/utils/path'
 
 export type ModelMode = 'standard' | 'keyboard' | 'gamepad'
 export type ModelImportKind = 'standard' | 'controlled'
+export type ModelProofStatus = 'unsigned' | 'manifest-detected' | 'controlled-release'
+
+export interface ModelAuthorProfile {
+  displayName?: string
+  statement?: string
+  homepage?: string
+  contact?: string
+  community?: string
+  source?: string
+  collaborators?: string[]
+}
+
+export interface ModelControlledRelease {
+  packageId?: string
+  releaseCode?: string
+  activationMode?: string
+  runtimeTelemetryRequired?: boolean
+  offlineLeaseAllowed?: boolean
+  reimportRestricted?: boolean
+}
 
 export interface Model {
   id: string
@@ -17,6 +37,10 @@ export interface Model {
   isPreset: boolean
   fingerprint?: string
   importKind?: ModelImportKind
+  proofStatus?: ModelProofStatus
+  packageId?: string
+  author?: ModelAuthorProfile
+  controlledRelease?: ModelControlledRelease
 }
 
 export interface ModelSupportKeyLayer {

--- a/src/utils/modelMetadata.ts
+++ b/src/utils/modelMetadata.ts
@@ -1,0 +1,98 @@
+import { exists, readTextFile } from '@tauri-apps/plugin-fs'
+import JSON5 from 'json5'
+
+import type { ModelAuthorProfile, ModelControlledRelease } from '@/stores/model'
+
+import { join } from '@/utils/path'
+
+export interface ModelProofManifest {
+  packageId?: string
+  author?: ModelAuthorProfile
+}
+
+async function readJSONManifest<T extends object>(
+  directoryPath: string,
+  manifestDirectory: string,
+  manifestFile: string,
+  fallbackOnInvalid?: T,
+): Promise<T | null> {
+  const manifestPath = join(directoryPath, manifestDirectory, manifestFile)
+
+  if (!await exists(manifestPath)) return null
+
+  try {
+    return JSON5.parse(await readTextFile(manifestPath)) as T
+  } catch {
+    return fallbackOnInvalid ?? null
+  }
+}
+
+async function readNearestManifest<T extends object>(
+  startPath: string,
+  manifestDirectory: string,
+  manifestFile: string,
+  stopPath?: string,
+  fallbackOnInvalid?: T,
+): Promise<T | null> {
+  let currentPath = startPath
+  const normalizedStopPath = stopPath ? normalizePath(stopPath) : undefined
+
+  while (currentPath) {
+    const manifest = await readJSONManifest<T>(
+      currentPath,
+      manifestDirectory,
+      manifestFile,
+      fallbackOnInvalid,
+    )
+
+    if (manifest) return manifest
+
+    const normalizedCurrentPath = normalizePath(currentPath)
+
+    if (normalizedStopPath && normalizedCurrentPath === normalizedStopPath) {
+      return null
+    }
+
+    const parentPath = getParentPath(currentPath)
+
+    if (!parentPath || normalizePath(parentPath) === normalizedCurrentPath) {
+      return null
+    }
+
+    currentPath = parentPath
+  }
+
+  return null
+}
+
+export async function readNearestProofManifest(startPath: string, stopPath?: string) {
+  return await readNearestManifest<ModelProofManifest>(
+    startPath,
+    'mochi-proof',
+    'manifest.json',
+    stopPath,
+  )
+}
+
+export async function readNearestControlledRelease(startPath: string, stopPath?: string) {
+  return await readNearestManifest<ModelControlledRelease>(
+    startPath,
+    'mochi-control',
+    'release.json',
+    stopPath,
+    {},
+  )
+}
+
+function getParentPath(path: string) {
+  const separator = path.includes('\\') ? '\\' : '/'
+  const parts = path.split(/[\\/]/)
+
+  parts.pop()
+
+  return parts.join(separator)
+}
+
+function normalizePath(path: string) {
+  return path.replace(/[\\/]+/g, '/').replace(/\/$/, '').toLowerCase()
+}


### PR DESCRIPTION
## Summary
Show proof metadata in model management and improve manifest discovery for imported models.

## Changes
- read and persist proof metadata from mochi-proof/manifest.json`n- show proof status, package ID, author info, and policy metadata in model cards
- search upward from each model directory to find the nearest proof manifest
- render additional author metadata fields and use theme token colors in the UI

## Testing
- verify signed packages display proof and author metadata
- verify nested package layouts still resolve the nearest manifest correctly
- verify unsigned packages continue to appear as normal packages