### PR TITLE
fix(release): support prerelease builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           releaseName: MochiPaw ${{ github.ref_name }}
           releaseBody: ''
           releaseDraft: true
-          prerelease: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
           args: ${{ matrix.tauriArgs }}
 
       - name: Build portable Windows archive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.3-demo.1"
+version = "1.1.3-1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.3-demo.1",
+  "version": "1.1.3-1",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.3-demo.1"
+version = "1.1.3-1"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary
- replace the Windows-incompatible demo version with v1.1.3-1
- mark tags with prerelease identifiers as GitHub prereleases automatically

## Verification
- cargo check --manifest-path src-tauri\\Cargo.toml