### PR TITLE
fix: use a null pointer for macOS ptrace

### DIFF
--- a/src-tauri/src/plugins/self-protect/src/checks.rs
+++ b/src-tauri/src/plugins/self-protect/src/checks.rs
@@ -47,7 +47,7 @@ fn check_macos() -> bool {
 
     const PT_DENY_ATTACH: c_int = 31;
     unsafe {
-        ptrace(PT_DENY_ATTACH, getpid(), 0, 0);
+        ptrace(PT_DENY_ATTACH, getpid(), std::ptr::null_mut(), 0);
     }
 
     false


### PR DESCRIPTION
Fixes #31

Use an explicit null pointer for the macOS ptrace address argument, matching the current libc signature.

Validation: git diff --check. The repository-wide cargo fmt check has pre-existing formatting differences; this change intentionally does not reformat unrelated code. The macOS release jobs provide the platform-specific compilation check.