### PR TITLE
docs: clarify licensing and upstream triage

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,41 +1,94 @@
 # Notices
 
-## Derivation from BongoCat
+## License Scope
 
-MochiPaw includes code derived from [BongoCat](https://github.com/ayangweb/BongoCat).
-BongoCat was released under the MIT License. The original copyright and license
-notice is retained in `LICENSES/MIT.txt`.
+MochiPaw is a multi-license repository derived from
+[BongoCat](https://github.com/ayangweb/BongoCat).
 
-## License Files
+BongoCat-derived files remain available under the MIT License. The original
+MIT notice is preserved below and in `LICENSES/MIT.txt`.
 
-| File | Content |
-|------|---------|
-| `LICENSE` | PolyForm Noncommercial License 1.0.0 — the primary license for MochiPaw original code and CatStack-maintained modifications |
-| `LICENSES/PolyForm-Noncommercial-1.0.0.txt` | Official PolyForm Noncommercial License 1.0.0 text (REUSE backup) |
-| `LICENSES/MIT.txt` | Original BongoCat MIT License text (REUSE backup) |
+CatStack-authored additions are licensed under the PolyForm Noncommercial
+License 1.0.0 unless a file states otherwise. The full PolyForm text is in
+`LICENSE` and `LICENSES/PolyForm-Noncommercial-1.0.0.txt`.
+
+The PolyForm license does not remove or narrow the MIT rights granted for
+BongoCat-derived material, bundled BongoCat model assets, or third-party
+dependencies.
+
+## CatStack-Authored Additions
+
+The following paths are treated as CatStack-authored additions for licensing
+and attribution purposes:
+
+- `.env.example`
+- `.github/`
+- `Agent.md`
+- `docs/`
+- `scripts/packagePortable.mjs`
+- `src-tauri/src/core/author_proof.rs`
+- `src-tauri/src/plugins/self-protect/`
+- `src/pages/preference/components/model/components/model-preview/`
+- `src/utils/authorProof.ts`
+- `src/utils/controlledRelease.ts`
+- `src/utils/modelMetadata.ts`
+- `src/utils/modelResourceMetrics.ts`
+- `src/utils/runtimeTelemetry.ts`
+- `src/utils/windowPosition.ts`
+- `src/utils/windowPosition.test.ts`
+
+When new CatStack-only files are added, update this list before distribution.
 
 ## Core Usage Rules
 
-| Use Case | Allowed? | Prerequisites |
-|----------|----------|---------------|
-| Personal learning, modification, private use | Allowed | Comply with PolyForm Noncommercial License 1.0.0 |
-| Non-profit distribution (free sharing) | Allowed | Comply with PolyForm Noncommercial License 1.0.0 |
-| Internal company use (no external revenue) | Caution | Non-commercial internal tools are typically fine; using it to enhance company profitability may cross the line |
-| Any form of commercial profit | **Prohibited** | Including paid distribution, SaaS hosting, ad monetization, integration into paid products, etc. |
-| Commercial license | Available upon request | Must obtain **written permission** from CatStack / InfinityXCat in advance |
+| Use case                                                                        | Status                         | Notes                                                          |
+| ------------------------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------- |
+| Personal learning, modification, and private use                                | Allowed                        | Must comply with the applicable license terms                  |
+| Non-profit distribution                                                         | Allowed                        | Preserve notices and license texts                             |
+| Internal company use                                                            | Review required                | Use that supports business operations may be commercial use    |
+| Commercial profit, paid distribution, SaaS hosting, or paid-product integration | Not allowed without permission | Requires prior written permission from CatStack / InfinityXCat |
 
-## Commercial Licensing Contact
+For commercial licensing, contact CatStack / InfinityXCat.
 
-To use MochiPaw or derivative works for any commercial purpose, contact:
-**CatStack / InfinityXCat**
+## BongoCat Attribution
 
-## Bundled Assets
+Original project: <https://github.com/ayangweb/BongoCat>
 
-Bundled Live2D/Cubism runtime files, model files, images, icons, and other
-assets may have separate upstream terms. Review those terms before
-redistributing modified builds or using the assets outside this repository.
+The default Live2D model directories are distributed from BongoCat:
 
-## Third-Party Dependencies
+- `src-tauri/assets/models/standard`
+- `src-tauri/assets/models/keyboard`
+- `src-tauri/assets/models/gamepad`
 
-Third-party dependencies and bundled runtime files are subject to their own
-licenses and notices.
+They remain under upstream attribution and are not claimed as CatStack-authored
+or relicensed under PolyForm by this repository.
+
+### BongoCat MIT Notice
+
+MIT License
+
+Copyright (c) 2025 ayangweb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Third-Party Dependencies and Assets
+
+Third-party dependencies, bundled runtimes, generated binaries, icons, images,
+and assets not listed above remain subject to their own license terms. This
+repository makes no ownership claim over them.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # MochiPaw
 
-[![License](https://img.shields.io/badge/License-PolyForm%20Noncommercial%201.0.0-blue)](./LICENSE)
-
 MochiPaw is a Tauri + Vue desktop pet app based on
 [BongoCat](https://github.com/ayangweb/BongoCat).
 
-This project is licensed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0).
-See [NOTICE.md](./NOTICE.md) for additional terms, core usage rules, and commercial licensing information.
+This repository contains BongoCat-derived material under the MIT License and
+CatStack-authored additions under the PolyForm Noncommercial License 1.0.0.
+See [NOTICE.md](./NOTICE.md) for license scope, attribution, core usage rules,
+and commercial licensing information.
 
 > **Noncommercial only.** Commercial use requires prior written permission from CatStack / InfinityXCat.
 
@@ -118,14 +118,23 @@ pnpm release
 The release script syncs package metadata through `scripts/release.ts` and uses
 `release-it`.
 
+## Upstream Triage
+
+MochiPaw tracks selected work from upstream BongoCat. See
+[docs/upstream-triage.md](./docs/upstream-triage.md) for the review and porting
+process.
+
 ## License
 
-MochiPaw original code and CatStack-maintained modifications are licensed under
-the PolyForm Noncommercial License 1.0.0. Commercial use, paid distribution,
-resale, monetized hosting, or integration into paid products or services
-requires prior written permission from CatStack / InfinityXCat.
+MochiPaw is a multi-license repository:
 
-See [LICENSE](./LICENSE).
+- BongoCat-derived material remains available under the MIT License.
+- CatStack-authored additions are licensed under the PolyForm Noncommercial
+  License 1.0.0 unless a file states otherwise.
+- Third-party dependencies and bundled assets keep their own terms.
+
+See [LICENSE](./LICENSE), [NOTICE.md](./NOTICE.md), and the full texts in
+[`LICENSES/`](./LICENSES).
 
 ## Attribution
 
@@ -133,10 +142,11 @@ MochiPaw is a derivative work of
 [ayangweb/BongoCat](https://github.com/ayangweb/BongoCat), which was released
 under the MIT License.
 
-The original MIT notice is retained in [NOTICE.md](./NOTICE.md). CatStack
-changes are licensed under the noncommercial MochiPaw license unless a file
-states otherwise.
+The original MIT notice is retained in [NOTICE.md](./NOTICE.md) and
+[`LICENSES/MIT.txt`](./LICENSES/MIT.txt). CatStack-authored additions are
+listed in [NOTICE.md](./NOTICE.md).
 
-Bundled Live2D/Cubism runtime and model assets keep their original upstream
-terms. If you redistribute modified builds, review the asset and runtime
-licenses for your distribution channel.
+Bundled Live2D/Cubism runtime files, model assets, images, icons, and other
+third-party material keep their original upstream terms. Review those terms
+before redistributing modified builds or using the assets outside this
+repository.

--- a/docs/upstream-triage.md
+++ b/docs/upstream-triage.md
@@ -1,0 +1,35 @@
+# BongoCat Upstream Triage
+
+MochiPaw tracks selected work from its upstream project,
+[ayangweb/BongoCat](https://github.com/ayangweb/BongoCat). The `upstream`
+remote is read-only and must never be pushed to.
+
+## Sync Procedure
+
+1. Fetch upstream references:
+
+   ```powershell
+   git fetch upstream --prune
+   ```
+
+2. Review upstream issues and pull requests without copying long discussions.
+   Migrate a work item only when it applies to MochiPaw, is not already
+   addressed, and has enough detail to implement or reproduce.
+3. Create a MochiPaw issue containing the upstream URL and author. Apply the
+   `upstream` label, plus `upstream-pr` for a port candidate or
+   `needs-reproduction` for an unverified bug report.
+4. Port pull requests through a new MochiPaw branch. Do not merge an upstream
+   branch directly. Revalidate dependencies, permissions, platform behavior,
+   and MochiPaw-specific changes made since the fork.
+5. Before merging a MochiPaw pull request, apply its classification label,
+   complete a code review, and use GitHub Squash and merge.
+
+## Initial Snapshot
+
+The initial review on 2026-07-17 created MochiPaw issues #10 through #20 for
+selected upstream work. Related feature requests and bug reports were combined
+into a single local task where they shared an implementation path.
+
+Upstream PR #989 was not migrated because its model import and deletion fixes
+were already covered by MochiPaw's importer and transactional delete logic. It
+should be reconsidered only if a reproducible MochiPaw regression appears.


### PR DESCRIPTION
## Summary
- clarify MochiPaw's multi-license scope and BongoCat attribution
- document commercial-use expectations and third-party asset caveats
- add an upstream triage process for future BongoCat issue and PR review

## Verification
- docs-only change
- checked for mojibake markers in README, NOTICE, and docs/upstream-triage.md