### PR TITLE
fix: exclude portable packaging from regular builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "run-s build:icon dev:vite",
-    "build": "run-s build:*",
+    "build": "run-s build:vite build:icon",
     "dev:vite": "vite",
     "build:vite": "vite build",
     "build:icon": "tsx scripts/buildIcon.ts",


### PR DESCRIPTION
Fixes #27

Regular `pnpm build` now runs only the Vite and icon build steps. The Windows portable archive remains an explicit release workflow step, so macOS and Linux builds no longer invoke the Windows-only packager.

Validation: `pnpm build`, `node --check scripts/packagePortable.mjs`, `git diff --check`.