### PR TITLE
fix: scope Windows APIs to Windows builds

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,12 +46,14 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 fs_extra = "1"
 zip = "4"
-windows.workspace = true
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-locale = "2"
 rdev = { git = "https://github.com/kunkunsh/rdev" }
 gilrs = { git = "https://github.com/ayangweb/gilrs", default-features = false, features = ["xinput"] }
+
+[target."cfg(target_os = \"windows\")".dependencies]
+windows.workspace = true
 
 [target."cfg(target_os = \"macos\")".dependencies]
 tauri-nspanel.workspace = true


### PR DESCRIPTION
Fixes #29

The root app now declares the windows crate only for Windows targets. All direct uses are already guarded by Windows target configuration, so macOS and Linux no longer compile the Windows API dependency chain.

Validation: cargo tree --target x86_64-unknown-linux-gnu -i windows-future reports no dependency; git diff --check. Windows cargo check exceeded the local time limit without an error, and the prior CI run completed the Windows package build.