### PR TITLE
feat: decrypt controlled package assets

### DIFF
--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -6,7 +6,6 @@ import { invoke } from '@tauri-apps/api/core'
 import { PhysicalPosition } from '@tauri-apps/api/dpi'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { isNil } from 'es-toolkit'
-import { Ticker } from 'pixi.js'
 import { onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { useAppStore } from '@/stores/app'
@@ -54,8 +53,10 @@ export function useDevice() {
   const latestCursorPoint = ref<CursorPoint>()
   const smoothedCursorPoint = ref<CursorPoint>()
   const scaleFactor = ref(1)
-  const { handlePress, handleRelease, handleMouseChange, handleMouseMove } = useModel()
+  const { handlePress, handleRelease, handleMouseChange, handleMouseMove, handleDestroy } = useModel()
   let lastRuntimeUsedReportAt = 0
+  let cursorSmoothingFrame = 0
+  let lastCursorSmoothingAt = 0
 
   const reportRuntimeUsed = () => {
     const now = Date.now()
@@ -64,14 +65,38 @@ export function useDevice() {
     reportRuntimeEventQuietly(modelStore.currentModel, 'used')
   }
 
-  const tickerCallback = (ticker: Ticker) => {
+  const stopCursorSmoothing = () => {
+    if (cursorSmoothingFrame) {
+      cancelAnimationFrame(cursorSmoothingFrame)
+      cursorSmoothingFrame = 0
+    }
+
+    lastCursorSmoothingAt = 0
+    latestCursorPoint.value = undefined
+    smoothedCursorPoint.value = undefined
+  }
+
+  const scheduleCursorSmoothing = () => {
+    if (catStore.model.ignoreMouse || cursorSmoothingFrame || !latestCursorPoint.value) return
+
+    cursorSmoothingFrame = requestAnimationFrame(runCursorSmoothing)
+  }
+
+  const runCursorSmoothing = (timestamp: number) => {
+    cursorSmoothingFrame = 0
+
     const destination = latestCursorPoint.value
 
     if (!destination) return
 
     const current = smoothedCursorPoint.value ?? destination
+    const deltaMS = lastCursorSmoothingAt
+      ? timestamp - lastCursorSmoothingAt
+      : 1000 / 60
 
-    const alpha = 1 - DAMPING_DECAY ** (ticker.deltaMS / (1000 / 60))
+    lastCursorSmoothingAt = timestamp
+
+    const alpha = 1 - DAMPING_DECAY ** (deltaMS / (1000 / 60))
 
     const interpolated = {
       x: current.x + (destination.x - current.x) * alpha,
@@ -82,11 +107,16 @@ export function useDevice() {
       smoothedCursorPoint.value = { ...destination }
 
       latestCursorPoint.value = void 0
+      lastCursorSmoothingAt = 0
     } else {
       smoothedCursorPoint.value = interpolated
     }
 
     void handleCursorMove(smoothedCursorPoint.value)
+
+    if (latestCursorPoint.value) {
+      scheduleCursorSmoothing()
+    }
   }
 
   onMounted(async () => {
@@ -100,15 +130,23 @@ export function useDevice() {
   })
 
   onUnmounted(() => {
-    Ticker.shared.remove(tickerCallback)
+    stopCursorSmoothing()
+
+    for (const timer of releaseTimers.values()) {
+      clearTimeout(timer)
+    }
+
+    releaseTimers.clear()
+    handleDestroy()
   })
 
   watch(() => catStore.model.ignoreMouse, (value) => {
     if (value) {
-      return Ticker.shared.remove(tickerCallback)
+      stopCursorSmoothing()
+      return
     }
 
-    return Ticker.shared.add(tickerCallback)
+    scheduleCursorSmoothing()
   }, { immediate: true })
 
   const startListening = () => {
@@ -277,7 +315,8 @@ export function useDevice() {
       case 'MouseRelease':
         return handleMouseChange(value, false)
       case 'MouseMove':
-        return latestCursorPoint.value = value
+        latestCursorPoint.value = value
+        return scheduleCursorSmoothing()
     }
   })
 

--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -213,10 +213,23 @@ export function useModel() {
       if (isLive2dLoadCancelledError(error)) return
 
       message.error(String(error))
+      throw error
     }
   }
 
   function handleDestroy() {
+    if (typingExpressionTimer) {
+      clearTimeout(typingExpressionTimer)
+      typingExpressionTimer = undefined
+    }
+
+    if (activeMotionResetTimer) {
+      clearTimeout(activeMotionResetTimer)
+      activeMotionResetTimer = undefined
+    }
+
+    activeMotionBehaviorId = undefined
+    currentExpressionBehaviorId = undefined
     live2d.destroy()
   }
 

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -11,7 +11,7 @@ import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { exists, readDir } from '@tauri-apps/plugin-fs'
 import { useDebounceFn, useEventListener } from '@vueuse/core'
 import { round } from 'es-toolkit'
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import type { ModelMotionInfo } from '@/stores/model'
 
@@ -63,6 +63,7 @@ let resizeFrame = 0
 let scalingWithShortcut = false
 let scaleSyncTimer: ReturnType<typeof setTimeout> | undefined
 let lastShortcutResizeAt = 0
+let currentModelLoadVersion = 0
 
 const SCALE_DRAG_SENSITIVITY = 0.12
 const SHORTCUT_RESIZE_INTERVAL = 33
@@ -92,14 +93,33 @@ useEventListener('resize', () => {
   debouncedResize()
 })
 
-watch(() => modelStore.currentModel, async (model) => {
+watch(() => {
+  const model = modelStore.currentModel
+
+  return model ? `${model.id}:${model.path}` : ''
+}, async () => {
+  const model = modelStore.currentModel
+  const loadVersion = ++currentModelLoadVersion
+
   if (!model) return
+
+  modelStore.modelReady = false
+
+  await nextTick()
 
   try {
     await ensureRuntimeLease(model)
+
+    if (loadVersion !== currentModelLoadVersion) return
+
     await handleLoad()
+
+    if (loadVersion !== currentModelLoadVersion) return
+
     reportRuntimeEventQuietly(model, 'opened')
   } catch (error) {
+    if (loadVersion !== currentModelLoadVersion) return
+
     console.warn('[mochi-paw] failed to load current model:', error)
     modelStore.modelReady = true
     return
@@ -108,6 +128,8 @@ watch(() => modelStore.currentModel, async (model) => {
   const path = join(model.path, 'resources', 'background.png')
 
   const existed = await exists(path)
+
+  if (loadVersion !== currentModelLoadVersion) return
 
   backgroundImagePath.value = existed ? convertFileSrc(path) : void 0
 
@@ -127,6 +149,8 @@ watch(() => modelStore.currentModel, async (model) => {
     const imageFiles = files.filter(file => isImage(file.name))
 
     for (const file of imageFiles) {
+      if (loadVersion !== currentModelLoadVersion) return
+
       const fileName = file.name.split('.')[0]
 
       modelStore.supportKeys[fileName] ??= []
@@ -137,8 +161,10 @@ watch(() => modelStore.currentModel, async (model) => {
     }
   }
 
-  modelStore.modelReady = true
-}, { deep: true, immediate: true })
+  if (loadVersion === currentModelLoadVersion) {
+    modelStore.modelReady = true
+  }
+}, { flush: 'post', immediate: true })
 
 watch([() => catStore.window.scale, modelSize], ([scale, modelSize]) => {
   if (!modelSize) return

--- a/src/pages/preference/components/about/index.vue
+++ b/src/pages/preference/components/about/index.vue
@@ -30,6 +30,8 @@ const metricsLoading = ref(false)
 const compactingMemory = ref(false)
 const { t } = useI18n()
 let metricsTimer: ReturnType<typeof window.setInterval> | undefined
+let metricsRefreshing = false
+const METRICS_REFRESH_INTERVAL = 2000
 const authors = [
   {
     name: 'InfinityXCat',
@@ -52,13 +54,13 @@ const modStatement = [
 
 onMounted(async () => {
   logDir.value = await appLogDir()
-  await refreshMetrics()
-  metricsTimer = window.setInterval(refreshMetrics, 1000)
+  await refreshMetrics({ showLoading: true })
+  scheduleMetricsRefresh()
 })
 
 onBeforeUnmount(() => {
   if (metricsTimer) {
-    window.clearInterval(metricsTimer)
+    window.clearTimeout(metricsTimer)
   }
 })
 
@@ -86,8 +88,23 @@ async function copyText(value: string, successText: string) {
   message.success(successText)
 }
 
-async function refreshMetrics() {
-  metricsLoading.value = true
+function scheduleMetricsRefresh() {
+  metricsTimer = window.setTimeout(async () => {
+    await refreshMetrics()
+    scheduleMetricsRefresh()
+  }, METRICS_REFRESH_INTERVAL)
+}
+
+async function refreshMetrics(options: { showLoading?: boolean } = {}) {
+  if (metricsRefreshing) return
+
+  if (document.hidden) return
+
+  metricsRefreshing = true
+
+  if (options.showLoading) {
+    metricsLoading.value = true
+  }
 
   try {
     metrics.value = await getProcessMetrics()
@@ -95,8 +112,16 @@ async function refreshMetrics() {
   } catch (error) {
     metricsError.value = error instanceof Error ? error.message : String(error)
   } finally {
-    metricsLoading.value = false
+    metricsRefreshing = false
+
+    if (options.showLoading) {
+      metricsLoading.value = false
+    }
   }
+}
+
+function handleRefreshMetrics() {
+  return refreshMetrics({ showLoading: true })
 }
 
 async function handleCompactMemory() {
@@ -104,7 +129,7 @@ async function handleCompactMemory() {
 
   try {
     await compactProcessMemory()
-    await refreshMetrics()
+    await refreshMetrics({ showLoading: true })
     message.success(t('pages.preference.about.hints.compactMemorySuccess'))
   } catch (error) {
     message.error(error instanceof Error ? error.message : String(error))
@@ -285,7 +310,7 @@ const metricsItems = computed(() => [
 
       <Button
         :loading="metricsLoading"
-        @click="refreshMetrics"
+        @click="handleRefreshMetrics"
       >
         {{ $t('pages.preference.about.buttons.refresh') }}
       </Button>

--- a/src/pages/preference/components/model/components/model-preview/index.vue
+++ b/src/pages/preference/components/model/components/model-preview/index.vue
@@ -7,7 +7,7 @@ import { convertFileSrc } from '@tauri-apps/api/core'
 import { exists } from '@tauri-apps/plugin-fs'
 import { useElementSize } from '@vueuse/core'
 import { CubismSetting, Live2DSprite } from 'easy-live2d'
-import { Application, Ticker } from 'pixi.js'
+import { Application } from 'pixi.js'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 
 import type { Model } from '@/stores/model'
@@ -78,6 +78,7 @@ async function loadPreview() {
       autoDensity: true,
       resolution: devicePixelRatio,
     })
+    nextApp.ticker.maxFPS = 24
 
     if (currentLoadId !== loadId) {
       nextApp.destroy(false)
@@ -105,7 +106,7 @@ async function loadPreview() {
 
     const nextSprite = new Live2DSprite({
       modelSetting,
-      ticker: Ticker.shared,
+      ticker: nextApp.ticker,
     })
 
     sprite = nextSprite

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -306,7 +306,6 @@ async function importFromPath(fromPath: string) {
       toPath,
     })
 
-    await normalizeResources(variant, toPath)
     await copyMetadataDirectories(variant, toPath)
 
     const model = createImportedModel({
@@ -326,6 +325,7 @@ async function importFromPath(fromPath: string) {
 
     try {
       await ensureRuntimeLease(model)
+      await normalizeResources(variant, toPath)
     } catch (error) {
       await remove(toPath, { recursive: true }).catch(() => undefined)
       throw error

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -35,6 +35,18 @@ export interface ModelControlledRelease {
   runtimeTelemetryRequired?: boolean
   offlineLeaseAllowed?: boolean
   reimportRestricted?: boolean
+  contentEncryption?: {
+    status?: string
+    algorithm?: string
+    keyDelivery?: string
+    encryptedFiles?: Array<{
+      path?: string
+      algorithm?: string
+      nonce?: string
+      originalSize?: number
+      ciphertextSize?: number
+    }>
+  }
 }
 
 export interface ModelRuntimeLease {

--- a/src/utils/live2d.ts
+++ b/src/utils/live2d.ts
@@ -9,7 +9,7 @@ import { readDir, readTextFile } from '@tauri-apps/plugin-fs'
 import { Config, CubismSetting, Live2DSprite, Priority } from 'easy-live2d'
 import { flatMap, groupBy } from 'es-toolkit/compat'
 import JSON5 from 'json5'
-import { Application, Ticker } from 'pixi.js'
+import { Application } from 'pixi.js'
 
 import type { ModelSize } from '@/composables/useModel'
 import type { ModelExpressionInfo, ModelMotionInfo } from '@/stores/model'
@@ -202,6 +202,7 @@ class Live2d {
   private app: Application | null = null
   private appInitPromise: Promise<void> | null = null
   private loadVersion = 0
+  private maxFPS = 60
   public model: Live2DSprite | null = null
 
   constructor() { }
@@ -212,7 +213,11 @@ class Live2d {
       return
     }
 
-    const view = document.getElementById('live2dCanvas') as HTMLCanvasElement
+    const view = document.getElementById('live2dCanvas')
+
+    if (!(view instanceof HTMLCanvasElement)) {
+      throw new TypeError('Live2D canvas is not mounted')
+    }
 
     this.app = new Application()
 
@@ -222,10 +227,13 @@ class Live2d {
       backgroundAlpha: 0,
       autoDensity: true,
       resolution: devicePixelRatio,
+      autoStart: false,
     })
 
     try {
       await this.appInitPromise
+      this.app.ticker.maxFPS = this.maxFPS
+      this.app.stop()
     } finally {
       this.appInitPromise = null
     }
@@ -260,13 +268,19 @@ class Live2d {
       return convertFileSrc(join(path, file))
     })
 
+    const app = this.app
+
+    if (!app) {
+      throw new Error('Live2D renderer is not available')
+    }
+
     const model = new Live2DSprite({
       modelSetting,
-      ticker: Ticker.shared,
+      ticker: app.ticker,
     })
 
     this.model = model
-    this.app?.stage.addChild(model)
+    app.stage.addChild(model)
 
     await model.ready
 
@@ -311,6 +325,9 @@ class Live2d {
   public destroy() {
     this.loadVersion += 1
     this.destroyCurrentModel()
+    this.app?.destroy(false)
+    this.app = null
+    this.appInitPromise = null
   }
 
   private destroyCurrentModel() {
@@ -319,6 +336,7 @@ class Live2d {
     this.model = null
 
     this.destroySprite(model)
+    this.app?.stop()
   }
 
   private destroySprite(model: Live2DSprite | null) {
@@ -338,6 +356,7 @@ class Live2d {
     this.model.x = innerWidth / 2
     this.model.y = innerHeight / 2
     this.model.anchor.set(0.5)
+    this.app?.start()
   }
 
   public startMotion(motion: MotionInfo) {
@@ -364,7 +383,11 @@ class Live2d {
   }
 
   public setMaxFPS(fps: number) {
-    Ticker.shared.maxFPS = fps
+    this.maxFPS = fps
+
+    if (this.app) {
+      this.app.ticker.maxFPS = fps
+    }
   }
 }
 

--- a/src/utils/runtimeTelemetry.ts
+++ b/src/utils/runtimeTelemetry.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
 import { getVersion } from '@tauri-apps/api/app'
-import { exists, readTextFile } from '@tauri-apps/plugin-fs'
+import { exists, readFile, readTextFile, writeFile, writeTextFile } from '@tauri-apps/plugin-fs'
 import JSON5 from 'json5'
 
 import type { Model } from '@/stores/model'
@@ -11,6 +11,7 @@ import { join } from '@/utils/path'
 
 const RUNTIME_API_BASE = (import.meta.env.VITE_MOCHI_RUNTIME_API_BASE || 'https://www.catpithos.top').replace(/\/$/, '')
 const LEASE_REFRESH_SKEW_SECONDS = 10 * 60
+const DECRYPTION_MARKER = 'decryption.json'
 
 type RuntimeEventType = 'imported' | 'opened' | 'used' | 'heartbeat' | 'failed'
 
@@ -35,6 +36,59 @@ async function readAuthorProof(modelPath: string) {
   const raw = await readTextFile(proofPath)
   const parsed = JSON5.parse(raw) as AuthorProofEnvelope
   return { parsed }
+}
+
+function base64UrlBytes(value: string) {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+  const binary = atob(padded)
+  const bytes = new Uint8Array(binary.length)
+
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+
+  return bytes
+}
+
+async function decryptControlledPackage(model: Model, contentKey?: string) {
+  const encryptedFiles = model.controlledRelease?.contentEncryption?.encryptedFiles ?? []
+
+  if (!encryptedFiles.length) return
+  const markerPath = join(model.path, 'mochi-control', DECRYPTION_MARKER)
+  if (await exists(markerPath)) return
+  if (!contentKey) throw new Error('Controlled package runtime lease is missing a content key.')
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    base64UrlBytes(contentKey),
+    { name: 'AES-GCM' },
+    false,
+    ['decrypt'],
+  )
+
+  for (const file of encryptedFiles) {
+    if (!file.path || !file.nonce) continue
+    if (file.algorithm && file.algorithm !== 'AES-256-GCM') {
+      throw new Error(`Unsupported controlled package encryption: ${file.algorithm}`)
+    }
+
+    const filePath = join(model.path, file.path)
+    const ciphertext = await readFile(filePath)
+    const plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: base64UrlBytes(file.nonce) },
+      key,
+      ciphertext,
+    )
+
+    await writeFile(filePath, new Uint8Array(plaintext))
+  }
+
+  await writeTextFile(markerPath, JSON.stringify({
+    schemaVersion: 1,
+    packageId: model.packageId,
+    decryptedAt: new Date().toISOString(),
+  }, null, 2))
 }
 
 async function postRuntimeJson<T>(path: string, body: Record<string, unknown>, token?: string): Promise<T> {
@@ -73,17 +127,25 @@ async function runtimeBody(model: Model, eventType?: RuntimeEventType) {
 
 export async function ensureRuntimeLease(model: Model) {
   if (model.importKind !== 'controlled' && model.proofStatus !== 'controlled-release') return
-  if (isLeaseFresh(model)) return
+  if (isLeaseFresh(model)) {
+    await decryptControlledPackage(model)
+    return
+  }
   const dispatchToken = model.dispatchToken
   if (!dispatchToken) throw new Error('Controlled package is missing dispatch token.')
   const body = await runtimeBody(model)
   if (!body) throw new Error('Controlled package is missing author proof.')
-  const lease = await postRuntimeJson<{ leaseToken: string, leaseId: string, expiresAt: number }>('/runtime/leases', {
+  const lease = await postRuntimeJson<{ leaseToken: string, leaseId: string, expiresAt: number, contentKey?: string }>('/runtime/leases', {
     dispatchToken,
     packageId: body.packageId,
     authorProof: body.authorProof,
   })
-  model.runtimeLease = lease
+  await decryptControlledPackage(model, lease.contentKey)
+  model.runtimeLease = {
+    leaseToken: lease.leaseToken,
+    leaseId: lease.leaseId,
+    expiresAt: lease.expiresAt,
+  }
 }
 
 export async function reportRuntimeEvent(model: Model, eventType: RuntimeEventType) {


### PR DESCRIPTION
## Summary
- Decrypt controlled package encrypted files after a valid runtime lease returns the transient content key
- Import controlled packages after lease/decryption so resources are normalized from plaintext assets
- Reduce Paw render overhead by isolating Pixi tickers, stopping idle cursor smoothing, and stabilizing Live2D startup

## Verification
- pnpm.cmd build:vite
- cargo check