### PR TITLE
docs(readme): add PolyForm license badge and explicit license statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # MochiPaw
 
+[![License](https://img.shields.io/badge/License-PolyForm%20Noncommercial%201.0.0-blue)](./LICENSE)
+
 MochiPaw is a Tauri + Vue desktop pet app based on
 [BongoCat](https://github.com/ayangweb/BongoCat).
 
-This repository is source-available for personal, research, learning, and
-other noncommercial use. Commercial use is not permitted without prior written
-permission from CatStack / InfinityXCat.
+This project is licensed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0).
+See [NOTICE.md](./NOTICE.md) for additional terms, core usage rules, and commercial licensing information.
+
+> **Noncommercial only.** Commercial use requires prior written permission from CatStack / InfinityXCat.
 
 ## Features
 


### PR DESCRIPTION
## Changes

- Add shields.io license badge at the top of README.md linking to LICENSE file
- Replace vague source-available wording with explicit PolyForm Noncommercial 1.0.0 link
- Reference NOTICE.md for additional terms and commercial licensing
- Keep noncommercial warning prominent with blockquote

## Why

GitHub Licensee tool cannot auto-detect PolyForm Noncommercial 1.0.0 (not in its pre-built list). The badge provides visible license info as a workaround.