### PR TITLE
chore(release): prepare v1.1.3-demo.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.2"
+version = "1.1.3-demo.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.2",
+  "version": "1.1.3-demo.1",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.2"
+version = "1.1.3-demo.1"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary
- prepare the v1.1.3-demo.1 prerelease version across the JavaScript and Rust manifests

## Verification
- pnpm build:vite
- cargo check --manifest-path src-tauri\\Cargo.toml