### PR TITLE
chore(license): REUSE compliance and GitHub license detection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ayangweb
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 name: Bug report
 title: '[bug] '
 description: Report a bug

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ayangweb
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 name: 💡 功能请求
 title: '[feat] '
 description: 提出一个想法

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ayangweb
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 name: MochiPaw Release
 
 on:

--- a/.github/workflows/upgradelink.yml
+++ b/.github/workflows/upgradelink.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ayangweb
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 name: Upload Release Metadata
 
 on:

--- a/.release-it.ts
+++ b/.release-it.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 /* eslint-disable no-template-curly-in-string */
 import type { Config } from 'release-it'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ayangweb
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 [workspace]
 resolver = "2"
 members = [ "src-tauri" ]

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ayangweb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/PolyForm-Noncommercial-1.0.0.txt
+++ b/LICENSES/PolyForm-Noncommercial-1.0.0.txt
@@ -1,6 +1,4 @@
-SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-
-# PolyForm Noncommercial License 1.0.0
+PolyForm Noncommercial License 1.0.0
 
 <https://polyformproject.org/licenses/noncommercial/1.0.0>
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -7,7 +7,36 @@ Original project: https://github.com/ayangweb/BongoCat
 BongoCat was released under the MIT License. The original copyright and
 license notice is retained below for the BongoCat-derived portions.
 
-## BongoCat MIT Notice
+## Core Usage Rules Quick Reference
+
+| Use Case                                   | Allowed?   | Prerequisites                                                              |
+|--------------------------------------------|-----------|----------------------------------------------------------------------------|
+| Personal learning, modification, private use | ✅ Allowed | Comply with PolyForm Noncommercial License 1.0.0 terms                     |
+| Non-profit distribution (free sharing)     | ✅ Allowed | Comply with PolyForm Noncommercial License 1.0.0 terms                     |
+| Internal company use (no external revenue) | ⚠️ Caution | If it is an "internal business tool" and generates no income, it is typically noncommercial; if used to enhance the company's profitability, it may cross the line |
+| Any form of commercial profit              | ❌ Strictly Prohibited | Including paid distribution, SaaS hosting, ad monetization, integration into paid products, etc. |
+| Obtain commercial license                  | ✅ Available upon request | Must obtain **written permission** from CatStack / InfinityXCat in advance |
+
+## Additional Commercial Use Exemption
+
+MochiPaw original code and CatStack-maintained modifications are licensed
+under the PolyForm Noncommercial License 1.0.0.
+
+Commercial use is not permitted without prior written permission from
+CatStack / InfinityXCat. This includes, without limitation, paid
+distribution, resale, monetized hosting, integration into paid products or
+services, commercial SaaS use, and other revenue-generating use.
+
+## Commercial Licensing
+
+To use MochiPaw or its derivative works for any commercial purpose,
+including but not limited to paid distribution, SaaS hosting, ad
+monetization, or integration into paid products or services, you must
+obtain prior written permission from CatStack / InfinityXCat.
+
+Commercial licensing inquiries: CatStack / InfinityXCat
+
+## Original BongoCat MIT License
 
 MIT License
 
@@ -31,18 +60,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-## MochiPaw Changes
-
-CatStack-maintained modifications and new MochiPaw code are licensed under
-the PolyForm Noncommercial License 1.0.0 unless a file states otherwise.
-
-License terms: https://polyformproject.org/licenses/noncommercial/1.0.0
-
-Commercial use of MochiPaw builds, source, derivatives, services, or bundled
-distributions requires prior written permission from CatStack / InfinityXCat.
-
 ## Bundled Assets
 
 Bundled Live2D/Cubism runtime files, model files, images, icons, and other
 assets may have separate upstream terms. Review those terms before
 redistributing modified builds or using the assets outside this repository.
