### PR TITLE
refactor(notice): streamline NOTICE.md to eliminate duplication

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,64 +1,33 @@
 # Notices
 
-MochiPaw includes code derived from BongoCat.
+## Derivation from BongoCat
 
-Original project: https://github.com/ayangweb/BongoCat
+MochiPaw includes code derived from [BongoCat](https://github.com/ayangweb/BongoCat).
+BongoCat was released under the MIT License. The original copyright and license
+notice is retained in `LICENSES/MIT.txt`.
 
-BongoCat was released under the MIT License. The original copyright and
-license notice is retained below for the BongoCat-derived portions.
+## License Files
 
-## Core Usage Rules Quick Reference
+| File | Content |
+|------|---------|
+| `LICENSE` | PolyForm Noncommercial License 1.0.0 — the primary license for MochiPaw original code and CatStack-maintained modifications |
+| `LICENSES/PolyForm-Noncommercial-1.0.0.txt` | Official PolyForm Noncommercial License 1.0.0 text (REUSE backup) |
+| `LICENSES/MIT.txt` | Original BongoCat MIT License text (REUSE backup) |
 
-| Use Case                                   | Allowed?   | Prerequisites                                                              |
-|--------------------------------------------|-----------|----------------------------------------------------------------------------|
-| Personal learning, modification, private use | ✅ Allowed | Comply with PolyForm Noncommercial License 1.0.0 terms                     |
-| Non-profit distribution (free sharing)     | ✅ Allowed | Comply with PolyForm Noncommercial License 1.0.0 terms                     |
-| Internal company use (no external revenue) | ⚠️ Caution | If it is an "internal business tool" and generates no income, it is typically noncommercial; if used to enhance the company's profitability, it may cross the line |
-| Any form of commercial profit              | ❌ Strictly Prohibited | Including paid distribution, SaaS hosting, ad monetization, integration into paid products, etc. |
-| Obtain commercial license                  | ✅ Available upon request | Must obtain **written permission** from CatStack / InfinityXCat in advance |
+## Core Usage Rules
 
-## Additional Commercial Use Exemption
+| Use Case | Allowed? | Prerequisites |
+|----------|----------|---------------|
+| Personal learning, modification, private use | Allowed | Comply with PolyForm Noncommercial License 1.0.0 |
+| Non-profit distribution (free sharing) | Allowed | Comply with PolyForm Noncommercial License 1.0.0 |
+| Internal company use (no external revenue) | Caution | Non-commercial internal tools are typically fine; using it to enhance company profitability may cross the line |
+| Any form of commercial profit | **Prohibited** | Including paid distribution, SaaS hosting, ad monetization, integration into paid products, etc. |
+| Commercial license | Available upon request | Must obtain **written permission** from CatStack / InfinityXCat in advance |
 
-MochiPaw original code and CatStack-maintained modifications are licensed
-under the PolyForm Noncommercial License 1.0.0.
+## Commercial Licensing Contact
 
-Commercial use is not permitted without prior written permission from
-CatStack / InfinityXCat. This includes, without limitation, paid
-distribution, resale, monetized hosting, integration into paid products or
-services, commercial SaaS use, and other revenue-generating use.
-
-## Commercial Licensing
-
-To use MochiPaw or its derivative works for any commercial purpose,
-including but not limited to paid distribution, SaaS hosting, ad
-monetization, or integration into paid products or services, you must
-obtain prior written permission from CatStack / InfinityXCat.
-
-Commercial licensing inquiries: CatStack / InfinityXCat
-
-## Original BongoCat MIT License
-
-MIT License
-
-Copyright (c) 2025 ayangweb
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+To use MochiPaw or derivative works for any commercial purpose, contact:
+**CatStack / InfinityXCat**
 
 ## Bundled Assets
 


### PR DESCRIPTION
## Changes

- Remove full MIT license text (already present in LICENSES/MIT.txt)
- Remove redundant PolyForm commercial exemption paragraphs
- Add License Files index table clarifying role of LICENSE / LICENSES/
- Keep only: BongoCat derivation note, usage rules table, contact, assets, deps
- Reduce from ~90 lines to ~40 lines