### PR TITLE
chore(release): prepare v1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "fs_extra",
  "gilrs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.1"
+version = "1.1.2"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary
- Bump Node, Tauri, and Cargo package metadata to 1.1.2.
- Prepare the v1.1.2 release tag after merge.

## Validation
- Vite production build passed.
- cargo check -p mochi-paw passed.
- Anonymous contributors manifest generation passed.