### PR TITLE
feat(submodel): optimize multi-instance runtime

### DIFF
--- a/src-tauri/src/core/device.rs
+++ b/src-tauri/src/core/device.rs
@@ -48,7 +48,7 @@ pub async fn start_device_listening<R: Runtime>(app_handle: AppHandle<R>) -> Res
         .name("device-event-emitter".into())
         .spawn(move || {
             while let Ok(device_event) = event_receiver.recv() {
-                let _ = app_handle.emit("device-changed", device_event);
+                let _ = app_handle.emit_to("main", "device-changed", device_event);
             }
         })
         .map_err(|err| {

--- a/src-tauri/src/core/gamepad.rs
+++ b/src-tauri/src/core/gamepad.rs
@@ -89,7 +89,7 @@ fn listen_for_gamepad_events<R: Runtime>(app_handle: AppHandle<R>, mut gilrs: Gi
                 _ => continue,
             };
 
-            let _ = app_handle.emit("gamepad-changed", gamepad_event);
+            let _ = app_handle.emit_to("main", "gamepad-changed", gamepad_event);
         }
 
         if !received_event {

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,6 +26,7 @@ import { useCatStore } from './stores/cat'
 import { useGeneralStore } from './stores/general'
 import { useModelStore } from './stores/model'
 import { useShortcutStore } from './stores/shortcut.ts'
+import { getSubModelRuntimeCapacity } from './utils/subModelRuntime'
 import { openSubModelWindow } from './utils/subModelWindow'
 
 const appStore = useAppStore()
@@ -34,7 +35,8 @@ const catStore = useCatStore()
 const generalStore = useGeneralStore()
 const shortcutStore = useShortcutStore()
 const appWindow = getCurrentWebviewWindow()
-const { isRestored, restoreState } = useWindowState()
+const isSubModelWindow = appWindow.label.startsWith('sub-model-')
+const { isRestored, restoreState } = useWindowState({ enabled: !isSubModelWindow })
 const { darkAlgorithm, defaultAlgorithm } = theme
 const { locale } = useI18n()
 
@@ -50,23 +52,48 @@ function formatError(reason: unknown) {
 }
 
 onMounted(async () => {
+  if (isSubModelWindow) {
+    await modelStore.$tauri.start()
+    await modelStore.init()
+    await catStore.$tauri.start()
+    catStore.init()
+    await generalStore.$tauri.start()
+    await generalStore.init()
+    await restoreState()
+    return
+  }
+
   await appStore.$tauri.start()
   await appStore.init()
   await modelStore.$tauri.start()
   await modelStore.init()
-
-  if (appWindow.label === 'main') {
-    await Promise.all(modelStore.subModels
-      .filter(instance => instance.visible && instance.showOnLaunch)
-      .map(openSubModelWindow))
-  }
-
   await catStore.$tauri.start()
   catStore.init()
   await generalStore.$tauri.start()
   await generalStore.init()
   await shortcutStore.$tauri.start()
   await restoreState()
+
+  for (const instance of modelStore.subModels.filter(item => item.visible && item.showOnLaunch)) {
+    const capacity = await getSubModelRuntimeCapacity(
+      modelStore.subModels,
+      modelStore.models,
+      modelStore.currentModel,
+    )
+
+    if (!capacity.allowed) {
+      instance.visible = false
+      error(`[sub-model] skipped ${instance.id}: runtime resource budget exceeded`)
+      continue
+    }
+
+    try {
+      await openSubModelWindow(instance)
+    } catch (reason) {
+      instance.visible = false
+      error(`[sub-model] failed to restore ${instance.id}: ${formatError(reason)}`)
+    }
+  }
 })
 
 watch(() => generalStore.appearance.language, (value) => {

--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -11,6 +11,7 @@ import { isNil } from 'es-toolkit'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import type { ModelRuntimeOptions } from '@/composables/useModel'
+import type { DeviceInputEvent } from '@/utils/subModelRuntime'
 
 import { useAppStore } from '@/stores/app'
 import { useCatStore } from '@/stores/cat'
@@ -23,15 +24,7 @@ import { INVOKE_KEY, LISTEN_KEY, WINDOW_LABEL } from '../constants'
 import { useModel } from './useModel'
 import { useTauriListen } from './useTauriListen'
 
-interface MouseButtonEvent {
-  kind: 'MousePress' | 'MouseRelease'
-  value: string
-}
-
-export interface CursorPoint {
-  x: number
-  y: number
-}
+type CursorPoint = Extract<DeviceInputEvent, { kind: 'MouseMove' }>['value']
 
 export interface DeviceListenerOptions {
   keyboard: boolean
@@ -42,19 +35,9 @@ export interface DeviceListenerOptions {
 export interface UseDeviceOptions extends ModelRuntimeOptions {
   listeners?: Readonly<Ref<DeviceListenerOptions>>
   enableWindowHover?: boolean
+  listen?: boolean
+  onInputEvent?: (event: DeviceInputEvent) => void
 }
-
-interface MouseMoveEvent {
-  kind: 'MouseMove'
-  value: CursorPoint
-}
-
-interface KeyboardEvent {
-  kind: 'KeyboardPress' | 'KeyboardRelease'
-  value: string
-}
-
-type DeviceEvent = MouseButtonEvent | MouseMoveEvent | KeyboardEvent
 
 const DAMPING_DECAY = 0.75
 const RUNTIME_USED_REPORT_INTERVAL = 5 * 60 * 1000
@@ -300,8 +283,8 @@ export function useDevice(options: UseDeviceOptions = {}) {
     handleRelease(key)
   }
 
-  useTauriListen<DeviceEvent>(LISTEN_KEY.DEVICE_CHANGED, ({ payload }) => {
-    const { kind, value } = payload
+  const handleInputEvent = (event: DeviceInputEvent) => {
+    const { kind, value } = event
 
     if (kind === 'KeyboardPress' || kind === 'KeyboardRelease') {
       if (!listeners.value.keyboard) return
@@ -359,9 +342,17 @@ export function useDevice(options: UseDeviceOptions = {}) {
         latestCursorPoint.value = value
         return scheduleCursorSmoothing()
     }
-  })
+  }
+
+  if (options.listen !== false) {
+    useTauriListen<DeviceInputEvent>(LISTEN_KEY.DEVICE_CHANGED, ({ payload }) => {
+      handleInputEvent(payload)
+      options.onInputEvent?.(payload)
+    })
+  }
 
   return {
+    handleInputEvent,
     startListening,
   }
 }

--- a/src/composables/useGamepad.ts
+++ b/src/composables/useGamepad.ts
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2026 InfinityXCat
 // SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
 
-import type { LiteralUnion } from 'type-fest'
 import type { Ref } from 'vue'
 
 import { invoke } from '@tauri-apps/api/core'
@@ -11,6 +10,7 @@ import { computed, onUnmounted, reactive, watch } from 'vue'
 
 import type { ModelRuntimeOptions } from '@/composables/useModel'
 import type { Model } from '@/stores/model'
+import type { GamepadInputEvent } from '@/utils/subModelRuntime'
 
 import { INVOKE_KEY, LISTEN_KEY } from '@/constants'
 import { useModelStore } from '@/stores/model'
@@ -18,14 +18,6 @@ import live2d from '@/utils/live2d'
 
 import { useModel } from './useModel'
 import { useTauriListen } from './useTauriListen'
-
-type GamepadEventName = LiteralUnion<'LeftStickX' | 'LeftStickY' | 'RightStickX' | 'RightStickY' | 'LeftThumb' | 'RightThumb', string>
-
-interface GamepadEvent {
-  kind: 'ButtonChanged' | 'AxisChanged'
-  name: GamepadEventName
-  value: number
-}
 
 interface StickState {
   x: number
@@ -45,12 +37,18 @@ const appWindow = getCurrentWebviewWindow()
 export interface UseGamepadOptions extends ModelRuntimeOptions {
   enabled?: Readonly<Ref<boolean>>
   currentModel?: Readonly<Ref<Model | undefined>>
+  listen?: boolean
+  nativeDemand?: Readonly<Ref<boolean>>
+  onInputEvent?: (event: GamepadInputEvent) => void
 }
 
 export function useGamepad(options: UseGamepadOptions = {}) {
   const modelStore = useModelStore()
   const enabled = options.enabled ?? computed(() => true)
   const currentModel = options.currentModel ?? computed(() => modelStore.currentModel)
+  const nativeDemand = computed(() => {
+    return options.nativeDemand?.value || (enabled.value && currentModel.value?.mode === 'gamepad')
+  })
   const { handlePress, handleRelease, handleAxisChange } = useModel(options)
   const sticks = reactive<Sticks>({
     left: { ...INITIAL_STICK_STATE },
@@ -63,13 +61,15 @@ export function useGamepad(options: UseGamepadOptions = {}) {
   }))
 
   const syncGamepadListener = (isEnabled: boolean) => {
+    if (options.listen === false) return Promise.resolve()
+
     return invoke(INVOKE_KEY.SET_GAMEPAD_LISTENER_ENABLED, {
       windowLabel: appWindow.label,
-      enabled: isEnabled && currentModel.value?.mode === 'gamepad',
+      enabled: isEnabled,
     })
   }
 
-  watch([enabled, currentModel], ([isEnabled]) => {
+  watch(nativeDemand, (isEnabled) => {
     void syncGamepadListener(isEnabled)
   }, { immediate: true })
 
@@ -109,7 +109,7 @@ export function useGamepad(options: UseGamepadOptions = {}) {
     live2d.setParameterValue('CatParamStickShowRightHand', moved || pressed)
   }, { deep: true })
 
-  useTauriListen<GamepadEvent>(LISTEN_KEY.GAMEPAD_CHANGED, ({ payload }) => {
+  const handleInputEvent = (payload: GamepadInputEvent) => {
     if (!enabled.value) return
 
     const { name, value } = payload
@@ -142,9 +142,17 @@ export function useGamepad(options: UseGamepadOptions = {}) {
       default:
         return value > 0 ? handlePress(name) : handleRelease(name)
     }
-  })
+  }
+
+  if (options.listen !== false) {
+    useTauriListen<GamepadInputEvent>(LISTEN_KEY.GAMEPAD_CHANGED, ({ payload }) => {
+      handleInputEvent(payload)
+      options.onInputEvent?.(payload)
+    })
+  }
 
   return {
+    handleInputEvent,
     stickActive,
   }
 }

--- a/src/composables/useTauriListen.ts
+++ b/src/composables/useTauriListen.ts
@@ -8,12 +8,24 @@ import { onMounted, onUnmounted, ref } from 'vue'
 
 export function useTauriListen<T>(...args: Parameters<typeof listen<T>>) {
   const unlisten = ref(noop)
+  let resolveReady!: () => void
+  const ready = new Promise<void>((resolve) => {
+    resolveReady = resolve
+  })
 
   onMounted(async () => {
-    unlisten.value = await listen<T>(...args)
+    try {
+      unlisten.value = await listen<T>(...args)
+    } finally {
+      resolveReady()
+    }
   })
 
   onUnmounted(() => {
     unlisten.value()
   })
+
+  return {
+    ready,
+  }
 }

--- a/src/composables/useWindowState.ts
+++ b/src/composables/useWindowState.ts
@@ -45,11 +45,14 @@ export async function returnMainWindowToScreen() {
   await mainWindow.setPosition(new PhysicalPosition(nextPosition.x, nextPosition.y))
 }
 
-export function useWindowState() {
+export function useWindowState(options: { enabled?: boolean } = {}) {
   const appStore = useAppStore()
   const isRestored = ref(false)
+  const enabled = options.enabled ?? true
 
   onMounted(() => {
+    if (!enabled) return
+
     appWindow.onMoved(onChange)
 
     appWindow.onResized(onChange)
@@ -66,6 +69,11 @@ export function useWindowState() {
   }
 
   const restoreState = async () => {
+    if (!enabled) {
+      isRestored.value = true
+      return
+    }
+
     const { x, y, width, height } = appStore.windowState[label] ?? {}
 
     if (isNumber(x) && isNumber(y)) {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -18,6 +18,8 @@ export const LISTEN_KEY = {
   SUB_MODEL_VISIBILITY_CHANGED: 'sub-model-visibility-changed',
   SUB_MODEL_WINDOW_CHANGED: 'sub-model-window-changed',
   UPDATE_SUB_MODEL: 'update-sub-model',
+  SUB_MODEL_RUNTIME_READY: 'sub-model-runtime-ready',
+  SUB_MODEL_INPUT_FRAME: 'sub-model-input-frame',
 }
 
 export const INVOKE_KEY = {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -173,7 +173,8 @@
         "hints": {
           "createTitle": "Create another sub model?",
           "createWarning": "More visible models require additional CPU, GPU, and memory.",
-          "delete": "This removes the sub model and its window settings."
+          "delete": "This removes the sub model and its window settings.",
+          "resourceLimit": "This pet cannot be started because the active model memory budget would be exceeded. Hide or remove another sub model, or choose a lighter model."
         },
         "sections": {
           "basic": "Basic",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -173,7 +173,8 @@
         "hints": {
           "createTitle": "Criar outro submodelo?",
           "createWarning": "Mais modelos visíveis exigem CPU, GPU e memória adicionais.",
-          "delete": "Isso remove o submodelo e suas configurações de janela."
+          "delete": "Isso remove o submodelo e suas configurações de janela.",
+          "resourceLimit": "Este pet não pode ser iniciado porque excederia o orçamento de memória dos modelos ativos. Oculte ou remova outro submodelo, ou escolha um modelo mais leve."
         },
         "sections": {
           "basic": "Básico",

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -173,7 +173,8 @@
         "hints": {
           "createTitle": "Tạo thêm mô hình phụ?",
           "createWarning": "Nhiều mô hình hiển thị hơn cần thêm CPU, GPU và bộ nhớ.",
-          "delete": "Thao tác này xóa mô hình phụ và cài đặt cửa sổ của nó."
+          "delete": "Thao tác này xóa mô hình phụ và cài đặt cửa sổ của nó.",
+          "resourceLimit": "Không thể khởi động pet này vì sẽ vượt quá ngân sách bộ nhớ của các mô hình đang hoạt động. Hãy ẩn hoặc xóa mô hình phụ khác, hoặc chọn mô hình nhẹ hơn."
         },
         "sections": {
           "basic": "Cơ bản",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -173,7 +173,8 @@
         "hints": {
           "createTitle": "创建更多子模型？",
           "createWarning": "更多可见模型会占用额外的 CPU、GPU 和内存。",
-          "delete": "这将删除子模型及其窗口设置。"
+          "delete": "这将删除子模型及其窗口设置。",
+          "resourceLimit": "无法启动此猫咪，因为活动模型将超过内存预算。请隐藏或删除其他子模型，或选择更轻量的模型。"
         },
         "sections": {
           "basic": "基础",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -173,7 +173,8 @@
         "hints": {
           "createTitle": "要建立更多子模型嗎？",
           "createWarning": "更多可見模型會使用額外的 CPU、GPU 與記憶體。",
-          "delete": "這會刪除子模型及其視窗設定。"
+          "delete": "這會刪除子模型及其視窗設定。",
+          "resourceLimit": "無法啟動此貓咪，因為活動模型將超過記憶體預算。請隱藏或刪除其他子模型，或選擇更輕量的模型。"
         },
         "sections": {
           "basic": "基礎",

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -16,6 +16,7 @@ import { computed, onMounted, onUnmounted, ref, toRaw, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
 import type { ModelMotionInfo, SubModelInstance } from '@/stores/model'
+import type { SubModelInputFrame } from '@/utils/subModelRuntime'
 
 import { useAppMenu } from '@/composables/useAppMenu'
 import { useDevice } from '@/composables/useDevice'
@@ -33,6 +34,7 @@ import { join } from '@/utils/path'
 import { isWindows } from '@/utils/platform'
 import { ensureRuntimeLease, reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
 import { clearObject } from '@/utils/shared'
+import { SubModelInputCoordinator } from '@/utils/subModelRuntime'
 
 const appWindow = getCurrentWebviewWindow()
 const route = useRoute()
@@ -41,6 +43,9 @@ const isSubModel = Boolean(subModelId)
 const modelStore = useModelStore()
 const catStore = useCatStore()
 const generalStore = useGeneralStore()
+const inputCoordinator = isSubModel
+  ? undefined
+  : new SubModelInputCoordinator(() => modelStore.subModels.filter(instance => instance.visible))
 const syncedSubModel = ref<SubModelInstance>()
 const subModel = computed(() => {
   if (!subModelId) return undefined
@@ -60,6 +65,18 @@ const listenerSettings = computed(() => subModel.value?.listeners ?? {
   gamepad: true,
   typingBehavior: true,
 })
+const gamepadEnabled = computed(() => {
+  return isSubModel ? listenerSettings.value.gamepad : activeModel.value?.mode === 'gamepad'
+})
+const gamepadNativeDemand = computed(() => {
+  if (activeModel.value?.mode === 'gamepad') return true
+
+  return modelStore.subModels.some((instance) => {
+    const model = modelStore.models.find(item => item.id === instance.modelId)
+
+    return instance.visible && instance.listeners.gamepad && model?.mode === 'gamepad'
+  })
+})
 const reportSubModelWindowChange = useDebounceFn((instance: SubModelInstance) => {
   void emit(LISTEN_KEY.SUB_MODEL_WINDOW_CHANGED, structuredClone(toRaw(instance)))
 }, 150)
@@ -76,11 +93,13 @@ const {
   mouseMirror: computed(() => appearanceSettings.value.mouseMirror),
   syncWindowScale: !isSubModel,
 })
-const { startListening } = useDevice({
+const { startListening, handleInputEvent: handleDeviceInputEvent } = useDevice({
   currentModel: activeModel,
   mouseMirror: computed(() => appearanceSettings.value.mouseMirror),
   listeners: listenerSettings,
   enableWindowHover: !isSubModel,
+  listen: !isSubModel,
+  onInputEvent: event => inputCoordinator?.enqueueDevice(event),
 })
 const { getBaseMenu, getExitMenu } = useAppMenu({
   windowSettings,
@@ -90,10 +109,13 @@ const { getBaseMenu, getExitMenu } = useAppMenu({
 })
 const backgroundImagePath = ref<string>()
 const live2dCanvas = ref<HTMLCanvasElement | null>(null)
-const { stickActive } = useGamepad({
+const { stickActive, handleInputEvent: handleGamepadInputEvent } = useGamepad({
   currentModel: activeModel,
   mouseMirror: computed(() => appearanceSettings.value.mouseMirror),
-  enabled: computed(() => listenerSettings.value.gamepad),
+  enabled: gamepadEnabled,
+  listen: !isSubModel,
+  nativeDemand: isSubModel ? undefined : gamepadNativeDemand,
+  onInputEvent: event => inputCoordinator?.enqueueGamepad(event),
 })
 const pressedKeyLayers = computed(() => {
   return Object.entries(modelStore.pressedKeys).flatMap(([key, layers]) => {
@@ -132,7 +154,7 @@ async function toggleMenuVisibility() {
   await emit(LISTEN_KEY.SUB_MODEL_VISIBILITY_CHANGED, { id: instance.id, visible: instance.visible })
 
   if (!instance.visible) {
-    await hideWindow()
+    await appWindow.destroy()
   }
 }
 
@@ -150,7 +172,7 @@ function applyWindowScale(scale: number, modelSizeValue = modelSize.value) {
 }
 
 onMounted(() => {
-  startListening()
+  if (!isSubModel) startListening()
 
   if (!isSubModel) return
 
@@ -176,6 +198,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  inputCoordinator?.dispose()
   currentModelLoadVersion += 1
   handleDestroy()
 })
@@ -331,10 +354,29 @@ useTauriListen<boolean>(LISTEN_KEY.SET_SUB_MODEL_RENDERING, ({ payload }) => {
   live2d.setRenderingEnabled(payload)
 })
 
-useTauriListen<SubModelInstance>(LISTEN_KEY.UPDATE_SUB_MODEL, ({ payload }) => {
+const subModelConfigListener = useTauriListen<SubModelInstance>(LISTEN_KEY.UPDATE_SUB_MODEL, ({ payload }) => {
   if (!isSubModel || payload.id !== subModelId) return
 
   syncedSubModel.value = payload
+})
+
+const subModelInputListener = useTauriListen<SubModelInputFrame>(LISTEN_KEY.SUB_MODEL_INPUT_FRAME, ({ payload }) => {
+  if (!isSubModel) return
+
+  for (const event of payload.deviceEvents) {
+    handleDeviceInputEvent(event)
+  }
+
+  for (const event of payload.gamepadEvents) {
+    handleGamepadInputEvent(event)
+  }
+})
+
+onMounted(async () => {
+  if (!isSubModel || !subModelId) return
+
+  await Promise.all([subModelConfigListener.ready, subModelInputListener.ready])
+  await emit(LISTEN_KEY.SUB_MODEL_RUNTIME_READY, { id: subModelId })
 })
 
 function handleMouseDown(event: MouseEvent) {

--- a/src/pages/preference/components/model/components/sub-model-manager/index.vue
+++ b/src/pages/preference/components/model/components/sub-model-manager/index.vue
@@ -13,6 +13,7 @@ import type { SubModelInstance } from '@/stores/model'
 import { useTauriListen } from '@/composables/useTauriListen'
 import { LISTEN_KEY } from '@/constants'
 import { getModelDisplayName, getSubModelDisplayName, useModelStore } from '@/stores/model'
+import { getSubModelRuntimeCapacity } from '@/utils/subModelRuntime'
 import {
   destroySubModelWindow,
   hideSubModelWindow,
@@ -137,10 +138,28 @@ async function saveInstanceText(instance: SubModelInstance, field: 'customName' 
   await notifyInstance(instance)
 }
 
+async function hasRuntimeCapacity() {
+  const capacity = await getSubModelRuntimeCapacity(
+    modelStore.subModels,
+    modelStore.models,
+    modelStore.currentModel,
+  )
+
+  if (capacity.allowed) return true
+
+  message.error(t('pages.preference.subModel.hints.resourceLimit'))
+  return false
+}
+
 async function createInstance() {
   if (!selectedModelId.value) return
 
   const instance = modelStore.createSubModel(selectedModelId.value)
+
+  if (!await hasRuntimeCapacity()) {
+    modelStore.removeSubModel(instance.id)
+    return
+  }
 
   try {
     await openSubModelWindow(instance)
@@ -165,6 +184,11 @@ function handleCreate() {
 
 async function setVisible(instance: SubModelInstance, visible: boolean) {
   instance.visible = visible
+
+  if (visible && !await hasRuntimeCapacity()) {
+    instance.visible = false
+    return
+  }
 
   try {
     if (visible) {

--- a/src/utils/subModelRuntime.ts
+++ b/src/utils/subModelRuntime.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import { emitTo } from '@tauri-apps/api/event'
+
+import type { Model, SubModelInstance } from '@/stores/model'
+
+import { LISTEN_KEY } from '@/constants'
+
+import { getModelResourceMetric } from './modelResourceMetrics'
+import { getSubModelWindowLabel } from './subModelWindow'
+
+export interface CursorPoint {
+  x: number
+  y: number
+}
+
+export type DeviceInputEvent
+  = | { kind: 'MousePress' | 'MouseRelease' | 'KeyboardPress' | 'KeyboardRelease', value: string }
+    | { kind: 'MouseMove', value: CursorPoint }
+
+export interface GamepadInputEvent {
+  kind: 'ButtonChanged' | 'AxisChanged'
+  name: string
+  value: number
+}
+
+export interface SubModelInputFrame {
+  sequence: number
+  deviceEvents: DeviceInputEvent[]
+  gamepadEvents: GamepadInputEvent[]
+}
+
+export interface SubModelRuntimeCapacity {
+  allowed: boolean
+  activeCount: number
+  maxActiveCount: number
+  reservedBytes: number
+  budgetBytes: number
+}
+
+const MEBIBYTE = 1024 * 1024
+const DEFAULT_RESOURCE_BUDGET_BYTES = 2 * 1024 * MEBIBYTE
+const RENDERER_RESERVATION_BYTES = 128 * MEBIBYTE
+const MODEL_MEMORY_MULTIPLIER = 1.5
+
+export const MAX_VISIBLE_SUB_MODELS = 7
+
+function getReservedModelBytes(estimatedMemoryBytes: number) {
+  return RENDERER_RESERVATION_BYTES + Math.ceil(estimatedMemoryBytes * MODEL_MEMORY_MULTIPLIER)
+}
+
+export async function getSubModelRuntimeCapacity(
+  instances: SubModelInstance[],
+  models: Model[],
+  primaryModel: Model | undefined,
+): Promise<SubModelRuntimeCapacity> {
+  const activeInstances = instances.filter(instance => instance.visible)
+  const activeModels = activeInstances
+    .map(instance => models.find(model => model.id === instance.modelId))
+    .filter((model): model is Model => Boolean(model))
+
+  if (primaryModel) activeModels.unshift(primaryModel)
+
+  const metrics = await Promise.all(activeModels.map(getModelResourceMetric))
+  const reservedBytes = metrics.reduce((total, metric) => {
+    return total + getReservedModelBytes(metric.estimatedMemoryBytes)
+  }, 0)
+
+  return {
+    allowed: activeInstances.length <= MAX_VISIBLE_SUB_MODELS && reservedBytes <= DEFAULT_RESOURCE_BUDGET_BYTES,
+    activeCount: activeInstances.length,
+    maxActiveCount: MAX_VISIBLE_SUB_MODELS,
+    reservedBytes,
+    budgetBytes: DEFAULT_RESOURCE_BUDGET_BYTES,
+  }
+}
+
+export class SubModelInputCoordinator {
+  private deviceEvents: DeviceInputEvent[] = []
+  private gamepadEvents: GamepadInputEvent[] = []
+  private frame = 0
+  private sequence = 0
+
+  constructor(private readonly getActiveInstances: () => SubModelInstance[]) {}
+
+  enqueueDevice(event: DeviceInputEvent) {
+    if (event.kind === 'MouseMove') {
+      const index = this.findLastIndex(this.deviceEvents, item => item.kind === 'MouseMove')
+
+      if (index !== -1) {
+        this.deviceEvents[index] = event
+      } else {
+        this.deviceEvents.push(event)
+      }
+    } else {
+      this.deviceEvents.push(event)
+    }
+
+    this.scheduleFlush()
+  }
+
+  enqueueGamepad(event: GamepadInputEvent) {
+    const index = this.findLastIndex(this.gamepadEvents, item => item.kind === event.kind && item.name === event.name)
+
+    if (index !== -1) {
+      this.gamepadEvents[index] = event
+    } else {
+      this.gamepadEvents.push(event)
+    }
+
+    this.scheduleFlush()
+  }
+
+  dispose() {
+    if (this.frame) cancelAnimationFrame(this.frame)
+
+    this.frame = 0
+    this.deviceEvents = []
+    this.gamepadEvents = []
+  }
+
+  private findLastIndex<T>(items: T[], predicate: (item: T) => boolean) {
+    for (let index = items.length - 1; index >= 0; index -= 1) {
+      if (predicate(items[index])) return index
+    }
+
+    return -1
+  }
+
+  private scheduleFlush() {
+    if (this.frame) return
+
+    this.frame = requestAnimationFrame(() => {
+      this.frame = 0
+      void this.flush()
+    })
+  }
+
+  private async flush() {
+    if (!this.deviceEvents.length && !this.gamepadEvents.length) return
+
+    const frame: SubModelInputFrame = {
+      sequence: ++this.sequence,
+      deviceEvents: this.deviceEvents,
+      gamepadEvents: this.gamepadEvents,
+    }
+
+    this.deviceEvents = []
+    this.gamepadEvents = []
+
+    await Promise.all(this.getActiveInstances().map((instance) => {
+      return emitTo(getSubModelWindowLabel(instance.id), LISTEN_KEY.SUB_MODEL_INPUT_FRAME, frame)
+        .catch(() => undefined)
+    }))
+  }
+}

--- a/src/utils/subModelWindow.ts
+++ b/src/utils/subModelWindow.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
 import { PhysicalPosition } from '@tauri-apps/api/dpi'
-import { emitTo } from '@tauri-apps/api/event'
+import { emitTo, listen } from '@tauri-apps/api/event'
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { toRaw } from 'vue'
 
@@ -12,12 +12,24 @@ import { LISTEN_KEY } from '@/constants'
 
 const SUB_MODEL_WINDOW_PREFIX = 'sub-model-'
 const DEFAULT_SIZE = 300
+const WINDOW_READY_TIMEOUT = 10_000
+let windowOpenQueue = Promise.resolve()
 
 export function getSubModelWindowLabel(instanceId: string) {
   return `${SUB_MODEL_WINDOW_PREFIX}${instanceId}`
 }
 
 export async function openSubModelWindow(instance: SubModelInstance) {
+  const task = windowOpenQueue.then(() => openSubModelWindowNow(instance))
+
+  windowOpenQueue = task.then(() => undefined, () => undefined)
+
+  return task
+}
+
+async function openSubModelWindowNow(instance: SubModelInstance) {
+  if (!instance.visible) return
+
   const label = getSubModelWindowLabel(instance.id)
   const existingWindow = await WebviewWindow.getByLabel(label)
 
@@ -29,35 +41,51 @@ export async function openSubModelWindow(instance: SubModelInstance) {
     return existingWindow
   }
 
-  const window = new WebviewWindow(label, {
-    url: `index.html/#/sub-model?instance=${encodeURIComponent(instance.id)}`,
-    title: 'MochiPaw',
-    width: DEFAULT_SIZE,
-    height: DEFAULT_SIZE,
-    x: instance.window.x,
-    y: instance.window.y,
-    shadow: false,
-    transparent: true,
-    decorations: false,
-    alwaysOnTop: instance.window.alwaysOnTop,
-    skipTaskbar: true,
-    maximizable: false,
-    visible: false,
-  })
+  const runtimeReady = await listenForSubModelRuntimeReady(instance.id)
+  let window: WebviewWindow | undefined
 
-  await waitForWindowCreation(window)
-  await syncSubModelWindow(instance, window)
-  await window.show()
+  try {
+    window = new WebviewWindow(label, {
+      url: `index.html/#/sub-model?instance=${encodeURIComponent(instance.id)}`,
+      title: 'MochiPaw',
+      width: DEFAULT_SIZE,
+      height: DEFAULT_SIZE,
+      x: instance.window.x,
+      y: instance.window.y,
+      shadow: false,
+      transparent: true,
+      decorations: false,
+      alwaysOnTop: instance.window.alwaysOnTop,
+      skipTaskbar: true,
+      maximizable: false,
+      visible: false,
+    })
 
-  return window
+    await Promise.all([waitForWindowCreation(window), runtimeReady.ready])
+
+    if (!instance.visible) {
+      await window.destroy()
+      return
+    }
+
+    await syncSubModelWindow(instance, window)
+    await window.show()
+
+    return window
+  } catch (error) {
+    await window?.destroy().catch(() => undefined)
+    throw error
+  } finally {
+    runtimeReady.dispose()
+  }
 }
 
 export async function hideSubModelWindow(instanceId: string) {
   const label = getSubModelWindowLabel(instanceId)
   const window = await WebviewWindow.getByLabel(label)
 
-  await emitTo(label, LISTEN_KEY.SET_SUB_MODEL_RENDERING, false)
-  await window?.hide()
+  await emitTo(label, LISTEN_KEY.SET_SUB_MODEL_RENDERING, false).catch(() => undefined)
+  await window?.destroy()
 }
 
 export async function destroySubModelWindow(instanceId: string) {
@@ -102,4 +130,32 @@ async function waitForWindowCreation(window: WebviewWindow) {
     void window.once('tauri://created', () => resolve())
     void window.once<string>('tauri://error', ({ payload }) => reject(new Error(payload)))
   })
+}
+
+async function listenForSubModelRuntimeReady(instanceId: string) {
+  let resolve!: () => void
+  let reject!: (error: Error) => void
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const ready = new Promise<void>((resolveReady, rejectReady) => {
+    resolve = resolveReady
+    reject = rejectReady
+  })
+  const unlisten = await listen<{ id: string }>(LISTEN_KEY.SUB_MODEL_RUNTIME_READY, ({ payload }) => {
+    if (payload.id !== instanceId) return
+
+    if (timeout) clearTimeout(timeout)
+    resolve()
+  })
+
+  timeout = setTimeout(() => {
+    reject(new Error(`Timed out waiting for sub-model ${instanceId} to initialize.`))
+  }, WINDOW_READY_TIMEOUT)
+
+  return {
+    ready,
+    dispose() {
+      if (timeout) clearTimeout(timeout)
+      unlisten()
+    },
+  }
 }


### PR DESCRIPTION
## Summary
- route native device and gamepad events through the main window before frame-coalesced child delivery
- serialize submodel startup and release WebView2 resources when a child is hidden
- enforce a seven-submodel resource admission limit without modifying configured FPS

## Validation
- pnpm exec eslint src
- cargo check -p mochi-paw
- pnpm build:vite