### PR TITLE
fix(release): preserve contributor manifest fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,4 +107,5 @@ jobs:
         if: matrix.portable && startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
+          draft: true
           files: target/${{ matrix.target }}/release/bundle/portable/*.zip

--- a/scripts/generateContributors.ts
+++ b/scripts/generateContributors.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 InfinityXCat
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
-import { writeFileSync } from 'node:fs'
+import { existsSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -52,6 +52,14 @@ function isGitHubContributor(value: unknown): value is GitHubContributor {
     && typeof contributor.html_url === 'string'
 }
 
-const contributors = await getContributors()
+try {
+  const contributors = await getContributors()
 
-writeFileSync(outputPath, `${JSON.stringify(contributors, null, 2)}\n`)
+  writeFileSync(outputPath, `${JSON.stringify(contributors, null, 2)}\n`)
+} catch (error) {
+  if (!existsSync(outputPath)) throw error
+
+  const message = error instanceof Error ? error.message : String(error)
+
+  console.warn(`Could not refresh GitHub contributors; keeping the bundled manifest: ${message}`)
+}


### PR DESCRIPTION
## Summary
- Keep the checked-in contributor manifest when the public GitHub Contributors API is temporarily unavailable.
- Create tagged releases as drafts so incomplete matrix builds cannot publish partial artifacts.

Fixes #43.

## Validation
- Anonymous contributors manifest generation.
- ESLint for the generator.
- Vite production build.
- Simulated Contributors API 503 fallback.
- git diff --check.