### PR TITLE
fix(submodel): isolate instance window settings

### DIFF
--- a/src/composables/useAppMenu.ts
+++ b/src/composables/useAppMenu.ts
@@ -2,36 +2,66 @@
 // SPDX-FileCopyrightText: 2026 InfinityXCat
 // SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
 
+import type { Ref } from 'vue'
+
 import { CheckMenuItem, MenuItem, PredefinedMenuItem, Submenu } from '@tauri-apps/api/menu'
 import { exit, relaunch } from '@tauri-apps/plugin-process'
 import { range } from 'es-toolkit'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+
+import type { CatStore } from '@/stores/cat'
 
 import { WINDOW_LABEL } from '@/constants'
 import { showWindow } from '@/plugins/window'
 import { useCatStore } from '@/stores/cat'
 import { isMac } from '@/utils/platform'
 
-export function useAppMenu() {
+type AppMenuWindowSettings = Pick<CatStore['window'], 'passThrough' | 'scale' | 'opacity'>
+
+export interface AppMenuOptions {
+  windowSettings?: Readonly<Ref<AppMenuWindowSettings>>
+  visible?: Readonly<Ref<boolean>>
+  onWindowSettingsChange?: () => void
+  toggleVisibility?: () => void | Promise<void>
+}
+
+export function useAppMenu(options: AppMenuOptions = {}) {
   const catStore = useCatStore()
   const { t } = useI18n()
+  const windowSettings = options.windowSettings ?? computed(() => catStore.window)
+  const visible = options.visible ?? computed(() => catStore.window.visible)
+
+  const notifyWindowSettingsChange = () => {
+    options.onWindowSettingsChange?.()
+  }
+
+  const toggleVisibility = () => {
+    if (options.toggleVisibility) {
+      void options.toggleVisibility()
+      return
+    }
+
+    catStore.window.visible = !catStore.window.visible
+  }
 
   const getScaleMenuItems = async () => {
-    const options = range(50, 151, 25)
+    const scaleOptions = range(50, 151, 25)
 
-    const items = options.map((item) => {
+    const items = scaleOptions.map((item) => {
       return CheckMenuItem.new({
         text: `${item}%`,
-        checked: catStore.window.scale === item,
+        checked: windowSettings.value.scale === item,
         action: () => {
-          catStore.window.scale = item
+          windowSettings.value.scale = item
+          notifyWindowSettingsChange()
         },
       })
     })
 
-    if (!options.includes(catStore.window.scale)) {
+    if (!scaleOptions.includes(windowSettings.value.scale)) {
       items.unshift(CheckMenuItem.new({
-        text: `${catStore.window.scale}%`,
+        text: `${windowSettings.value.scale}%`,
         checked: true,
         enabled: false,
       }))
@@ -41,21 +71,22 @@ export function useAppMenu() {
   }
 
   const getOpacityMenuItems = async () => {
-    const options = range(25, 101, 25)
+    const opacityOptions = range(25, 101, 25)
 
-    const items = options.map((item) => {
+    const items = opacityOptions.map((item) => {
       return CheckMenuItem.new({
         text: `${item}%`,
-        checked: catStore.window.opacity === item,
+        checked: windowSettings.value.opacity === item,
         action: () => {
-          catStore.window.opacity = item
+          windowSettings.value.opacity = item
+          notifyWindowSettingsChange()
         },
       })
     })
 
-    if (!options.includes(catStore.window.opacity)) {
+    if (!opacityOptions.includes(windowSettings.value.opacity)) {
       items.unshift(CheckMenuItem.new({
-        text: `${catStore.window.opacity}%`,
+        text: `${windowSettings.value.opacity}%`,
         checked: true,
         enabled: false,
       }))
@@ -72,17 +103,16 @@ export function useAppMenu() {
         action: () => showWindow(WINDOW_LABEL.PREFERENCE),
       }),
       MenuItem.new({
-        text: catStore.window.visible ? t('composables.useAppMenu.labels.hideCat') : t('composables.useAppMenu.labels.showCat'),
-        action: () => {
-          catStore.window.visible = !catStore.window.visible
-        },
+        text: visible.value ? t('composables.useAppMenu.labels.hideCat') : t('composables.useAppMenu.labels.showCat'),
+        action: toggleVisibility,
       }),
       PredefinedMenuItem.new({ item: 'Separator' }),
       CheckMenuItem.new({
         text: t('composables.useAppMenu.labels.passThrough'),
-        checked: catStore.window.passThrough,
+        checked: windowSettings.value.passThrough,
         action: () => {
-          catStore.window.passThrough = !catStore.window.passThrough
+          windowSettings.value.passThrough = !windowSettings.value.passThrough
+          notifyWindowSettingsChange()
         },
       }),
       Submenu.new({

--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -41,11 +41,11 @@ export interface ModelRuntimeOptions {
   syncWindowScale?: boolean
 }
 
-export function useModel(options: ModelRuntimeOptions = {}) {
+export function useModel(runtimeOptions: ModelRuntimeOptions = {}) {
   const modelStore = useModelStore()
   const catStore = useCatStore()
-  const currentModel = options.currentModel ?? computed(() => modelStore.currentModel)
-  const mouseMirror = options.mouseMirror ?? computed(() => catStore.model.mouseMirror)
+  const currentModel = runtimeOptions.currentModel ?? computed(() => modelStore.currentModel)
+  const mouseMirror = runtimeOptions.mouseMirror ?? computed(() => catStore.model.mouseMirror)
   const modelSize = ref<ModelSize>()
   let typingExpressionTimer: ReturnType<typeof setTimeout> | undefined
   let nextTypingExpressionAt = 0
@@ -242,7 +242,7 @@ export function useModel(options: ModelRuntimeOptions = {}) {
     live2d.destroy()
   }
 
-  async function handleResize(options: { syncScale?: boolean } = {}) {
+  async function handleResize(resizeOptions: { syncScale?: boolean } = {}) {
     if (!modelSize.value) return
 
     const { width, height } = modelSize.value
@@ -261,7 +261,7 @@ export function useModel(options: ModelRuntimeOptions = {}) {
 
     live2d.resizeModel(modelSize.value)
 
-    if (options.syncScale === false || options.syncWindowScale === false) return
+    if (resizeOptions.syncScale === false || runtimeOptions.syncWindowScale === false) return
 
     const size = await appWindow.size()
 

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -60,6 +60,9 @@ const listenerSettings = computed(() => subModel.value?.listeners ?? {
   gamepad: true,
   typingBehavior: true,
 })
+const reportSubModelWindowChange = useDebounceFn((instance: SubModelInstance) => {
+  void emit(LISTEN_KEY.SUB_MODEL_WINDOW_CHANGED, structuredClone(toRaw(instance)))
+}, 150)
 const {
   modelSize,
   handleLoad,
@@ -79,7 +82,12 @@ const { startListening } = useDevice({
   listeners: listenerSettings,
   enableWindowHover: !isSubModel,
 })
-const { getBaseMenu, getExitMenu } = useAppMenu()
+const { getBaseMenu, getExitMenu } = useAppMenu({
+  windowSettings,
+  visible: computed(() => subModel.value?.visible ?? catStore.window.visible),
+  onWindowSettingsChange: reportCurrentSubModelWindowChange,
+  toggleVisibility: isSubModel ? toggleMenuVisibility : undefined,
+})
 const backgroundImagePath = ref<string>()
 const live2dCanvas = ref<HTMLCanvasElement | null>(null)
 const { stickActive } = useGamepad({
@@ -105,9 +113,28 @@ let currentModelLoadVersion = 0
 
 const SCALE_DRAG_SENSITIVITY = 0.12
 const SHORTCUT_RESIZE_INTERVAL = 33
-const reportSubModelWindowChange = useDebounceFn((instance: SubModelInstance) => {
-  void emit(LISTEN_KEY.SUB_MODEL_WINDOW_CHANGED, structuredClone(toRaw(instance)))
-}, 150)
+
+function reportCurrentSubModelWindowChange() {
+  const instance = subModel.value
+
+  if (instance) {
+    reportSubModelWindowChange(instance)
+  }
+}
+
+async function toggleMenuVisibility() {
+  const instance = subModel.value
+
+  if (!instance) return
+
+  instance.visible = !instance.visible
+  live2d.setRenderingEnabled(instance.visible)
+  await emit(LISTEN_KEY.SUB_MODEL_VISIBILITY_CHANGED, { id: instance.id, visible: instance.visible })
+
+  if (!instance.visible) {
+    await hideWindow()
+  }
+}
 
 function applyWindowScale(scale: number, modelSizeValue = modelSize.value) {
   if (!modelSizeValue) return
@@ -366,6 +393,8 @@ function handleMouseMove(event: MouseEvent) {
     pendingScaleDelta = 0
     scalingWithShortcut = true
     windowSettings.value.scale = round(nextScale)
+
+    reportCurrentSubModelWindowChange()
 
     if (scaleSyncTimer) {
       clearTimeout(scaleSyncTimer)

--- a/src/pages/preference/components/model/components/sub-model-manager/index.vue
+++ b/src/pages/preference/components/model/components/sub-model-manager/index.vue
@@ -5,7 +5,7 @@
 <script setup lang="ts">
 import { emitTo } from '@tauri-apps/api/event'
 import { Button, InputNumber, message, Modal, Popconfirm, Select, Switch } from 'antdv-next'
-import { computed, ref, toRaw, watch } from 'vue'
+import { computed, nextTick, ref, toRaw, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { Model, SubModelInstance } from '@/stores/model'
@@ -60,6 +60,8 @@ function getModelName(instance: SubModelInstance) {
 }
 
 async function notifyInstance(instance: SubModelInstance) {
+  await nextTick()
+
   await emitTo(
     getSubModelWindowLabel(instance.id),
     LISTEN_KEY.UPDATE_SUB_MODEL,


### PR DESCRIPTION
## Summary

- isolate submodel resize state from the main desktop pet
- make submodel context menus operate on their own instance settings
- send configuration updates after Vue commits new values

## Validation

- `pnpm exec eslint src/composables/useAppMenu.ts src/composables/useModel.ts src/pages/main/index.vue src/pages/preference/components/model/components/sub-model-manager/index.vue`
- `pnpm exec tsc --noEmit`
- `pnpm exec tsx --test src/utils/monitor.test.ts src/utils/windowPosition.test.ts`
- `pnpm run build:vite`