### PR TITLE
fix(window): resolve monitors with physical cursor coordinates

### DIFF
--- a/src/utils/monitor.test.ts
+++ b/src/utils/monitor.test.ts
@@ -1,0 +1,13 @@
+import type { PhysicalPosition } from '@tauri-apps/api/window'
+
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import { getMonitorPoint } from './monitor'
+
+test('uses global physical cursor coordinates for monitor lookup', () => {
+  const cursorPosition = { x: -1440, y: 900 } as PhysicalPosition
+
+  assert.deepEqual(getMonitorPoint(cursorPosition), { x: -1440, y: 900 })
+})

--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -4,8 +4,11 @@
 
 import type { Monitor, PhysicalPosition } from '@tauri-apps/api/window'
 
-import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { cursorPosition, monitorFromPoint } from '@tauri-apps/api/window'
+
+export function getMonitorPoint(cursorPoint: PhysicalPosition) {
+  return { x: cursorPoint.x, y: cursorPoint.y }
+}
 
 function createCursorMonitor() {
   let cachedMonitor: Monitor | null = null
@@ -26,11 +29,9 @@ function createCursorMonitor() {
       }
     }
 
-    const appWindow = getCurrentWebviewWindow()
-
-    const scaleFactor = await appWindow.scaleFactor()
-
-    const { x, y } = cursorPoint.toLogical(scaleFactor)
+    // Both APIs use global physical coordinates. Converting with the current
+    // window's scale factor selects the wrong monitor on mixed-DPI setups.
+    const { x, y } = getMonitorPoint(cursorPoint)
 
     cachedMonitor = await monitorFromPoint(x, y)
 


### PR DESCRIPTION
## Summary
- Use global physical cursor coordinates for monitor lookup.
- Prevent mixed-DPI windows from resolving the wrong monitor.
- Add a regression test for negative-coordinate displays.

## Issue
Related to #21.

## Validation
- Targeted Node tests passed.
- ESLint passed.
- Vite production build passed.