### PR TITLE
ci: restore cross-platform release builds

### DIFF
--- a/.github/DOWNLOAD_GUIDE.md
+++ b/.github/DOWNLOAD_GUIDE.md
@@ -2,18 +2,22 @@
 
 ## Windows
 
-The maintained release target is Windows.
+Windows releases provide MSI and NSIS installers. Tagged releases also include
+a portable ZIP that can run without installation.
 
 1. Open the Releases page:
    https://github.com/CatStack-pixe/MochiPaw/releases
-2. Download the latest `.msi` installer.
-3. If a portable zip is attached to the release, you can use it without running
-   the installer.
+2. Download the latest `.msi` or `.exe` installer, or the portable ZIP.
+3. Extract the portable ZIP and run `MochiPaw.exe` without installing it.
 
 ## macOS and Linux
 
-Official macOS and Linux release packages are not maintained right now. Build
-from source if you want to run MochiPaw on those platforms:
+Tagged releases build macOS and Linux packages alongside Windows:
+
+- macOS: `.dmg` and `.app`
+- Linux: `.AppImage`, `.deb`, and `.rpm`
+
+If a package is not available for your architecture, build from source:
 
 ```bash
 pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,27 @@ jobs:
   build-app:
     permissions:
       contents: write
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            target: aarch64-apple-darwin
+            tauriArgs: --target aarch64-apple-darwin
+          - platform: macos-latest
+            target: x86_64-apple-darwin
+            tauriArgs: --target x86_64-apple-darwin
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
+            tauriArgs: --target x86_64-pc-windows-msvc --bundles msi,nsis
+            portable: true
+          - platform: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            tauriArgs: --target x86_64-unknown-linux-gnu
+          - platform: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            tauriArgs: --target aarch64-unknown-linux-gnu
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,7 +47,13 @@ jobs:
           version: 10
 
       - name: Install rust target
-        run: rustup target add x86_64-pc-windows-msvc
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install Linux dependencies
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libudev-dev patchelf xdg-utils
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -52,7 +78,7 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           CI: false
-          PLATFORM: windows-latest
+          PLATFORM: ${{ matrix.platform }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: ${{ github.ref_name }}
@@ -60,11 +86,22 @@ jobs:
           releaseBody: ''
           releaseDraft: true
           prerelease: false
-          args: --target x86_64-pc-windows-msvc --bundles msi
+          args: ${{ matrix.tauriArgs }}
 
-      - name: Upload MSI installer
+      - name: Build portable Windows archive
+        if: matrix.portable
+        run: pnpm build:portable -- --skip-build --target ${{ matrix.target }}
+
+      - name: Upload portable Windows archive
+        if: matrix.portable
         uses: actions/upload-artifact@v4
         with:
-          name: MochiPaw-msi-x86_64
-          path: target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
+          name: MochiPaw-portable-windows-x86_64
+          path: target/${{ matrix.target }}/release/bundle/portable/*.zip
           if-no-files-found: error
+
+      - name: Attach portable archive to release
+        if: matrix.portable && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/${{ matrix.target }}/release/bundle/portable/*.zip

--- a/README.md
+++ b/README.md
@@ -65,16 +65,18 @@ Build frontend and regenerate icons:
 pnpm build
 ```
 
-Build the Tauri app:
+Build the Tauri app for the current platform:
 
 ```bash
 pnpm tauri build
 ```
 
-Current Windows installer output is configured as MSI:
+Release builds cover Windows, macOS, and Linux:
 
 ```text
-target/release/bundle/msi/
+Windows: target/release/bundle/msi/ and target/release/bundle/nsis/
+macOS:   target/release/bundle/dmg/ and target/release/bundle/macos/
+Linux:   target/release/bundle/appimage/, target/release/bundle/deb/, and target/release/bundle/rpm/
 ```
 
 ## Portable Zip
@@ -82,7 +84,7 @@ target/release/bundle/msi/
 Build a portable Windows zip:
 
 ```bash
-pnpm package:portable
+pnpm build:portable
 ```
 
 The archive is written to:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build:icon": "tsx scripts/buildIcon.ts",
     "preview": "vite preview",
     "tauri": "tauri",
+    "build:portable": "node scripts/packagePortable.mjs",
     "package:portable": "node scripts/packagePortable.mjs",
     "lint": "eslint --fix src",
     "preinstall": "npx only-allow pnpm",

--- a/scripts/packagePortable.mjs
+++ b/scripts/packagePortable.mjs
@@ -11,7 +11,10 @@ import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const rootDir = resolve(__dirname, '..')
-const releaseDir = resolve(rootDir, 'target', 'release')
+const targetIndex = argv.indexOf('--target')
+const target = targetIndex === -1 ? undefined : argv[targetIndex + 1]
+const targetDir = target ? resolve(rootDir, 'target', target) : resolve(rootDir, 'target')
+const releaseDir = resolve(targetDir, 'release')
 const bundleDir = resolve(releaseDir, 'bundle', 'portable')
 const portableConfigPath = resolve(rootDir, 'target', 'portable-tauri.conf.json')
 const tauriCliPath = resolve(rootDir, 'node_modules', '.bin', 'tauri.CMD')
@@ -27,6 +30,10 @@ const stageDir = resolve(stageRootDir, productName)
 const archiveName = `${productName}_${packageJson.version}_windows_${arch}_portable.zip`
 const archivePath = resolve(bundleDir, archiveName)
 const skipBuild = argv.includes('--skip-build')
+
+if (targetIndex !== -1 && !target) {
+  throw new Error('The --target option requires a Rust target triple.')
+}
 
 function quotePowerShell(value) {
   return `'${value.replace(/'/g, '\'\'')}'`
@@ -102,7 +109,8 @@ writeFileSync(portableConfigPath, JSON.stringify({
 if (!skipBuild) {
   rmSync(exePath, { force: true })
   rmSync(legacyExePath, { force: true })
-  run(`${quoteCommand(tauriCliPath)} build --no-bundle --config ${quoteCommand(portableConfigPath)}`)
+  const targetArg = target ? ` --target ${quoteCommand(target)}` : ''
+  run(`${quoteCommand(tauriCliPath)} build --no-bundle${targetArg} --config ${quoteCommand(portableConfigPath)}`)
 }
 
 const builtExePath = existsSync(exePath) ? exePath : legacyExePath

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,7 +51,7 @@
     "active": true,
     "category": "Entertainment",
     "createUpdaterArtifacts": false,
-    "targets": ["msi"],
+    "targets": ["msi", "nsis", "dmg", "app", "appimage", "deb", "rpm"],
     "shortDescription": "MochiPaw",
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
- restore macOS, Windows, and Linux tagged release builds
- publish MSI, NSIS, macOS, and Linux package formats from the platform matrix
- build and attach a portable Windows ZIP from the native Windows release executable
- document supported release packages and the local portable build command

Fixes #23

## Validation
- YAML workflow validation
- JSON validation for package and Tauri configuration
- node --check scripts/packagePortable.mjs