+
+## Third-Party Dependencies
+
+Third-party dependencies and bundled runtime files are subject to their own
+licenses and notices.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import antfu from '@antfu/eslint-config'
 
 export default antfu({

--- a/index.html
+++ b/index.html
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <!doctype html>
 <html lang="zh">
   <head>

--- a/scripts/buildIcon.ts
+++ b/scripts/buildIcon.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { execSync } from 'node:child_process'
 import { env, platform } from 'node:process'
 

--- a/scripts/packagePortable.mjs
+++ b/scripts/packagePortable.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ayangweb
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 [package]
 name = "mochi-paw"
 version = "1.1.0"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 use std::{
     env,
     fs,

--- a/src-tauri/src/core/device.rs
+++ b/src-tauri/src/core/device.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 use rdev::{Event, EventType, listen};
 use serde::Serialize;
 use serde_json::{Value, json};

--- a/src-tauri/src/core/gamepad.rs
+++ b/src-tauri/src/core/gamepad.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 use gilrs::{EventType, Gilrs};
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 pub mod device;
 pub mod gamepad;
 pub mod prevent_default;

--- a/src-tauri/src/core/prevent_default.rs
+++ b/src-tauri/src/core/prevent_default.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 pub fn init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
     #[cfg(debug_assertions)]
     {

--- a/src-tauri/src/core/setup/common.rs
+++ b/src-tauri/src/core/setup/common.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 use tauri::{AppHandle, WebviewWindow};
 
 pub fn platform(

--- a/src-tauri/src/core/setup/macos.rs
+++ b/src-tauri/src/core/setup/macos.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 #![allow(deprecated)]
 use tauri::{AppHandle, Emitter, EventTarget, Manager, WebviewWindow};
 use tauri_nspanel::{CollectionBehavior, PanelLevel, StyleMask, WebviewWindowExt, tauri_panel};

--- a/src-tauri/src/core/setup/mod.rs
+++ b/src-tauri/src/core/setup/mod.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 use tauri::{AppHandle, WebviewWindow};
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 mod core;
 mod utils;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {

--- a/src-tauri/src/plugins/admin-status/Cargo.toml
+++ b/src-tauri/src/plugins/admin-status/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 [package]
 name = "tauri-plugin-admin-status"
 version = "0.1.0"

--- a/src-tauri/src/plugins/admin-status/build.rs
+++ b/src-tauri/src/plugins/admin-status/build.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 const COMMANDS: &[&str] = &[
     "is_running_as_administrator",
     "relaunch_as_administrator",

--- a/src-tauri/src/plugins/admin-status/permissions/default.toml
+++ b/src-tauri/src/plugins/admin-status/permissions/default.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 "$schema" = "schemas/schema.json"
 
 [default]

--- a/src-tauri/src/plugins/admin-status/src/commands/mod.rs
+++ b/src-tauri/src/plugins/admin-status/src/commands/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 use tauri::command;
 
 #[derive(serde::Serialize)]

--- a/src-tauri/src/plugins/admin-status/src/lib.rs
+++ b/src-tauri/src/plugins/admin-status/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 use tauri::{
     Runtime, generate_handler,
     plugin::{Builder, TauriPlugin},

--- a/src-tauri/src/plugins/self-protect/Cargo.toml
+++ b/src-tauri/src/plugins/self-protect/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 [package]
 name = "tauri-plugin-self-protect"
 version = "0.1.0"

--- a/src-tauri/src/plugins/self-protect/build.rs
+++ b/src-tauri/src/plugins/self-protect/build.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 const COMMANDS: &[&str] = &[
     "self_protect_check_status",
 ];

--- a/src-tauri/src/plugins/self-protect/src/checks.rs
+++ b/src-tauri/src/plugins/self-protect/src/checks.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 /// 检查当前进程是否存在调试器附加迹象。
 pub fn check_all() -> bool {
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/plugins/self-protect/src/lib.rs
+++ b/src-tauri/src/plugins/self-protect/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 mod checks;
 
 use tauri::{

--- a/src-tauri/src/plugins/window/Cargo.toml
+++ b/src-tauri/src/plugins/window/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 [package]
 name = "tauri-plugin-custom-window"
 version = "0.1.0"

--- a/src-tauri/src/plugins/window/build.rs
+++ b/src-tauri/src/plugins/window/build.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 const COMMANDS: &[&str] = &[
     "show_window",
     "hide_window",

--- a/src-tauri/src/plugins/window/permissions/default.toml
+++ b/src-tauri/src/plugins/window/permissions/default.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 "$schema" = "schemas/schema.json"
 
 [default]

--- a/src-tauri/src/plugins/window/src/commands/linux.rs
+++ b/src-tauri/src/plugins/window/src/commands/linux.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 use tauri::{AppHandle, Runtime, WebviewWindow, command};
 
 #[command]

--- a/src-tauri/src/plugins/window/src/commands/macos.rs
+++ b/src-tauri/src/plugins/window/src/commands/macos.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 #![allow(deprecated)]
 use crate::MAIN_WINDOW_LABEL;
 use tauri::{AppHandle, Runtime, WebviewWindow, command};

--- a/src-tauri/src/plugins/window/src/commands/mod.rs
+++ b/src-tauri/src/plugins/window/src/commands/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 use tauri::{AppHandle, Manager, async_runtime::spawn};
 
 pub static MAIN_WINDOW_LABEL: &str = "main";

--- a/src-tauri/src/plugins/window/src/commands/windows.rs
+++ b/src-tauri/src/plugins/window/src/commands/windows.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::thread;

--- a/src-tauri/src/plugins/window/src/lib.rs
+++ b/src-tauri/src/plugins/window/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 use tauri::{
     Runtime, generate_handler,
     plugin::{Builder, TauriPlugin},

--- a/src-tauri/src/utils/fs_extra.rs
+++ b/src-tauri/src/utils/fs_extra.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 use fs_extra::dir::{CopyOptions, copy};
 use std::{
     fs::{File, create_dir_all},

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,1 +1,5 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 pub mod fs_extra;

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { HappyProvider } from '@antdv-next/happy-work-theme'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'

--- a/src/assets/css/global.scss
+++ b/src/assets/css/global.scss
@@ -1,3 +1,8 @@
+/* SPDX-FileCopyrightText: 2025 ayangweb
+ * SPDX-FileCopyrightText: 2026 InfinityXCat
+ * SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ */
+
 html {
   --uno: select-none overscroll-none antialiased;
 

--- a/src/components/pro-list-item/index.vue
+++ b/src/components/pro-list-item/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { Flex } from 'antdv-next'
 import { computed } from 'vue'

--- a/src/components/pro-list/index.vue
+++ b/src/components/pro-list/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { Flex } from 'antdv-next'
 

--- a/src/components/shortcut/index.vue
+++ b/src/components/shortcut/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { find, map, remove, some, split } from 'es-toolkit/compat'
 import { ref, useTemplateRef, watch } from 'vue'

--- a/src/components/update-app/index.vue
+++ b/src/components/update-app/index.vue
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import type { Update } from '@tauri-apps/plugin-updater'
 

--- a/src/composables/useAppMenu.ts
+++ b/src/composables/useAppMenu.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { CheckMenuItem, MenuItem, PredefinedMenuItem, Submenu } from '@tauri-apps/api/menu'
 import { exit, relaunch } from '@tauri-apps/plugin-process'
 import { range } from 'es-toolkit'

--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { invoke } from '@tauri-apps/api/core'
 import { PhysicalPosition } from '@tauri-apps/api/dpi'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'

--- a/src/composables/useGamepad.ts
+++ b/src/composables/useGamepad.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import type { LiteralUnion } from 'type-fest'
 
 import { invoke } from '@tauri-apps/api/core'

--- a/src/composables/useKeyPress.ts
+++ b/src/composables/useKeyPress.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import type { ShortcutHandler } from '@tauri-apps/plugin-global-shortcut'
 import type { Ref } from 'vue'
 

--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 import type { PhysicalPosition } from '@tauri-apps/api/dpi'
 
 import { LogicalSize } from '@tauri-apps/api/dpi'

--- a/src/composables/useTauriListen.ts
+++ b/src/composables/useTauriListen.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { listen } from '@tauri-apps/api/event'
 import { noop } from '@vueuse/core'
 import { onMounted, onUnmounted, ref } from 'vue'

--- a/src/composables/useTray.ts
+++ b/src/composables/useTray.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import type { TrayIconOptions } from '@tauri-apps/api/tray'
 
 import { getName, getVersion } from '@tauri-apps/api/app'

--- a/src/composables/useWindowState.ts
+++ b/src/composables/useWindowState.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import type { Event } from '@tauri-apps/api/event'
 
 import { PhysicalPosition, PhysicalSize } from '@tauri-apps/api/dpi'

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 export const GITHUB_LINK = 'https://github.com/CatStack-pixe/MochiPaw'
 
 export const UPGRADE_LINK_ACCESS_KEY = 'xDbrq2rOoRThDqKOHL2ZRA'

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import type { Locale as AntdLocale } from 'antdv-next/dist/locale/index'
 
 import antdEnUS from 'antdv-next/locale/en_US'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { createPlugin } from '@tauri-store/pinia'
 import { createPinia } from 'pinia'
 import { createApp } from 'vue'

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { convertFileSrc } from '@tauri-apps/api/core'
 import { PhysicalSize } from '@tauri-apps/api/dpi'

--- a/src/pages/preference/components/about/index.vue
+++ b/src/pages/preference/components/about/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { getTauriVersion } from '@tauri-apps/api/app'
 import { emit } from '@tauri-apps/api/event'

--- a/src/pages/preference/components/cat/index.vue
+++ b/src/pages/preference/components/cat/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { Divider, Flex, InputNumber, Select, Slider, SpaceAddon, SpaceCompact, Switch } from 'antdv-next'
 import { computed } from 'vue'

--- a/src/pages/preference/components/general/components/language/index.vue
+++ b/src/pages/preference/components/general/components/language/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { Select } from 'antdv-next'
 

--- a/src/pages/preference/components/general/components/macos-permissions/index.vue
+++ b/src/pages/preference/components/general/components/macos-permissions/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { confirm } from '@tauri-apps/plugin-dialog'
 import { Space } from 'antdv-next'

--- a/src/pages/preference/components/general/components/theme-mode/index.vue
+++ b/src/pages/preference/components/general/components/theme-mode/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { Select } from 'antdv-next'

--- a/src/pages/preference/components/general/components/windows-permissions/index.vue
+++ b/src/pages/preference/components/general/components/windows-permissions/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { confirm, message } from '@tauri-apps/plugin-dialog'
 import { Space } from 'antdv-next'

--- a/src/pages/preference/components/general/index.vue
+++ b/src/pages/preference/components/general/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { disable, enable, isEnabled } from '@tauri-apps/plugin-autostart'
 import { Switch } from 'antdv-next'

--- a/src/pages/preference/components/model/components/behavior-modal/components/behavior-item/index.vue
+++ b/src/pages/preference/components/model/components/behavior-modal/components/behavior-item/index.vue
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { Button, Checkbox, Divider, Input } from 'antdv-next'
 

--- a/src/pages/preference/components/model/components/behavior-modal/index.vue
+++ b/src/pages/preference/components/model/components/behavior-modal/index.vue
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { emit } from '@tauri-apps/api/event'
 import { Button, Empty, Input, Modal, Select } from 'antdv-next'

--- a/src/pages/preference/components/model/components/float-menu/index.vue
+++ b/src/pages/preference/components/model/components/float-menu/index.vue
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { EditOutlined, MenuOutlined, SyncOutlined, UnorderedListOutlined } from '@antdv-next/icons'
 import { openUrl } from '@tauri-apps/plugin-opener'

--- a/src/pages/preference/components/model/components/model-preview/index.vue
+++ b/src/pages/preference/components/model/components/model-preview/index.vue
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { convertFileSrc } from '@tauri-apps/api/core'
 import { exists } from '@tauri-apps/plugin-fs'

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { invoke } from '@tauri-apps/api/core'
 import { appDataDir } from '@tauri-apps/api/path'

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { exists, remove } from '@tauri-apps/plugin-fs'
 import { revealItemInDir } from '@tauri-apps/plugin-opener'

--- a/src/pages/preference/components/shortcut/index.vue
+++ b/src/pages/preference/components/shortcut/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 

--- a/src/pages/preference/index.vue
+++ b/src/pages/preference/index.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: 2025 ayangweb
+  SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+ -->
+
 <script setup lang="ts">
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { Flex, Spin } from 'antdv-next'

--- a/src/plugins/adminStatus.ts
+++ b/src/plugins/adminStatus.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { invoke } from '@tauri-apps/api/core'
 
 const COMMAND = {

--- a/src/plugins/window.ts
+++ b/src/plugins/window.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { invoke } from '@tauri-apps/api/core'
 import { emit } from '@tauri-apps/api/event'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import type { RouteRecordRaw } from 'vue-router'
 
 import { createRouter, createWebHashHistory } from 'vue-router'

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { getName, getVersion } from '@tauri-apps/api/app'
 import { defineStore } from 'pinia'
 import { reactive, ref } from 'vue'

--- a/src/stores/cat.ts
+++ b/src/stores/cat.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { defineStore } from 'pinia'
 import { reactive, ref } from 'vue'
 

--- a/src/stores/general.ts
+++ b/src/stores/general.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { defineStore } from 'pinia'
 import { getLocale } from 'tauri-plugin-locale-api'
 import { reactive, ref } from 'vue'

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import type { ExpressionInfo, MotionInfo } from 'easy-live2d'
 
 import { resolveResource } from '@tauri-apps/api/path'

--- a/src/stores/shortcut.ts
+++ b/src/stores/shortcut.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 

--- a/src/utils/controlledRelease.ts
+++ b/src/utils/controlledRelease.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 import { exists, readTextFile } from '@tauri-apps/plugin-fs'
 import JSON5 from 'json5'
 

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 export function isImage(value: string) {
   const regex = /\.(?:jpe?g|png|webp|avif|gif|svg|bmp|ico|tiff?|heic|apng)$/i
 

--- a/src/utils/keyboard.ts
+++ b/src/utils/keyboard.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { isMac } from './platform'
 
 export interface Key {

--- a/src/utils/live2d.ts
+++ b/src/utils/live2d.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import type { ExpressionInfo, MotionInfo } from 'easy-live2d'
 
 import { convertFileSrc } from '@tauri-apps/api/core'

--- a/src/utils/modelMetadata.ts
+++ b/src/utils/modelMetadata.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 import { exists, readTextFile } from '@tauri-apps/plugin-fs'
 import JSON5 from 'json5'
 

--- a/src/utils/modelResourceMetrics.ts
+++ b/src/utils/modelResourceMetrics.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 import type { DirEntry } from '@tauri-apps/plugin-fs'
 
 import { readDir, readFile, stat } from '@tauri-apps/plugin-fs'

--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import type { Monitor, PhysicalPosition } from '@tauri-apps/api/window'
 
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { sep } from '@tauri-apps/api/path'
 
 export function join(...paths: string[]) {

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { platform } from '@tauri-apps/plugin-os'
 
 export const isMac = platform() === 'macos'

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { castArray } from 'es-toolkit/compat'
 
 export function clearObject<T extends Record<string, unknown>>(targets: T | T[]) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 /// <reference types="vite/client" />
 
 declare module '*.vue' {

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import { presetAntd } from '@antdv-next/unocss'
 import {
   defineConfig,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 ayangweb
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'node:path'
 import { env } from 'node:process'


### PR DESCRIPTION
## Summary

Restructure license files for REUSE specification compliance and enable GitHub to correctly detect PolyForm Noncommercial 1.0.0 license.

## Changes

- **LICENSE**: Replaced with pure PolyForm Noncommercial 1.0.0 text + SPDX identifier for GitHub Licensee detection
- **NOTICE.md**: Moved additional terms here — core usage rules table (bilingual), commercial use exemption, BongoCat MIT notice, bundled assets declaration
- **LICENSES/**: Added directory with official license texts (PolyForm-Noncommercial-1.0.0.txt, MIT.txt) per REUSE spec
- **Source file headers**: Added SPDX-FileCopyrightText and SPDX-License-Identifier to 93+ files
  - PolyForm-only for CatStack-original code (admin-status, self-protect, window plugins, etc.)
  - MIT AND PolyForm for BongoCat-derived files (dual license)

## Result

- GitHub repo page will display PolyForm-Noncommercial-1.0.0 license badge
- Project fully complies with REUSE specification (passable by reuse lint)
- Original BongoCat MIT notice preserved in NOTICE.md