### PR TITLE
chore(release): remove contributors API token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,6 @@ jobs:
 
       - name: Generate contributors manifest
         run: pnpm generate:contributors
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build the app
         uses: tauri-apps/tauri-action@v0

--- a/scripts/generateContributors.ts
+++ b/scripts/generateContributors.ts
@@ -3,7 +3,6 @@
 
 import { writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
-import { env } from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 interface GitHubContributor {
@@ -17,13 +16,11 @@ const outputPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'publi
 
 async function getContributors() {
   const contributors: GitHubContributor[] = []
-  const token = env.GITHUB_TOKEN
 
   for (let page = 1; ; page += 1) {
     const response = await fetch(`https://api.github.com/repos/${repository}/contributors?per_page=100&page=${page}`, {
       headers: {
         Accept: 'application/vnd.github+json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
     })
 


### PR DESCRIPTION
## Summary
- Remove the GitHub token from the contributors generator and release workflow.
- Use the public Contributors API anonymously during release builds.

## Validation
- Anonymous contributor manifest generation passed.
- ESLint passed.