### PR TITLE
fix: preserve imported model display names

### DIFF
--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -43,6 +43,8 @@ interface LegacyGamepadConfig {
 }
 
 interface CubismModelJSON {
+  Name?: string
+  DisplayName?: string
   FileReferences?: {
     Moc?: string
     Textures?: string[]
@@ -55,7 +57,12 @@ interface ImportVariant {
   mode: ModelMode
   rootPath: string
   modelPath: string
+  displayName?: string
   fingerprint: string
+}
+
+interface ProofManifest {
+  modelName?: string
 }
 
 interface KeyImageRef {
@@ -283,6 +290,7 @@ async function importFromPath(fromPath: string) {
 
     models.push({
       id,
+      displayName: variant.displayName,
       path: toPath,
       mode: variant.mode,
       isPreset: false,
@@ -338,6 +346,7 @@ async function discoverLegacyVariants(sourcePath: string) {
     for (const mode of LEGACY_MODELS) {
       const rootPath = join(imgDir, mode)
       const modelPath = join(rootPath, 'cat_model')
+      const proofManifest = await readNearestProofManifest(modelPath, sourcePath)
 
       if (!await exists(join(modelPath, 'cat.model3.json'))) continue
 
@@ -345,6 +354,11 @@ async function discoverLegacyVariants(sourcePath: string) {
         mode,
         rootPath,
         modelPath,
+        displayName: await inferImportDisplayName({
+          modelPath,
+          sourcePath,
+          proofManifest,
+        }),
         fingerprint: await getModelFingerprint(modelPath, mode),
       })
     }
@@ -358,14 +372,86 @@ async function discoverCubismVariants(sourcePath: string) {
 
   return await Promise.all(modelPaths.map(async (modelPath): Promise<ImportVariant> => {
     const mode = await inferMode(modelPath)
+    const proofManifest = await readNearestProofManifest(modelPath, sourcePath)
 
     return {
       mode,
       rootPath: modelPath,
       modelPath,
+      displayName: await inferImportDisplayName({
+        modelPath,
+        sourcePath,
+        proofManifest,
+      }),
       fingerprint: await getModelFingerprint(modelPath, mode),
     }
   }))
+}
+
+async function inferImportDisplayName({
+  modelPath,
+  sourcePath,
+  proofManifest,
+}: {
+  modelPath: string
+  sourcePath: string
+  proofManifest: ProofManifest | null
+}) {
+  const manifestName = normalizeDisplayName(proofManifest?.modelName)
+  if (manifestName) return manifestName
+
+  const modelFile = await findModelFile(modelPath).catch(() => undefined)
+  if (modelFile) {
+    const modelJSON = await readCubismModelJSON(modelFile).catch(() => undefined)
+    const modelName = normalizeDisplayName(modelJSON?.DisplayName ?? modelJSON?.Name)
+
+    if (modelName) return modelName
+
+    const modelFileBaseName = stripModelFileExtension(getPathBaseName(modelFile))
+
+    if (modelFileBaseName) return modelFileBaseName
+  }
+
+  return normalizeDisplayName(getPathBaseName(sourcePath))
+}
+
+async function readProofManifest(sourcePath: string): Promise<ProofManifest | null> {
+  const manifestPath = join(sourcePath, 'mochi-proof', 'manifest.json')
+
+  if (!await exists(manifestPath)) return null
+
+  try {
+    return JSON5.parse(await readTextFile(manifestPath)) as ProofManifest
+  } catch {
+    return null
+  }
+}
+
+async function readNearestProofManifest(startPath: string, stopPath?: string): Promise<ProofManifest | null> {
+  let currentPath = startPath
+  const normalizedStopPath = stopPath ? normalizePath(stopPath) : undefined
+
+  while (currentPath) {
+    const manifest = await readProofManifest(currentPath)
+
+    if (manifest) return manifest
+
+    const normalizedCurrentPath = normalizePath(currentPath)
+
+    if (normalizedStopPath && normalizedCurrentPath === normalizedStopPath) {
+      return null
+    }
+
+    const parentPath = getParentPath(currentPath)
+
+    if (!parentPath || normalizePath(parentPath) === normalizedCurrentPath) {
+      return null
+    }
+
+    currentPath = parentPath
+  }
+
+  return null
 }
 
 async function findDirectoriesNamed(rootPath: string, name: string) {
@@ -443,8 +529,7 @@ async function getImportedFingerprints() {
 
 async function getModelFingerprint(modelPath: string, mode: ModelMode) {
   const modelFile = await findModelFile(modelPath)
-  const modelJSONText = await readTextFile(modelFile)
-  const modelJSON = JSON5.parse(modelJSONText) as CubismModelJSON
+  const modelJSON = await readCubismModelJSON(modelFile)
   const references = modelJSON.FileReferences
   const files = [
     { key: modelFile.split(/[\\/]/).at(-1) ?? 'model3.json', path: modelFile },
@@ -477,6 +562,10 @@ async function getModelFingerprint(modelPath: string, mode: ModelMode) {
     .join('')
 
   return `${mode}:${hash}`
+}
+
+async function readCubismModelJSON(modelFile: string) {
+  return JSON5.parse(await readTextFile(modelFile)) as CubismModelJSON
 }
 
 function concatBytes(chunks: Uint8Array[], totalLength: number) {
@@ -561,6 +650,26 @@ function getParentPath(path: string) {
   parts.pop()
 
   return parts.join(separator)
+}
+
+function normalizePath(path: string) {
+  return path.replace(/[\\/]+/g, '/').replace(/\/$/, '').toLowerCase()
+}
+
+function normalizeDisplayName(value: unknown) {
+  if (typeof value !== 'string') return undefined
+
+  const displayName = value.trim()
+
+  return displayName || undefined
+}
+
+function getPathBaseName(path: string) {
+  return path.split(/[\\/]/).at(-1) ?? ''
+}
+
+function stripModelFileExtension(fileName: string) {
+  return fileName.replace(/\.model3\.json$/i, '').trim() || undefined
 }
 
 function getKeyImageRefs(variant: ImportVariant, config: LegacyPetConfig) {

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -23,6 +23,10 @@ const { height } = useElementSize(firstCardRef)
 const { t } = useI18n()
 const openBehaviorModal = ref(false)
 
+function modelTitle(model: Model) {
+  return model.displayName?.trim() || model.id
+}
+
 function waitForFrames(count = 2) {
   return new Promise<void>((resolve) => {
     const wait = () => {
@@ -117,6 +121,10 @@ async function handleDelete(item: Model) {
           <ModelPreview :model="data" />
         </template>
 
+        <template #title>
+          <span class="model-card-title">{{ modelTitle(data) }}</span>
+        </template>
+
         <template #actions>
           <i
             class="i-lucide:circle-check"
@@ -156,6 +164,16 @@ async function handleDelete(item: Model) {
 
   <BehaviorModal
     v-if="catStore.model.behavior"
-    v-model="openBehaviorModal"
+  v-model="openBehaviorModal"
   />
 </template>
+
+<style scoped lang="scss">
+.model-card-title {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -1,7 +1,9 @@
 import type { ExpressionInfo, MotionInfo } from 'easy-live2d'
 
 import { resolveResource } from '@tauri-apps/api/path'
+import { exists, readDir, readTextFile } from '@tauri-apps/plugin-fs'
 import { filter, find } from 'es-toolkit/compat'
+import JSON5 from 'json5'
 import { defineStore } from 'pinia'
 import { reactive, ref } from 'vue'
 
@@ -11,6 +13,7 @@ export type ModelMode = 'standard' | 'keyboard' | 'gamepad'
 
 export interface Model {
   id: string
+  displayName?: string
   path: string
   mode: ModelMode
   isPreset: boolean
@@ -55,6 +58,15 @@ interface PresetModel {
   id: string
   mode: ModelMode
   path: string
+}
+
+interface StoredProofManifest {
+  modelName?: string
+}
+
+interface StoredCubismModelJSON {
+  Name?: string
+  DisplayName?: string
 }
 
 const PRESET_MODELS: PresetModel[] = [
@@ -110,6 +122,8 @@ export const useModelStore = defineStore('model', () => {
       })
     }
 
+    await Promise.all(nextModels.map(ensureModelDisplayName))
+
     const matched = find(nextModels, { id: currentModel.value?.id })
 
     currentModel.value = matched ?? nextModels[0]
@@ -136,3 +150,69 @@ export const useModelStore = defineStore('model', () => {
     filterKeys: ['supportKeys', 'pressedKeys', 'activeKeys'],
   },
 })
+
+async function ensureModelDisplayName(model: Model) {
+  if (model.isPreset || model.displayName?.trim()) return
+
+  model.displayName = await inferStoredModelDisplayName(model)
+}
+
+async function inferStoredModelDisplayName(model: Model) {
+  const proofName = await readStoredProofModelName(model.path)
+  if (proofName) return proofName
+
+  const modelFile = await findStoredModelFile(model.path)
+  if (!modelFile) return undefined
+
+  const modelName = await readStoredCubismModelName(modelFile)
+  if (modelName) return modelName
+
+  return stripModelFileExtension(getPathBaseName(modelFile))
+}
+
+async function readStoredProofModelName(modelPath: string) {
+  const manifestPath = join(modelPath, 'mochi-proof', 'manifest.json')
+
+  if (!await exists(manifestPath).catch(() => false)) return undefined
+
+  try {
+    const manifest = JSON5.parse(await readTextFile(manifestPath)) as StoredProofManifest
+
+    return normalizeDisplayName(manifest.modelName)
+  } catch {
+    return undefined
+  }
+}
+
+async function readStoredCubismModelName(modelFile: string) {
+  try {
+    const modelJSON = JSON5.parse(await readTextFile(modelFile)) as StoredCubismModelJSON
+
+    return normalizeDisplayName(modelJSON.DisplayName ?? modelJSON.Name)
+  } catch {
+    return undefined
+  }
+}
+
+async function findStoredModelFile(modelPath: string) {
+  const files = await readDir(modelPath).catch(() => [])
+  const modelFile = files.find(file => file.isFile && file.name.endsWith('.model3.json'))
+
+  return modelFile ? join(modelPath, modelFile.name) : undefined
+}
+
+function normalizeDisplayName(value: unknown) {
+  if (typeof value !== 'string') return undefined
+
+  const displayName = value.trim()
+
+  return displayName || undefined
+}
+
+function getPathBaseName(path: string) {
+  return path.split(/[\\/]/).at(-1) ?? ''
+}
+
+function stripModelFileExtension(fileName: string) {
+  return fileName.replace(/\.model3\.json$/i, '').trim() || undefined
+}


### PR DESCRIPTION
## Summary
- store imported model display names instead of showing random ids
- infer names from proof manifests, Cubism metadata, model file names, or source directories
- backfill display names for existing custom models during store init

## Verification
- pnpm.cmd build:vite