### PR TITLE
fix(submodel): improve window sync defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.4"
+version = "1.1.4-1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.4",
+  "version": "1.1.4-1",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.4"
+version = "1.1.4-1"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"

--- a/src-tauri/src/plugins/window/src/commands/windows.rs
+++ b/src-tauri/src/plugins/window/src/commands/windows.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 InfinityXCat
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 use tauri::{AppHandle, Runtime, WebviewWindow, command};
@@ -11,7 +12,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
     HWND_NOTOPMOST, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SetWindowPos,
 };
 
-static TOPMOST_RUNNING: OnceLock<Arc<AtomicBool>> = OnceLock::new();
+static TOPMOST_WINDOWS: OnceLock<Mutex<HashMap<isize, Arc<AtomicBool>>>> = OnceLock::new();
 
 #[command]
 pub async fn show_window<R: Runtime>(_app_handle: AppHandle<R>, window: WebviewWindow<R>) {
@@ -31,25 +32,29 @@ pub async fn set_always_on_top<R: Runtime>(
     window: WebviewWindow<R>,
     always_on_top: bool,
 ) {
-    let running = TOPMOST_RUNNING.get_or_init(|| Arc::new(AtomicBool::new(false)));
-
     let Ok(hwnd) = window.hwnd() else { return };
     let raw_hwnd = hwnd.0 as isize;
+    let windows = TOPMOST_WINDOWS.get_or_init(|| Mutex::new(HashMap::new()));
 
     if always_on_top {
-        let Ok(_) = running.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        else {
+        let Ok(mut windows) = windows.lock() else {
             return;
         };
 
-        let running = Arc::clone(running);
+        if windows.contains_key(&raw_hwnd) {
+            return;
+        }
+
+        let running = Arc::new(AtomicBool::new(true));
+
+        windows.insert(raw_hwnd, Arc::clone(&running));
 
         thread::spawn(move || {
             let hwnd = HWND(raw_hwnd as *mut _);
 
             while running.load(Ordering::SeqCst) {
-                unsafe {
-                    let _ = SetWindowPos(
+                let result = unsafe {
+                    SetWindowPos(
                         hwnd,
                         Some(HWND_TOPMOST),
                         0,
@@ -57,13 +62,34 @@ pub async fn set_always_on_top<R: Runtime>(
                         0,
                         0,
                         SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
-                    );
+                    )
+                };
+
+                if result.is_err() {
+                    break;
                 }
+
                 thread::sleep(Duration::from_millis(16));
+            }
+
+            if let Some(windows) = TOPMOST_WINDOWS.get()
+                && let Ok(mut windows) = windows.lock()
+            {
+                let should_remove = windows
+                    .get(&raw_hwnd)
+                    .is_some_and(|current| Arc::ptr_eq(current, &running));
+
+                if should_remove {
+                    windows.remove(&raw_hwnd);
+                }
             }
         });
     } else {
-        running.store(false, Ordering::SeqCst);
+        if let Ok(mut windows) = windows.lock() {
+            if let Some(running) = windows.remove(&raw_hwnd) {
+                running.store(false, Ordering::SeqCst);
+            }
+        }
 
         let hwnd = HWND(raw_hwnd as *mut _);
 

--- a/src/pages/preference/components/model/components/sub-model-manager/index.vue
+++ b/src/pages/preference/components/model/components/sub-model-manager/index.vue
@@ -3,9 +3,9 @@
  -->
 
 <script setup lang="ts">
-import { emitTo } from '@tauri-apps/api/event'
+import { useDebounceFn } from '@vueuse/core'
 import { Button, Input, InputNumber, message, Modal, Popconfirm, Select, Switch } from 'antdv-next'
-import { computed, nextTick, reactive, ref, toRaw, watch } from 'vue'
+import { computed, nextTick, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { SubModelInstance } from '@/stores/model'
@@ -14,11 +14,10 @@ import { useTauriListen } from '@/composables/useTauriListen'
 import { LISTEN_KEY } from '@/constants'
 import { getModelDisplayName, getSubModelDisplayName, useModelStore } from '@/stores/model'
 import {
-  applySubModelWindowPosition,
   destroySubModelWindow,
-  getSubModelWindowLabel,
   hideSubModelWindow,
   openSubModelWindow,
+  syncSubModelWindow,
 } from '@/utils/subModelWindow'
 
 const { standalone = false } = defineProps<{
@@ -56,6 +55,31 @@ useTauriListen<{ id: string, visible: boolean }>(LISTEN_KEY.SUB_MODEL_VISIBILITY
   }
 })
 
+const syncVisibleSubModels = useDebounceFn(() => {
+  modelStore.subModels
+    .filter(instance => instance.visible)
+    .forEach((instance) => {
+      void syncSubModelWindow(instance)
+    })
+}, 16)
+
+watch(() => modelStore.subModels.map(instance => ({
+  id: instance.id,
+  modelId: instance.modelId,
+  visible: instance.visible,
+  listeners: { ...instance.listeners },
+  window: {
+    scale: instance.window.scale,
+    opacity: instance.window.opacity,
+    radius: instance.window.radius,
+    passThrough: instance.window.passThrough,
+    alwaysOnTop: instance.window.alwaysOnTop,
+  },
+  appearance: { ...instance.appearance },
+})), () => {
+  syncVisibleSubModels()
+}, { deep: true })
+
 function getInstanceModel(instance: SubModelInstance) {
   return models.value.find(item => item.id === instance.modelId)
 }
@@ -85,11 +109,7 @@ function toggleExpanded(instanceId: string) {
 async function notifyInstance(instance: SubModelInstance) {
   await nextTick()
 
-  await emitTo(
-    getSubModelWindowLabel(instance.id),
-    LISTEN_KEY.UPDATE_SUB_MODEL,
-    structuredClone(toRaw(instance)),
-  ).catch(() => undefined)
+  await syncSubModelWindow(instance)
 }
 
 function normalizePositionValue(value: number | string | null | undefined) {
@@ -110,7 +130,6 @@ async function updateWindowPosition(
   instance.window[axis] = normalizePositionValue(value)
 
   await notifyInstance(instance)
-  await applySubModelWindowPosition(instance).catch(() => undefined)
 }
 
 async function saveInstanceText(instance: SubModelInstance, field: 'customName' | 'note') {

--- a/src/stores/cat.ts
+++ b/src/stores/cat.ts
@@ -65,7 +65,7 @@ export const useCatStore = defineStore('cat', () => {
     typingExpressionMaxDelay: 30,
     typingBehaviorGroup: 'default',
     autoReleaseDelay: 3,
-    maxFPS: 30,
+    maxFPS: 60,
     ignoreMouse: false,
   })
 

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -230,10 +230,10 @@ export const useModelStore = defineStore('model', () => {
       showOnLaunch: true,
       createdAt: Date.now(),
       listeners: {
-        keyboard: false,
-        mouse: false,
-        gamepad: false,
-        typingBehavior: false,
+        keyboard: true,
+        mouse: true,
+        gamepad: true,
+        typingBehavior: true,
       },
       window: {
         scale: 100,
@@ -245,7 +245,7 @@ export const useModelStore = defineStore('model', () => {
       appearance: {
         mirror: false,
         mouseMirror: false,
-        maxFPS: 15,
+        maxFPS: 60,
       },
     }
 

--- a/src/utils/subModelWindow.ts
+++ b/src/utils/subModelWindow.ts
@@ -4,6 +4,7 @@
 import { PhysicalPosition } from '@tauri-apps/api/dpi'
 import { emitTo } from '@tauri-apps/api/event'
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
+import { toRaw } from 'vue'
 
 import type { SubModelInstance } from '@/stores/model'
 
@@ -21,7 +22,7 @@ export async function openSubModelWindow(instance: SubModelInstance) {
   const existingWindow = await WebviewWindow.getByLabel(label)
 
   if (existingWindow) {
-    await applySubModelWindowPosition(instance, existingWindow)
+    await syncSubModelWindow(instance, existingWindow)
     await existingWindow.show()
     await emitTo(label, LISTEN_KEY.SET_SUB_MODEL_RENDERING, true)
     await existingWindow.setFocus()
@@ -45,6 +46,7 @@ export async function openSubModelWindow(instance: SubModelInstance) {
   })
 
   await waitForWindowCreation(window)
+  await syncSubModelWindow(instance, window)
   await window.show()
 
   return window
@@ -72,6 +74,27 @@ export async function applySubModelWindowPosition(instance: SubModelInstance, ex
   const window = existingWindow ?? await WebviewWindow.getByLabel(getSubModelWindowLabel(instance.id))
 
   await window?.setPosition(new PhysicalPosition(x, y))
+}
+
+export async function applySubModelWindowSettings(instance: SubModelInstance, existingWindow?: WebviewWindow | null) {
+  const window = existingWindow ?? await WebviewWindow.getByLabel(getSubModelWindowLabel(instance.id))
+
+  if (!window) return
+
+  await Promise.all([
+    applySubModelWindowPosition(instance, window).catch(() => undefined),
+    window.setAlwaysOnTop(instance.window.alwaysOnTop).catch(() => undefined),
+    window.setIgnoreCursorEvents(instance.window.passThrough).catch(() => undefined),
+  ])
+}
+
+export async function syncSubModelWindow(instance: SubModelInstance, existingWindow?: WebviewWindow | null) {
+  const label = getSubModelWindowLabel(instance.id)
+
+  await Promise.all([
+    applySubModelWindowSettings(instance, existingWindow),
+    emitTo(label, LISTEN_KEY.UPDATE_SUB_MODEL, structuredClone(toRaw(instance))).catch(() => undefined),
+  ])
 }
 
 async function waitForWindowCreation(window: WebviewWindow) {


### PR DESCRIPTION
## What's New
- Default the main desktop pet renderer to 60 FPS.
- Default newly created sub desktop pets to 60 FPS.
- Enable show-on-launch, keyboard, mouse, gamepad, and typing behavior by default for newly created sub desktop pets.

## Fixes
- Keep always-on-top state independently for each Windows pet window instead of sharing one global topmost loop.
- Apply sub desktop pet window settings directly while also notifying the sub window, making always-on-top, pass-through, and appearance/listener changes more responsive.

## Verification
- pnpm exec eslint src/stores/cat.ts src/stores/model.ts src/utils/subModelWindow.ts src/pages/preference/components/model/components/sub-model-manager/index.vue package.json
- pnpm build:vite
- cargo check -p mochi-paw
- rustfmt --edition 2024 --check src-tauri/src/plugins/window/src/commands/windows.rs

Note: cargo fmt --all --check still reports pre-existing formatting diffs in unrelated Rust files.