### PR TITLE
feat: support Paw runtime telemetry

### DIFF
--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -14,6 +14,7 @@ import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
 import { inBetween } from '@/utils/is'
 import { isMac, isWindows } from '@/utils/platform'
+import { reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
 
 import { INVOKE_KEY, LISTEN_KEY, WINDOW_LABEL } from '../constants'
 import { useModel } from './useModel'
@@ -42,6 +43,7 @@ interface KeyboardEvent {
 type DeviceEvent = MouseButtonEvent | MouseMoveEvent | KeyboardEvent
 
 const DAMPING_DECAY = 0.75
+const RUNTIME_USED_REPORT_INTERVAL = 5 * 60 * 1000
 const appWindow = getCurrentWebviewWindow()
 
 export function useDevice() {
@@ -53,6 +55,14 @@ export function useDevice() {
   const smoothedCursorPoint = ref<CursorPoint>()
   const scaleFactor = ref(1)
   const { handlePress, handleRelease, handleMouseChange, handleMouseMove } = useModel()
+  let lastRuntimeUsedReportAt = 0
+
+  const reportRuntimeUsed = () => {
+    const now = Date.now()
+    if (now - lastRuntimeUsedReportAt < RUNTIME_USED_REPORT_INTERVAL) return
+    lastRuntimeUsedReportAt = now
+    reportRuntimeEventQuietly(modelStore.currentModel, 'used')
+  }
 
   const tickerCallback = (ticker: Ticker) => {
     const destination = latestCursorPoint.value
@@ -234,6 +244,8 @@ export function useDevice() {
       }
 
       if (kind === 'KeyboardPress') {
+        reportRuntimeUsed()
+
         if (isWindows) {
           const delay = catStore.model.autoReleaseDelay * 1000
 
@@ -260,6 +272,7 @@ export function useDevice() {
 
     switch (kind) {
       case 'MousePress':
+        reportRuntimeUsed()
         return handleMouseChange(value)
       case 'MouseRelease':
         return handleMouseChange(value, false)

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -29,6 +29,7 @@ import { isImage } from '@/utils/is'
 import live2d from '@/utils/live2d'
 import { join } from '@/utils/path'
 import { isWindows } from '@/utils/platform'
+import { ensureRuntimeLease, reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
 import { clearObject } from '@/utils/shared'
 
 const { startListening } = useDevice()
@@ -94,7 +95,15 @@ useEventListener('resize', () => {
 watch(() => modelStore.currentModel, async (model) => {
   if (!model) return
 
-  await handleLoad()
+  try {
+    await ensureRuntimeLease(model)
+    await handleLoad()
+    reportRuntimeEventQuietly(model, 'opened')
+  } catch (error) {
+    console.warn('[mochi-paw] failed to load current model:', error)
+    modelStore.modelReady = true
+    return
+  }
 
   const path = join(model.path, 'resources', 'background.png')
 

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -7,8 +7,8 @@ import { invoke } from '@tauri-apps/api/core'
 import { appDataDir } from '@tauri-apps/api/path'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { open } from '@tauri-apps/plugin-dialog'
-import { copyFile, exists, mkdir, readDir, readFile, readTextFile, stat } from '@tauri-apps/plugin-fs'
-import { message, Modal } from 'antdv-next'
+import { copyFile, exists, mkdir, readDir, readFile, readTextFile, remove, stat } from '@tauri-apps/plugin-fs'
+import { message } from 'antdv-next'
 import JSON5 from 'json5'
 import { nanoid } from 'nanoid'
 import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
@@ -25,6 +25,7 @@ import { INVOKE_KEY } from '@/constants'
 import { useModelStore } from '@/stores/model'
 import { readNearestControlledRelease, readNearestProofManifest } from '@/utils/modelMetadata'
 import { join } from '@/utils/path'
+import { ensureRuntimeLease, reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
 
 interface LegacyPetConfig {
   standard?: LegacyStandardConfig
@@ -72,8 +73,11 @@ interface ImportVariant {
   importKind: 'standard' | 'controlled'
   proofStatus: ModelProofStatus
   packageId?: string
+  dispatchToken?: string
   author?: ModelAuthorProfile
   controlledRelease?: ModelControlledRelease
+  proofDirectory?: string
+  controlDirectory?: string
 }
 
 interface KeyImageRef {
@@ -187,7 +191,6 @@ const GAMEPAD_BUTTON_NAMES = [
 type ImportFromPathResult
   = | { status: 'imported', models: Array<ReturnType<typeof createImportedModel>> }
     | { status: 'duplicate' }
-    | { status: 'blocked-controlled', release: ModelControlledRelease }
 
 onMounted(() => {
   const appWindow = getCurrentWebviewWindow()
@@ -259,17 +262,6 @@ watch(selectPaths, async (paths) => {
     try {
       const result = await importFromPath(fromPath)
 
-      if (result.status === 'blocked-controlled') {
-        Modal.warning({
-          title: t('pages.preference.model.controlledImport.title'),
-          content: t('pages.preference.model.controlledImport.content', {
-            packageId: result.release.packageId ?? t('pages.preference.model.controlledImport.unknownPackage'),
-          }),
-        })
-
-        continue
-      }
-
       if (result.status === 'duplicate') {
         message.info(t('pages.preference.model.hints.alreadyImported'))
 
@@ -278,6 +270,7 @@ watch(selectPaths, async (paths) => {
 
       for (const model of result.models) {
         modelStore.models.push(model)
+        reportRuntimeEventQuietly(model, 'imported')
       }
 
       message.success(t('pages.preference.model.hints.importSuccess'))
@@ -299,15 +292,6 @@ async function importFromPath(fromPath: string) {
     throw new Error('No model3.json found')
   }
 
-  const controlledVariant = variants.find(variant => variant.controlledRelease)
-
-  if (controlledVariant?.controlledRelease) {
-    return {
-      status: 'blocked-controlled',
-      release: controlledVariant.controlledRelease,
-    } satisfies ImportFromPathResult
-  }
-
   const models = []
   const importedFingerprints = await getImportedFingerprints()
 
@@ -323,8 +307,9 @@ async function importFromPath(fromPath: string) {
     })
 
     await normalizeResources(variant, toPath)
+    await copyMetadataDirectories(variant, toPath)
 
-    models.push(createImportedModel({
+    const model = createImportedModel({
       id,
       displayName: variant.displayName,
       path: toPath,
@@ -334,9 +319,19 @@ async function importFromPath(fromPath: string) {
       importKind: variant.importKind,
       proofStatus: variant.proofStatus,
       packageId: variant.packageId,
+      dispatchToken: variant.dispatchToken,
       author: variant.author,
       controlledRelease: variant.controlledRelease,
-    }))
+    })
+
+    try {
+      await ensureRuntimeLease(model)
+    } catch (error) {
+      await remove(toPath, { recursive: true }).catch(() => undefined)
+      throw error
+    }
+
+    models.push(model)
 
     importedFingerprints.add(variant.fingerprint)
   }
@@ -358,6 +353,7 @@ function createImportedModel(model: {
   importKind?: 'standard' | 'controlled'
   proofStatus?: ModelProofStatus
   packageId?: string
+  dispatchToken?: string
   author?: ModelAuthorProfile
   controlledRelease?: ModelControlledRelease
 }) {
@@ -412,6 +408,8 @@ async function discoverLegacyVariants(sourcePath: string) {
 
       const proofManifest = await readNearestProofManifest(modelPath, sourcePath)
       const controlledRelease = await readNearestControlledRelease(modelPath, sourcePath)
+      const proofDirectory = await findNearestManifestDirectory(modelPath, 'mochi-proof', 'manifest.json', sourcePath)
+      const controlDirectory = await findNearestManifestDirectory(modelPath, 'mochi-control', 'release.json', sourcePath)
 
       variants.push({
         mode,
@@ -426,8 +424,11 @@ async function discoverLegacyVariants(sourcePath: string) {
         importKind: controlledRelease ? 'controlled' : 'standard',
         proofStatus: controlledRelease ? 'controlled-release' : proofManifest ? 'manifest-detected' : 'unsigned',
         packageId: proofManifest?.packageId ?? controlledRelease?.packageId,
+        dispatchToken: proofManifest?.dispatch?.dispatchToken,
         author: proofManifest?.author,
         controlledRelease,
+        proofDirectory,
+        controlDirectory,
       })
     }
   }
@@ -442,6 +443,8 @@ async function discoverCubismVariants(sourcePath: string) {
     const mode = await inferMode(modelPath)
     const proofManifest = await readNearestProofManifest(modelPath, sourcePath)
     const controlledRelease = await readNearestControlledRelease(modelPath, sourcePath)
+    const proofDirectory = await findNearestManifestDirectory(modelPath, 'mochi-proof', 'manifest.json', sourcePath)
+    const controlDirectory = await findNearestManifestDirectory(modelPath, 'mochi-control', 'release.json', sourcePath)
 
     return {
       mode,
@@ -456,10 +459,48 @@ async function discoverCubismVariants(sourcePath: string) {
       importKind: controlledRelease ? 'controlled' : 'standard',
       proofStatus: controlledRelease ? 'controlled-release' : proofManifest ? 'manifest-detected' : 'unsigned',
       packageId: proofManifest?.packageId ?? controlledRelease?.packageId,
+      dispatchToken: proofManifest?.dispatch?.dispatchToken,
       author: proofManifest?.author,
       controlledRelease,
+      proofDirectory,
+      controlDirectory,
     }
   }))
+}
+
+async function copyMetadataDirectories(variant: ImportVariant, toPath: string) {
+  if (variant.proofDirectory) {
+    await invoke(INVOKE_KEY.COPY_DIR, {
+      fromPath: variant.proofDirectory,
+      toPath: join(toPath, 'mochi-proof'),
+    })
+  }
+  if (variant.controlDirectory) {
+    await invoke(INVOKE_KEY.COPY_DIR, {
+      fromPath: variant.controlDirectory,
+      toPath: join(toPath, 'mochi-control'),
+    })
+  }
+}
+
+async function findNearestManifestDirectory(startPath: string, manifestDirectory: string, manifestFile: string, stopPath?: string) {
+  let currentPath = startPath
+  const normalizedStopPath = stopPath ? normalizePath(stopPath) : undefined
+
+  while (currentPath) {
+    const candidate = join(currentPath, manifestDirectory)
+    if (await exists(join(candidate, manifestFile))) return candidate
+
+    const normalizedCurrentPath = normalizePath(currentPath)
+    if (normalizedStopPath && normalizedCurrentPath === normalizedStopPath) return undefined
+
+    const parentPath = getParentPath(currentPath)
+    if (!parentPath || normalizePath(parentPath) === normalizedCurrentPath) return undefined
+
+    currentPath = parentPath
+  }
+
+  return undefined
 }
 
 async function inferImportDisplayName({
@@ -687,12 +728,16 @@ function getParentPath(path: string) {
   return parts.join(separator)
 }
 
+function normalizePath(path: string) {
+  return path.replace(/[\\/]+/g, '/').replace(/\/$/, '').toLowerCase()
+}
+
 function normalizeDisplayName(value: unknown) {
   if (typeof value !== 'string') return undefined
 
   const displayName = value.trim()
 
-  if (!displayName || /^(none|null|undefined|n\/a)$/i.test(displayName)) return undefined
+  if (!displayName || /^(?:none|null|undefined|n\/a)$/i.test(displayName)) return undefined
 
   return displayName
 }

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -15,6 +15,7 @@ import type { Model } from '@/stores/model'
 
 import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
+import { ensureRuntimeLease, reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
 
 import BehaviorModal from './components/behavior-modal/index.vue'
 import FloatMenu from './components/float-menu/index.vue'
@@ -74,7 +75,7 @@ function displayMetaValue(value: unknown) {
   if (typeof value !== 'string') return ''
 
   const text = value.trim()
-  if (!text || /^(none|null|undefined|n\/a)$/i.test(text)) return ''
+  if (!text || /^(?:none|null|undefined|n\/a)$/i.test(text)) return ''
 
   return text
 }
@@ -115,12 +116,20 @@ const masonryItems = computed(() => {
   return [{ key: 'upload', data: null }, ...items]
 })
 
-function handleToggle(nextModel: Model) {
+async function handleToggle(nextModel: Model) {
   if (modelStore.currentModel?.id === nextModel.id) return
+
+  try {
+    await ensureRuntimeLease(nextModel)
+  } catch (error) {
+    message.error(String(error))
+    return
+  }
 
   modelStore.modelReady = false
 
   modelStore.currentModel = nextModel
+  reportRuntimeEventQuietly(nextModel, 'opened')
 }
 
 async function handleDelete(item: Model) {

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -37,6 +37,12 @@ export interface ModelControlledRelease {
   reimportRestricted?: boolean
 }
 
+export interface ModelRuntimeLease {
+  leaseToken: string
+  leaseId: string
+  expiresAt: number
+}
+
 export interface Model {
   id: string
   displayName?: string
@@ -49,6 +55,8 @@ export interface Model {
   packageId?: string
   author?: ModelAuthorProfile
   controlledRelease?: ModelControlledRelease
+  dispatchToken?: string
+  runtimeLease?: ModelRuntimeLease
 }
 
 export interface ModelSupportKeyLayer {
@@ -187,6 +195,7 @@ async function fillModelMetadata(model: Model) {
   model.packageId = proofManifest?.packageId ?? controlledRelease?.packageId ?? model.packageId
   model.author = proofManifest?.author ?? model.author
   model.controlledRelease = controlledRelease ?? model.controlledRelease
+  model.dispatchToken = proofManifest?.dispatch?.dispatchToken ?? model.dispatchToken
 
   if (!model.isPreset && !model.displayName?.trim()) {
     model.displayName = await inferStoredModelDisplayName(model, proofManifest?.modelName)
@@ -228,7 +237,7 @@ function normalizeDisplayName(value: unknown) {
 
   const displayName = value.trim()
 
-  if (!displayName || /^(none|null|undefined|n\/a)$/i.test(displayName)) return undefined
+  if (!displayName || /^(?:none|null|undefined|n\/a)$/i.test(displayName)) return undefined
 
   return displayName
 }

--- a/src/utils/modelMetadata.ts
+++ b/src/utils/modelMetadata.ts
@@ -11,6 +11,14 @@ import { join } from '@/utils/path'
 export interface ModelProofManifest {
   modelName?: string
   packageId?: string
+  distributionMode?: string
+  runtimeDistributionMode?: string
+  dispatch?: {
+    dispatchToken?: string
+    dispatchCode?: string
+    distributionCode?: string
+    productId?: string
+  } | null
   author?: ModelAuthorProfile
 }
 

--- a/src/utils/runtimeTelemetry.ts
+++ b/src/utils/runtimeTelemetry.ts
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import { getVersion } from '@tauri-apps/api/app'
+import { exists, readTextFile } from '@tauri-apps/plugin-fs'
+import JSON5 from 'json5'
+
+import type { Model } from '@/stores/model'
+
+import { join } from '@/utils/path'
+
+const RUNTIME_API_BASE = (import.meta.env.VITE_MOCHI_RUNTIME_API_BASE || 'https://www.catpithos.top').replace(/\/$/, '')
+const LEASE_REFRESH_SKEW_SECONDS = 10 * 60
+
+type RuntimeEventType = 'imported' | 'opened' | 'used' | 'heartbeat' | 'failed'
+
+interface AuthorProofEnvelope {
+  payload?: {
+    packageId?: string
+    package_id?: string
+  }
+}
+
+function nowSeconds() {
+  return Math.floor(Date.now() / 1000)
+}
+
+function isLeaseFresh(model: Model) {
+  return Boolean(model.runtimeLease?.leaseToken && model.runtimeLease.expiresAt > nowSeconds() + LEASE_REFRESH_SKEW_SECONDS)
+}
+
+async function readAuthorProof(modelPath: string) {
+  const proofPath = join(modelPath, 'mochi-proof', 'author.mpa')
+  if (!await exists(proofPath)) return null
+  const raw = await readTextFile(proofPath)
+  const parsed = JSON5.parse(raw) as AuthorProofEnvelope
+  return { parsed }
+}
+
+async function postRuntimeJson<T>(path: string, body: Record<string, unknown>, token?: string): Promise<T> {
+  const response = await fetch(`${RUNTIME_API_BASE}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+  const payload = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    const detail = typeof payload.detail === 'string' ? payload.detail : `runtime API returned HTTP ${response.status}`
+    throw new Error(detail)
+  }
+  return payload as T
+}
+
+function proofPackageId(proof: AuthorProofEnvelope) {
+  return String(proof.payload?.packageId || proof.payload?.package_id || '').trim()
+}
+
+async function runtimeBody(model: Model, eventType?: RuntimeEventType) {
+  const proof = await readAuthorProof(model.path)
+  if (!proof) return null
+  const packageId = model.packageId || proofPackageId(proof.parsed)
+  if (!packageId) return null
+  return {
+    packageId,
+    eventType,
+    authorProof: proof.parsed,
+    appVersion: await getVersion().catch(() => undefined),
+  }
+}
+
+export async function ensureRuntimeLease(model: Model) {
+  if (model.importKind !== 'controlled' && model.proofStatus !== 'controlled-release') return
+  if (isLeaseFresh(model)) return
+  const dispatchToken = model.dispatchToken
+  if (!dispatchToken) throw new Error('Controlled package is missing dispatch token.')
+  const body = await runtimeBody(model)
+  if (!body) throw new Error('Controlled package is missing author proof.')
+  const lease = await postRuntimeJson<{ leaseToken: string, leaseId: string, expiresAt: number }>('/runtime/leases', {
+    dispatchToken,
+    packageId: body.packageId,
+    authorProof: body.authorProof,
+  })
+  model.runtimeLease = lease
+}
+
+export async function reportRuntimeEvent(model: Model, eventType: RuntimeEventType) {
+  const body = await runtimeBody(model, eventType)
+  if (!body) return
+  if (model.importKind === 'controlled' || model.proofStatus === 'controlled-release') {
+    await ensureRuntimeLease(model)
+    const leaseToken = model.runtimeLease?.leaseToken
+    if (!leaseToken) throw new Error('Controlled package runtime lease is missing.')
+    await postRuntimeJson('/runtime/events', body, leaseToken)
+    return
+  }
+  await postRuntimeJson('/runtime/events', body)
+}
+
+export function reportRuntimeEventQuietly(model: Model | undefined, eventType: RuntimeEventType) {
+  if (!model || model.isPreset) return
+  void reportRuntimeEvent(model, eventType).catch((error) => {
+    console.warn('[mochi-paw] runtime telemetry failed:', error)
+  })
+}


### PR DESCRIPTION
## Summary
- import Studio signed packages with author-proof metadata preserved
- activate controlled packages with Dashboard runtime leases
- report imported/opened/used runtime events to Dashboard with throttling

## Verification
- pnpm build
- pnpm build:vite
- cargo check -p mochi-paw