### PR TITLE
feat(wayland): add privileged input service

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Build Wayland input service
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: cargo build --manifest-path src-tauri/Cargo.toml --release --features inputd --bin mochi-paw-inputd
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "evdev"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "libc",
+ "nix 0.29.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,10 +3085,12 @@ version = "1.1.5"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
+ "evdev",
  "fs_extra",
  "getrandom 0.3.4",
  "gilrs",
  "keyring",
+ "libc",
  "rdev",
  "reqwest 0.12.28",
  "serde",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "generate:contributors": "tsx scripts/generateContributors.ts",
     "build:portable": "node scripts/packagePortable.mjs",
     "package:portable": "node scripts/packagePortable.mjs",
+    "bundle:linux": "cargo build --manifest-path src-tauri/Cargo.toml --release --features inputd --bin mochi-paw-inputd && tauri build --bundles deb,rpm,appimage",
     "lint": "eslint --fix src",
     "preinstall": "npx only-allow pnpm",
     "prepare": "simple-git-hooks",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,11 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 name = "mochi-paw"
 path = "src/main.rs"
 
+[[bin]]
+name = "mochi-paw-inputd"
+path = "src/bin/mochi-paw-inputd.rs"
+required-features = ["inputd"]
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
@@ -58,6 +63,10 @@ sha2 = "0.10"
 rdev = { git = "https://github.com/kunkunsh/rdev" }
 gilrs = { git = "https://github.com/ayangweb/gilrs", default-features = false, features = ["xinput"] }
 
+[target."cfg(target_os = \"linux\")".dependencies]
+libc = "0.2"
+evdev = "0.13"
+
 [target."cfg(target_os = \"windows\")".dependencies]
 windows.workspace = true
 
@@ -66,3 +75,4 @@ tauri-nspanel.workspace = true
 
 [features]
 cargo-clippy = []
+inputd = []

--- a/src-tauri/packaging/linux/com.catstack.mochipaw.inputd.policy
+++ b/src-tauri/packaging/linux/com.catstack.mochipaw.inputd.policy
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN" "https://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <action id="com.catstack.mochipaw.inputd.install">
+    <description>Install MochiPaw Wayland input support</description>
+    <message>Authentication is required to install MochiPaw's Wayland input relay.</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+</policyconfig>

--- a/src-tauri/packaging/linux/mochi-paw-inputd.service
+++ b/src-tauri/packaging/linux/mochi-paw-inputd.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=MochiPaw Wayland input relay
+After=systemd-logind.service
+
+[Service]
+Type=simple
+ExecStart=/usr/lib/mochi-paw/mochi-paw-inputd
+Restart=on-failure
+RestartSec=2
+User=root
+Group=root
+PrivateTmp=yes
+PrivateNetwork=yes
+ProtectHome=yes
+ProtectSystem=strict
+ReadWritePaths=/run/user
+PrivateDevices=no
+NoNewPrivileges=yes
+RestrictAddressFamilies=AF_UNIX
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target

--- a/src-tauri/packaging/linux/postinstall.sh
+++ b/src-tauri/packaging/linux/postinstall.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload
+  systemctl enable --now mochi-paw-inputd.service || true
+  systemctl is-active --quiet mochi-paw-inputd.service || \
+    echo "MochiPaw input service was installed but is not ready." >&2
+else
+  echo "MochiPaw input service was installed without systemd verification." >&2
+fi

--- a/src-tauri/packaging/linux/postremove.sh
+++ b/src-tauri/packaging/linux/postremove.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload
+fi

--- a/src-tauri/packaging/linux/preremove.sh
+++ b/src-tauri/packaging/linux/preremove.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+systemctl disable --now mochi-paw-inputd.service || true

--- a/src-tauri/src/bin/mochi-paw-inputd.rs
+++ b/src-tauri/src/bin/mochi-paw-inputd.rs
@@ -1,0 +1,347 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+//! Privileged Linux input relay for MochiPaw Wayland sessions.
+//! It deliberately exposes only normalized key, button, and relative motion events.
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("mochi-paw-inputd is only available on Linux");
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use evdev::{Device, EventType};
+    use serde::{Deserialize, Serialize};
+    use std::{
+        fs,
+        io::{self, BufRead, Write},
+        os::{
+            fd::AsRawFd,
+            unix::{
+                fs::PermissionsExt,
+                net::{UnixListener, UnixStream},
+            },
+        },
+        path::{Path, PathBuf},
+        process::Command,
+        sync::mpsc,
+        thread,
+        time::Duration,
+    };
+
+    const SOCKET_NAME: &str = "mochi-paw-inputd.sock";
+
+    #[derive(Serialize)]
+    #[serde(tag = "kind", content = "value")]
+    enum Message {
+        Ready,
+        KeyboardPress(String),
+        KeyboardRelease(String),
+        MousePress(String),
+        MouseRelease(String),
+        MouseRelativeMove { dx: i32, dy: i32 },
+    }
+
+    #[derive(Deserialize)]
+    #[serde(tag = "kind")]
+    enum ClientMessage {
+        Subscribe,
+    }
+
+    struct Session {
+        uid: u32,
+        runtime_dir: PathBuf,
+    }
+
+    pub fn run() -> Result<(), String> {
+        loop {
+            let session = active_graphical_session()?;
+            let socket_path = session.runtime_dir.join(SOCKET_NAME);
+            let listener = bind_socket(&socket_path, session.uid)?;
+            listener
+                .set_nonblocking(true)
+                .map_err(|error| format!("failed to configure input service socket: {error}"))?;
+
+            loop {
+                match listener.accept() {
+                    Ok((stream, _)) if peer_uid(&stream) == Ok(session.uid) => {
+                        let _ = serve_connection(stream);
+                    }
+                    Ok(_) => {}
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(250));
+                    }
+                    Err(error) => return Err(format!("input service socket error: {error}")),
+                }
+
+                // A session switch changes the authorized UID and socket location.
+                if active_graphical_session()
+                    .map(|next| next.uid != session.uid)
+                    .unwrap_or(true)
+                {
+                    break;
+                }
+            }
+
+            let _ = fs::remove_file(socket_path);
+        }
+    }
+
+    fn active_graphical_session() -> Result<Session, String> {
+        let sessions = Command::new("loginctl")
+            .args(["list-sessions", "--no-legend"])
+            .output()
+            .map_err(|error| {
+                format!("loginctl is required to validate the graphical session: {error}")
+            })?;
+
+        for line in String::from_utf8_lossy(&sessions.stdout).lines() {
+            let Some(id) = line.split_whitespace().next() else {
+                continue;
+            };
+            let output = Command::new("loginctl")
+                .args([
+                    "show-session",
+                    id,
+                    "--property=Active",
+                    "--property=Type",
+                    "--property=User",
+                    "--value",
+                ])
+                .output()
+                .map_err(|error| format!("failed to inspect login session: {error}"))?;
+            let fields = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .collect::<Vec<_>>();
+
+            if fields.len() < 3 || fields[0] != "yes" || !matches!(fields[1], "wayland" | "x11") {
+                continue;
+            }
+
+            let uid = fields[2]
+                .parse::<u32>()
+                .map_err(|_| "loginctl returned an invalid session user".to_string())?;
+            let runtime_dir = PathBuf::from(format!("/run/user/{uid}"));
+            if runtime_dir.is_dir() {
+                return Ok(Session { uid, runtime_dir });
+            }
+        }
+
+        Err("no active graphical login session is available".into())
+    }
+
+    fn bind_socket(path: &Path, uid: u32) -> Result<UnixListener, String> {
+        let _ = fs::remove_file(path);
+        let listener = UnixListener::bind(path)
+            .map_err(|error| format!("failed to bind input service socket: {error}"))?;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("failed to secure input service socket: {error}"))?;
+
+        let path_bytes = std::ffi::CString::new(path.as_os_str().as_encoded_bytes())
+            .map_err(|_| "input service socket path contains a null byte".to_string())?;
+        if unsafe { libc::chown(path_bytes.as_ptr(), uid, u32::MAX) } != 0 {
+            return Err(format!(
+                "failed to assign input service socket to session user: {}",
+                io::Error::last_os_error()
+            ));
+        }
+
+        Ok(listener)
+    }
+
+    fn peer_uid(stream: &UnixStream) -> Result<u32, String> {
+        let mut credentials: libc::ucred = unsafe { std::mem::zeroed() };
+        let mut length = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+        let result = unsafe {
+            libc::getsockopt(
+                stream.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_PEERCRED,
+                (&mut credentials as *mut libc::ucred).cast(),
+                &mut length,
+            )
+        };
+        if result == 0 {
+            Ok(credentials.uid)
+        } else {
+            Err(io::Error::last_os_error().to_string())
+        }
+    }
+
+    fn write_message(stream: &mut UnixStream, message: &Message) -> Result<(), String> {
+        serde_json::to_writer(&mut *stream, message)
+            .map_err(|error| format!("failed to encode input event: {error}"))?;
+        stream
+            .write_all(b"\n")
+            .map_err(|error| format!("failed to deliver input event: {error}"))?;
+        stream
+            .flush()
+            .map_err(|error| format!("failed to flush input event: {error}"))
+    }
+
+    fn serve_connection(mut stream: UnixStream) -> Result<(), String> {
+        write_message(&mut stream, &Message::Ready)?;
+        let mut subscription = String::new();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .map_err(|error| format!("failed to configure input service client: {error}"))?;
+        std::io::BufReader::new(
+            stream
+                .try_clone()
+                .map_err(|error| format!("failed to read input service client request: {error}"))?,
+        )
+        .read_line(&mut subscription)
+        .map_err(|error| format!("input service client did not subscribe: {error}"))?;
+        if subscription.len() > 4096
+            || !matches!(
+                serde_json::from_str(&subscription),
+                Ok(ClientMessage::Subscribe)
+            )
+        {
+            return Ok(());
+        }
+        stream
+            .set_read_timeout(None)
+            .map_err(|error| format!("failed to configure input service client: {error}"))?;
+
+        let (sender, receiver) = mpsc::sync_channel(512);
+
+        for path in input_devices()? {
+            let sender = sender.clone();
+            thread::spawn(move || read_device(path, sender));
+        }
+        drop(sender);
+
+        while let Ok(message) = receiver.recv() {
+            if write_message(&mut stream, &message).is_err() {
+                return Ok(());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn input_devices() -> Result<Vec<PathBuf>, String> {
+        let entries = fs::read_dir("/dev/input")
+            .map_err(|error| format!("cannot read /dev/input: {error}"))?;
+        Ok(entries
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .is_some_and(|name| name.to_string_lossy().starts_with("event"))
+            })
+            .collect())
+    }
+
+    fn read_device(path: PathBuf, sender: mpsc::SyncSender<Message>) {
+        let Ok(mut device) = Device::open(path) else {
+            return;
+        };
+        loop {
+            match device.fetch_events() {
+                Ok(events) => {
+                    for event in events {
+                        if let Some(message) =
+                            normalize_event(event.event_type(), event.code(), event.value())
+                        {
+                            if sender.send(message).is_err() {
+                                return;
+                            }
+                        }
+                    }
+                }
+                Err(_) => thread::sleep(Duration::from_millis(25)),
+            }
+        }
+    }
+
+    fn normalize_event(kind: EventType, code: u16, value: i32) -> Option<Message> {
+        match kind {
+            EventType::KEY if code == 272 => button_event("Left", value),
+            EventType::KEY if code == 273 => button_event("Right", value),
+            EventType::KEY => key_event(key_name(code)?, value),
+            EventType::RELATIVE if code == 0 && value != 0 => {
+                Some(Message::MouseRelativeMove { dx: value, dy: 0 })
+            }
+            EventType::RELATIVE if code == 1 && value != 0 => {
+                Some(Message::MouseRelativeMove { dx: 0, dy: value })
+            }
+            _ => None,
+        }
+    }
+
+    fn button_event(button: &str, value: i32) -> Option<Message> {
+        match value {
+            1 => Some(Message::MousePress(button.into())),
+            0 => Some(Message::MouseRelease(button.into())),
+            _ => None,
+        }
+    }
+
+    fn key_event(key: &str, value: i32) -> Option<Message> {
+        match value {
+            1 => Some(Message::KeyboardPress(key.into())),
+            0 => Some(Message::KeyboardRelease(key.into())),
+            _ => None,
+        }
+    }
+
+    // Names deliberately match rdev's debug representation used by existing models.
+    fn key_name(code: u16) -> Option<&'static str> {
+        const LETTERS: [&str; 26] = [
+            "KeyQ", "KeyW", "KeyE", "KeyR", "KeyT", "KeyY", "KeyU", "KeyI", "KeyO", "KeyP", "KeyA",
+            "KeyS", "KeyD", "KeyF", "KeyG", "KeyH", "KeyJ", "KeyK", "KeyL", "KeyZ", "KeyX", "KeyC",
+            "KeyV", "KeyB", "KeyN", "KeyM",
+        ];
+        match code {
+            2..=11 => Some(
+                [
+                    "Num1", "Num2", "Num3", "Num4", "Num5", "Num6", "Num7", "Num8", "Num9", "Num0",
+                ][(code - 2) as usize],
+            ),
+            16..=25 => Some(LETTERS[(code - 16) as usize]),
+            30..=38 => Some(LETTERS[(code - 30 + 10) as usize]),
+            44..=50 => Some(LETTERS[(code - 44 + 19) as usize]),
+            1 => Some("Escape"),
+            14 => Some("Backspace"),
+            15 => Some("Tab"),
+            28 => Some("Return"),
+            29 => Some("ControlLeft"),
+            42 => Some("ShiftLeft"),
+            54 => Some("ShiftRight"),
+            56 => Some("Alt"),
+            57 => Some("Space"),
+            58 => Some("CapsLock"),
+            69 => Some("NumLock"),
+            97 => Some("ControlRight"),
+            100 => Some("AltGr"),
+            102 => Some("Home"),
+            103 => Some("UpArrow"),
+            104 => Some("PageUp"),
+            105 => Some("LeftArrow"),
+            106 => Some("RightArrow"),
+            107 => Some("End"),
+            108 => Some("DownArrow"),
+            109 => Some("PageDown"),
+            111 => Some("Delete"),
+            125 => Some("MetaLeft"),
+            126 => Some("MetaRight"),
+            59..=68 => Some(
+                ["F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10"][(code - 59) as usize],
+            ),
+            87 => Some("F11"),
+            88 => Some("F12"),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    if let Err(error) = linux::run() {
+        eprintln!("mochi-paw-inputd: {error}");
+        std::process::exit(1);
+    }
+}

--- a/src-tauri/src/core/device.rs
+++ b/src-tauri/src/core/device.rs
@@ -61,6 +61,7 @@ pub fn get_device_input_status() -> DeviceInputStatus {
             hover_supported: false,
             error: None,
         },
+        #[cfg(target_os = "linux")]
         InputBackend::WaylandService => match probe_wayland_service() {
             Ok(_) => DeviceInputStatus {
                 backend: "wayland-service".into(),

--- a/src-tauri/src/core/device.rs
+++ b/src-tauri/src/core/device.rs
@@ -54,6 +54,13 @@ pub fn get_device_input_status() -> DeviceInputStatus {
             error: None,
         },
         #[cfg(target_os = "linux")]
+        InputBackend::WaylandService if IS_LISTENING.load(Ordering::SeqCst) => DeviceInputStatus {
+            backend: "wayland-service".into(),
+            available: true,
+            authorized: true,
+            hover_supported: false,
+            error: None,
+        },
         InputBackend::WaylandService => match probe_wayland_service() {
             Ok(_) => DeviceInputStatus {
                 backend: "wayland-service".into(),

--- a/src-tauri/src/core/device.rs
+++ b/src-tauri/src/core/device.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
 
 use rdev::{Event, EventType, listen};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{
     sync::{
@@ -15,22 +15,71 @@ use std::{
 };
 use tauri::{AppHandle, Emitter, Runtime, command};
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum DeviceEventKind {
     MousePress,
     MouseRelease,
     MouseMove,
+    MouseRelativeMove,
     KeyboardPress,
     KeyboardRelease,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceEvent {
     kind: DeviceEventKind,
     value: Value,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceInputStatus {
+    pub backend: String,
+    pub available: bool,
+    pub authorized: bool,
+    pub hover_supported: bool,
+    pub error: Option<String>,
+}
+
 static IS_LISTENING: AtomicBool = AtomicBool::new(false);
+
+#[command]
+pub fn get_device_input_status() -> DeviceInputStatus {
+    match select_backend() {
+        InputBackend::Rdev => DeviceInputStatus {
+            backend: "rdev".into(),
+            available: true,
+            authorized: true,
+            hover_supported: true,
+            error: None,
+        },
+        #[cfg(target_os = "linux")]
+        InputBackend::WaylandService => match probe_wayland_service() {
+            Ok(_) => DeviceInputStatus {
+                backend: "wayland-service".into(),
+                available: true,
+                authorized: true,
+                hover_supported: false,
+                error: None,
+            },
+            Err(error) => DeviceInputStatus {
+                backend: "wayland-service".into(),
+                available: false,
+                authorized: false,
+                hover_supported: false,
+                error: Some(error),
+            },
+        },
+        #[cfg(target_os = "linux")]
+        InputBackend::WaylandAppImage => DeviceInputStatus {
+            backend: "wayland-appimage".into(),
+            available: false,
+            authorized: false,
+            hover_supported: false,
+            error: Some("AppImage packages do not install the Wayland input service.".into()),
+        },
+    }
+}
 
 #[command]
 pub async fn start_device_listening<R: Runtime>(app_handle: AppHandle<R>) -> Result<(), String> {
@@ -51,54 +100,30 @@ pub async fn start_device_listening<R: Runtime>(app_handle: AppHandle<R>) -> Res
                 let _ = app_handle.emit_to("main", "device-changed", device_event);
             }
         })
-        .map_err(|err| {
+        .map_err(|error| {
             IS_LISTENING.store(false, Ordering::SeqCst);
-
-            format!("Failed to spawn device event emitter: {err}")
+            format!("Failed to spawn device event emitter: {error}")
         })?;
-
-    let callback = move |event: Event| {
-        let device_event = match event.event_type {
-            EventType::ButtonPress(button) => DeviceEvent {
-                kind: DeviceEventKind::MousePress,
-                value: json!(format!("{:?}", button)),
-            },
-            EventType::ButtonRelease(button) => DeviceEvent {
-                kind: DeviceEventKind::MouseRelease,
-                value: json!(format!("{:?}", button)),
-            },
-            EventType::MouseMove { x, y } => DeviceEvent {
-                kind: DeviceEventKind::MouseMove,
-                value: json!({ "x": x, "y": y }),
-            },
-            EventType::KeyPress(key) => DeviceEvent {
-                kind: DeviceEventKind::KeyboardPress,
-                value: json!(format!("{:?}", key)),
-            },
-            EventType::KeyRelease(key) => DeviceEvent {
-                kind: DeviceEventKind::KeyboardRelease,
-                value: json!(format!("{:?}", key)),
-            },
-            _ => return,
-        };
-
-        let _ = event_sender.try_send(device_event);
-    };
 
     thread::Builder::new()
         .name("device-listener".into())
         .spawn(move || {
-            let listen_result =
-                listen(callback).map_err(|err| format!("Failed to listen device: {:?}", err));
+            let result = match select_backend() {
+                InputBackend::Rdev => listen_rdev(event_sender),
+                #[cfg(target_os = "linux")]
+                InputBackend::WaylandService => listen_wayland_service(event_sender),
+                #[cfg(target_os = "linux")]
+                InputBackend::WaylandAppImage => {
+                    Err("Global input is unavailable for AppImage on Wayland.".into())
+                }
+            };
 
             IS_LISTENING.store(false, Ordering::SeqCst);
-
-            let _ = startup_sender.send(listen_result);
+            let _ = startup_sender.send(result);
         })
-        .map_err(|err| {
+        .map_err(|error| {
             IS_LISTENING.store(false, Ordering::SeqCst);
-
-            format!("Failed to spawn device listener: {err}")
+            format!("Failed to spawn device listener: {error}")
         })?;
 
     if let Ok(result) = startup_receiver.recv_timeout(Duration::from_millis(300)) {
@@ -106,4 +131,204 @@ pub async fn start_device_listening<R: Runtime>(app_handle: AppHandle<R>) -> Res
     }
 
     Ok(())
+}
+
+fn listen_rdev(event_sender: mpsc::SyncSender<DeviceEvent>) -> Result<(), String> {
+    let callback = move |event: Event| {
+        let device_event = match event.event_type {
+            EventType::ButtonPress(button) => DeviceEvent {
+                kind: DeviceEventKind::MousePress,
+                value: json!(format!("{button:?}")),
+            },
+            EventType::ButtonRelease(button) => DeviceEvent {
+                kind: DeviceEventKind::MouseRelease,
+                value: json!(format!("{button:?}")),
+            },
+            EventType::MouseMove { x, y } => DeviceEvent {
+                kind: DeviceEventKind::MouseMove,
+                value: json!({ "x": x, "y": y }),
+            },
+            EventType::KeyPress(key) => DeviceEvent {
+                kind: DeviceEventKind::KeyboardPress,
+                value: json!(format!("{key:?}")),
+            },
+            EventType::KeyRelease(key) => DeviceEvent {
+                kind: DeviceEventKind::KeyboardRelease,
+                value: json!(format!("{key:?}")),
+            },
+            _ => return,
+        };
+        let _ = event_sender.try_send(device_event);
+    };
+
+    listen(callback).map_err(|error| format!("Failed to listen device: {error:?}"))
+}
+
+enum InputBackend {
+    Rdev,
+    #[cfg(target_os = "linux")]
+    WaylandService,
+    #[cfg(target_os = "linux")]
+    WaylandAppImage,
+}
+
+fn select_backend() -> InputBackend {
+    #[cfg(target_os = "linux")]
+    if is_wayland_session() {
+        return if std::env::var_os("APPIMAGE").is_some() {
+            InputBackend::WaylandAppImage
+        } else {
+            InputBackend::WaylandService
+        };
+    }
+
+    InputBackend::Rdev
+}
+
+#[cfg(target_os = "linux")]
+fn is_wayland_session() -> bool {
+    if std::env::var_os("MOCHI_PAW_FORCE_X11").is_some() {
+        return false;
+    }
+
+    matches!(std::env::var("XDG_SESSION_TYPE").as_deref(), Ok("wayland"))
+        || std::env::var_os("WAYLAND_DISPLAY").is_some()
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_socket_path() -> Result<std::path::PathBuf, String> {
+    let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR").ok_or_else(|| {
+        "XDG_RUNTIME_DIR is unavailable for the active Wayland session.".to_string()
+    })?;
+    Ok(std::path::PathBuf::from(runtime_dir).join("mochi-paw-inputd.sock"))
+}
+
+#[cfg(target_os = "linux")]
+fn connect_wayland_service() -> Result<std::os::unix::net::UnixStream, String> {
+    let socket_path = daemon_socket_path()?;
+    std::os::unix::net::UnixStream::connect(&socket_path).map_err(|error| {
+        format!(
+            "Wayland input service is unavailable at {}: {error}",
+            socket_path.display()
+        )
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn probe_wayland_service() -> Result<(), String> {
+    use std::io::{BufRead, BufReader};
+
+    let stream = connect_wayland_service()?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .map_err(|error| format!("failed to validate Wayland input service: {error}"))?;
+    let mut line = String::new();
+    BufReader::new(stream)
+        .read_line(&mut line)
+        .map_err(|error| format!("Wayland input service did not confirm this session: {error}"))?;
+
+    if line.trim() == r#"{"kind":"Ready"}"# {
+        Ok(())
+    } else {
+        Err("Wayland input service rejected the active session.".into())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn listen_wayland_service(event_sender: mpsc::SyncSender<DeviceEvent>) -> Result<(), String> {
+    use std::io::{BufRead, BufReader, Write};
+
+    let mut stream = connect_wayland_service()?;
+    stream
+        .write_all(b"{\"kind\":\"Subscribe\"}\n")
+        .map_err(|error| format!("failed to subscribe to Wayland input service: {error}"))?;
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let bytes = reader
+            .read_line(&mut line)
+            .map_err(|error| format!("Wayland input service disconnected: {error}"))?;
+        if bytes == 0 {
+            return Err("Wayland input service disconnected.".into());
+        }
+        if line.len() > 4096 {
+            return Err("Wayland input service sent an oversized message.".into());
+        }
+
+        let event: DaemonMessage = serde_json::from_str(&line)
+            .map_err(|error| format!("Wayland input service sent an invalid message: {error}"))?;
+        if let Some(event) = event.into_device_event() {
+            let _ = event_sender.try_send(event);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Deserialize)]
+#[serde(tag = "kind", content = "value")]
+enum DaemonMessage {
+    Ready,
+    KeyboardPress(String),
+    KeyboardRelease(String),
+    MousePress(String),
+    MouseRelease(String),
+    MouseRelativeMove { dx: i32, dy: i32 },
+}
+
+#[cfg(target_os = "linux")]
+impl DaemonMessage {
+    fn into_device_event(self) -> Option<DeviceEvent> {
+        match self {
+            Self::Ready => None,
+            Self::KeyboardPress(value) => Some(DeviceEvent {
+                kind: DeviceEventKind::KeyboardPress,
+                value: json!(value),
+            }),
+            Self::KeyboardRelease(value) => Some(DeviceEvent {
+                kind: DeviceEventKind::KeyboardRelease,
+                value: json!(value),
+            }),
+            Self::MousePress(value) => Some(DeviceEvent {
+                kind: DeviceEventKind::MousePress,
+                value: json!(value),
+            }),
+            Self::MouseRelease(value) => Some(DeviceEvent {
+                kind: DeviceEventKind::MouseRelease,
+                value: json!(value),
+            }),
+            Self::MouseRelativeMove { dx, dy } => Some(DeviceEvent {
+                kind: DeviceEventKind::MouseRelativeMove,
+                value: json!({ "dx": dx, "dy": dy }),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_linux_uses_rdev() {
+        #[cfg(not(target_os = "linux"))]
+        assert!(matches!(select_backend(), InputBackend::Rdev));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn daemon_ready_message_is_not_emitted() {
+        assert!(DaemonMessage::Ready.into_device_event().is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn relative_message_is_normalized() {
+        let event = DaemonMessage::MouseRelativeMove { dx: 4, dy: -2 }
+            .into_device_event()
+            .unwrap();
+        assert_eq!(event.kind, DeviceEventKind::MouseRelativeMove);
+        assert_eq!(event.value, json!({ "dx": 4, "dy": -2 }));
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ mod core;
 mod utils;
 
 use core::{
-    device::start_device_listening,
+    device::{get_device_input_status, start_device_listening},
     gamepad::{set_gamepad_listener_enabled, start_gamepad_listing, stop_gamepad_listing},
     prevent_default,
     runtime_security::{
@@ -49,6 +49,7 @@ pub fn run() {
             copy_dir,
             extract_zip,
             start_device_listening,
+            get_device_input_status,
             start_gamepad_listing,
             stop_gamepad_listing,
             set_gamepad_listener_enabled,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -69,7 +69,8 @@
           "packaging/linux/com.catstack.mochipaw.inputd.policy": "/usr/share/polkit-1/actions/com.catstack.mochipaw.inputd.policy"
         },
         "postInstallScript": "packaging/linux/postinstall.sh",
-        "preRemoveScript": "packaging/linux/preremove.sh"
+        "preRemoveScript": "packaging/linux/preremove.sh",
+        "postRemoveScript": "packaging/linux/postremove.sh"
       },
       "rpm": {
         "files": {
@@ -78,7 +79,8 @@
           "packaging/linux/com.catstack.mochipaw.inputd.policy": "/usr/share/polkit-1/actions/com.catstack.mochipaw.inputd.policy"
         },
         "postInstallScript": "packaging/linux/postinstall.sh",
-        "preRemoveScript": "packaging/linux/preremove.sh"
+        "preRemoveScript": "packaging/linux/preremove.sh",
+        "postRemoveScript": "packaging/linux/postremove.sh"
       }
     }
   },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,7 +60,27 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "resources": ["assets/tray.png", "assets/models"]
+    "resources": ["assets/tray.png", "assets/models"],
+    "linux": {
+      "deb": {
+        "files": {
+          "../target/release/mochi-paw-inputd": "/usr/lib/mochi-paw/mochi-paw-inputd",
+          "packaging/linux/mochi-paw-inputd.service": "/usr/lib/systemd/system/mochi-paw-inputd.service",
+          "packaging/linux/com.catstack.mochipaw.inputd.policy": "/usr/share/polkit-1/actions/com.catstack.mochipaw.inputd.policy"
+        },
+        "postInstallScript": "packaging/linux/postinstall.sh",
+        "preRemoveScript": "packaging/linux/preremove.sh"
+      },
+      "rpm": {
+        "files": {
+          "../target/release/mochi-paw-inputd": "/usr/lib/mochi-paw/mochi-paw-inputd",
+          "packaging/linux/mochi-paw-inputd.service": "/usr/lib/systemd/system/mochi-paw-inputd.service",
+          "packaging/linux/com.catstack.mochipaw.inputd.policy": "/usr/share/polkit-1/actions/com.catstack.mochipaw.inputd.policy"
+        },
+        "postInstallScript": "packaging/linux/postinstall.sh",
+        "preRemoveScript": "packaging/linux/preremove.sh"
+      }
+    }
   },
   "plugins": {
     "updater": {

--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -25,6 +25,7 @@ import { useModel } from './useModel'
 import { useTauriListen } from './useTauriListen'
 
 type CursorPoint = Extract<DeviceInputEvent, { kind: 'MouseMove' }>['value']
+type RelativeMouseMove = Extract<DeviceInputEvent, { kind: 'MouseRelativeMove' }>['value']
 
 export interface DeviceListenerOptions {
   keyboard: boolean
@@ -51,16 +52,18 @@ export function useDevice(options: UseDeviceOptions = {}) {
   const catStore = useCatStore()
   const latestCursorPoint = ref<CursorPoint>()
   const smoothedCursorPoint = ref<CursorPoint>()
+  const relativeMouseMove = ref<RelativeMouseMove>()
   const scaleFactor = ref(1)
   const listeners = options.listeners ?? computed<DeviceListenerOptions>(() => ({
     keyboard: true,
     mouse: true,
     typingBehavior: true,
   }))
-  const { handlePress, handleRelease, handleMouseChange, handleMouseMove, handleDestroy } = useModel(options)
+  const { handlePress, handleRelease, handleMouseChange, handleMouseMove, handleRelativeMouseMove, handleDestroy } = useModel(options)
   let lastRuntimeUsedReportAt = 0
   let cursorSmoothingFrame = 0
   let lastCursorSmoothingAt = 0
+  let relativeMouseFrame = 0
 
   const reportRuntimeUsed = () => {
     const now = Date.now()
@@ -78,6 +81,12 @@ export function useDevice(options: UseDeviceOptions = {}) {
     lastCursorSmoothingAt = 0
     latestCursorPoint.value = undefined
     smoothedCursorPoint.value = undefined
+    relativeMouseMove.value = undefined
+
+    if (relativeMouseFrame) {
+      cancelAnimationFrame(relativeMouseFrame)
+      relativeMouseFrame = 0
+    }
   }
 
   const scheduleCursorSmoothing = () => {
@@ -169,7 +178,7 @@ export function useDevice(options: UseDeviceOptions = {}) {
   }, { immediate: true })
 
   const startListening = () => {
-    invoke(INVOKE_KEY.START_DEVICE_LISTENING)
+    void invoke(INVOKE_KEY.START_DEVICE_LISTENING).catch(() => undefined)
   }
 
   const getSupportedKeys = (key: string) => {
@@ -258,6 +267,19 @@ export function useDevice(options: UseDeviceOptions = {}) {
     onHideOnHover(x, y)
   }
 
+  const scheduleRelativeMouseMove = () => {
+    if (catStore.model.ignoreMouse || !listeners.value.mouse || relativeMouseFrame || !relativeMouseMove.value) return
+
+    relativeMouseFrame = requestAnimationFrame(() => {
+      relativeMouseFrame = 0
+
+      const movement = relativeMouseMove.value
+      relativeMouseMove.value = undefined
+
+      if (movement) handleRelativeMouseMove(movement.dx, movement.dy)
+    })
+  }
+
   const handleAutoRelease = (key: string, delay = 100) => {
     if (releaseTimers.has(key)) {
       clearTimeout(releaseTimers.get(key))
@@ -341,6 +363,13 @@ export function useDevice(options: UseDeviceOptions = {}) {
         if (!listeners.value.mouse) return
         latestCursorPoint.value = value
         return scheduleCursorSmoothing()
+      case 'MouseRelativeMove':
+        if (!listeners.value.mouse) return
+        relativeMouseMove.value = {
+          dx: (relativeMouseMove.value?.dx ?? 0) + value.dx,
+          dy: (relativeMouseMove.value?.dy ?? 0) + value.dy,
+        }
+        return scheduleRelativeMouseMove()
     }
   }
 

--- a/src/composables/useDeviceInputStatus.ts
+++ b/src/composables/useDeviceInputStatus.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import { invoke } from '@tauri-apps/api/core'
+import { onMounted, ref } from 'vue'
+
+import { INVOKE_KEY } from '@/constants'
+
+export interface DeviceInputStatus {
+  backend: 'rdev' | 'wayland-service' | 'wayland-appimage'
+  available: boolean
+  authorized: boolean
+  hoverSupported: boolean
+  error?: string
+}
+
+export function useDeviceInputStatus() {
+  const status = ref<DeviceInputStatus>()
+
+  const refresh = async () => {
+    status.value = await invoke<DeviceInputStatus>(INVOKE_KEY.GET_DEVICE_INPUT_STATUS)
+    return status.value
+  }
+
+  onMounted(() => {
+    void refresh().catch(() => undefined)
+  })
+
+  return { status, refresh }
+}

--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -51,6 +51,7 @@ export function useModel(runtimeOptions: ModelRuntimeOptions = {}) {
   let nextTypingExpressionAt = 0
   let activeMotionBehaviorId: string | undefined
   let currentExpressionBehaviorId: string | undefined
+  let relativeLookPosition = { x: 0.5, y: 0.5 }
   let activeMotionResetTimer: ReturnType<typeof setTimeout> | undefined
 
   function getBehaviorShortcut(index: number) {
@@ -502,15 +503,7 @@ export function useModel(runtimeOptions: ModelRuntimeOptions = {}) {
     return (min + Math.random() * (max - min)) * 1000
   }
 
-  async function handleMouseMove(cursorPoint: PhysicalPosition) {
-    const monitor = await getCursorMonitor(cursorPoint)
-
-    if (!monitor) return
-
-    const { size, position } = monitor
-
-    const xRatio = (cursorPoint.x - position.x) / size.width
-    const yRatio = (cursorPoint.y - position.y) / size.height
+  function applyMouseLook(xRatio: number, yRatio: number) {
     const lookTargetX = (mouseMirror.value ? -1 : 1) * (1 - 2 * xRatio)
     const lookTargetY = 1 - 2 * yRatio
 
@@ -558,6 +551,30 @@ export function useModel(runtimeOptions: ModelRuntimeOptions = {}) {
     live2d.setLookTarget(lookTargetX, lookTargetY)
   }
 
+  async function handleMouseMove(cursorPoint: PhysicalPosition) {
+    const monitor = await getCursorMonitor(cursorPoint)
+
+    if (!monitor) return
+
+    const { size, position } = monitor
+
+    applyMouseLook(
+      (cursorPoint.x - position.x) / size.width,
+      (cursorPoint.y - position.y) / size.height,
+    )
+  }
+
+  function handleRelativeMouseMove(dx: number, dy: number) {
+    // Wayland intentionally does not expose global cursor coordinates. Keep a bounded
+    // virtual cursor so relative motion still drives the same Live2D look parameters.
+    relativeLookPosition = {
+      x: Math.min(1, Math.max(0, relativeLookPosition.x + dx / 240)),
+      y: Math.min(1, Math.max(0, relativeLookPosition.y + dy / 240)),
+    }
+
+    applyMouseLook(relativeLookPosition.x, relativeLookPosition.y)
+  }
+
   async function handleAxisChange(id: string, value: number) {
     const range = live2d.getParameterValueRange(id)
 
@@ -578,6 +595,7 @@ export function useModel(runtimeOptions: ModelRuntimeOptions = {}) {
     handleKeyChange,
     handleMouseChange,
     handleMouseMove,
+    handleRelativeMouseMove,
     handleAxisChange,
     playMotionBehavior,
     playExpressionBehavior,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -26,6 +26,7 @@ export const INVOKE_KEY = {
   COPY_DIR: 'copy_dir',
   EXTRACT_ZIP: 'extract_zip',
   START_DEVICE_LISTENING: 'start_device_listening',
+  GET_DEVICE_INPUT_STATUS: 'get_device_input_status',
   START_GAMEPAD_LISTING: 'start_gamepad_listing',
   STOP_GAMEPAD_LISTING: 'stop_gamepad_listing',
   SET_GAMEPAD_LISTENER_ENABLED: 'set_gamepad_listener_enabled',

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -60,7 +60,8 @@
           "autoCheckUpdate": "Auto Check for Updates",
           "permissionsSettings": "Permissions Settings",
           "inputMonitoringPermission": "Input Monitoring Permission",
-          "administratorPermission": "Administrator"
+          "administratorPermission": "Administrator",
+          "waylandInput": "Wayland Input Service"
         },
         "options": {
           "auto": "System",
@@ -74,13 +75,18 @@
           "inputMonitoringPermissionGuide": "Input Monitoring permission is required for the app to receive keyboard and mouse events from the system.\n\nSteps:\n1. Open System Settings → Privacy & Security → Input Monitoring.\n2. If MochiPaw already appears in the list, select it and click the \"-\" button to remove it.\n3. Click the \"+\" button to find and add MochiPaw.\n4. Restart the app for the permission to take effect.",
           "administratorPermission": "Running the app as administrator helps capture some system-level keys and input events more reliably.",
           "administratorPermissionGuide": "To capture some system-level keys and input events more reliably, it is recommended to run the app as administrator.\n\nHow to do it:\n1. Exit the app first.\n2. Find the app exe or its shortcut in File Explorer.\n3. Choose how to launch:\n   • One-time: Right-click and choose \"Run as administrator\".\n   • Always (default): Right-click → Properties → Compatibility tab → check \"Run this program as an administrator\" → OK.",
-          "administratorRelaunchFailed": "Unable to restart as administrator. Please right-click the app and choose \"Run as administrator\"."
+          "administratorRelaunchFailed": "Unable to restart as administrator. Please right-click the app and choose \"Run as administrator\".",
+          "waylandReady": "The installed system service sends normalized keyboard, mouse button, and relative mouse movement only. It does not record, inject, or transmit input.",
+          "waylandUnavailable": "The Wayland input service is unavailable or was not authorized during package installation. Install the DEB or RPM package, then check the system service. X11 continues to use the built-in input backend.",
+          "waylandAppImage": "AppImage does not install a privileged input service, so global input is unavailable on Wayland. No authorization is requested.",
+          "hideOnHoverWayland": "Unavailable on Wayland because global absolute cursor coordinates are not exposed."
         },
         "status": {
           "authorized": "Authorized",
           "adminEnabled": "Enabled",
           "authorize": "Go to Enable",
-          "viewGuide": "View Instructions"
+          "viewGuide": "View Instructions",
+          "unavailable": "Unavailable"
         },
         "buttons": {
           "openNow": "Open Now",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -60,7 +60,8 @@
           "autoCheckUpdate": "自动检查更新",
           "permissionsSettings": "权限设置",
           "inputMonitoringPermission": "输入监控权限",
-          "administratorPermission": "管理员身份"
+          "administratorPermission": "管理员身份",
+          "waylandInput": "Wayland 输入服务"
         },
         "options": {
           "auto": "跟随系统",
@@ -74,13 +75,18 @@
           "inputMonitoringPermissionGuide": "开启输入监控权限后，应用才能接收系统的键盘和鼠标事件，从而响应你的操作。\n\n操作方式：\n1. 打开「系统设置」→「隐私与安全性」→「输入监控」。\n2. 若列表中已存在 MochiPaw，请先选中它，点击「-」按钮将其删除。\n3. 点击「+」按钮，找到并添加 MochiPaw 应用。\n4. 重启应用，以确保权限正式生效。",
           "administratorPermission": "以管理员身份运行应用，可以更稳定地捕获部分系统级按键与输入事件。",
           "administratorPermissionGuide": "为了能更稳定地捕获部分系统级按键与输入事件，建议以管理员身份运行应用。\n\n操作方式：\n1. 先退出应用。\n2. 在资源管理器中找到应用的 exe 或快捷方式。\n3. 根据需要选择启动方式：\n   • 仅本次：右键并选择「以管理员身份运行」。\n   • 永久默认：右键 → 属性 → 兼容性选项卡 → 勾选「以管理员身份运行此程序」→ 确定。",
-          "administratorRelaunchFailed": "无法以管理员身份重启应用，请手动右键选择「以管理员身份运行」。"
+          "administratorRelaunchFailed": "无法以管理员身份重启应用，请手动右键选择「以管理员身份运行」。",
+          "waylandReady": "已安装的系统服务只发送标准化键盘、鼠标按键和相对鼠标移动事件。它不会记录、注入或传输输入内容。",
+          "waylandUnavailable": "Wayland 输入服务不可用，或安装软件包时未获授权。请安装 DEB 或 RPM 软件包后检查系统服务。X11 会继续使用内置输入后端。",
+          "waylandAppImage": "AppImage 不安装特权输入服务，因此在 Wayland 上无法使用全局输入，也不会请求授权。",
+          "hideOnHoverWayland": "Wayland 不提供全局绝对鼠标坐标，因此此功能不可用。"
         },
         "status": {
           "authorized": "已授权",
           "adminEnabled": "已启用",
           "authorize": "去授权",
-          "viewGuide": "查看操作说明"
+          "viewGuide": "查看操作说明",
+          "unavailable": "不可用"
         },
         "buttons": {
           "openNow": "前往开启",

--- a/src/pages/preference/components/cat/index.vue
+++ b/src/pages/preference/components/cat/index.vue
@@ -5,10 +5,11 @@
 
 <script setup lang="ts">
 import { Button, Divider, Flex, InputNumber, Select, Slider, SpaceAddon, SpaceCompact, Switch } from 'antdv-next'
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 
 import ProListItem from '@/components/pro-list-item/index.vue'
 import ProList from '@/components/pro-list/index.vue'
+import { useDeviceInputStatus } from '@/composables/useDeviceInputStatus'
 import { returnMainWindowToScreen } from '@/composables/useWindowState'
 import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
@@ -16,6 +17,13 @@ import { isWindows } from '@/utils/platform'
 
 const catStore = useCatStore()
 const modelStore = useModelStore()
+const { status: inputStatus } = useDeviceInputStatus()
+
+const hideOnHoverSupported = computed(() => inputStatus.value?.hoverSupported !== false)
+
+watch(hideOnHoverSupported, (supported) => {
+  if (!supported) catStore.window.hideOnHover = false
+}, { immediate: true })
 
 async function handleReturnToScreen() {
   await returnMainWindowToScreen()
@@ -163,11 +171,14 @@ const typingBehaviorGroupOptions = computed(() => {
     </ProListItem>
 
     <ProListItem
-      :description="$t('pages.preference.cat.hints.hideOnHover')"
+      :description="hideOnHoverSupported ? $t('pages.preference.cat.hints.hideOnHover') : $t('pages.preference.cat.hints.hideOnHoverWayland')"
       :title="$t('pages.preference.cat.labels.hideOnHover')"
     >
       <Flex align="center">
-        <Switch v-model:checked="catStore.window.hideOnHover" />
+        <Switch
+          v-model:checked="catStore.window.hideOnHover"
+          :disabled="!hideOnHoverSupported"
+        />
 
         <Flex
           align="center"

--- a/src/pages/preference/components/general/components/linux-input-status/index.vue
+++ b/src/pages/preference/components/general/components/linux-input-status/index.vue
@@ -1,0 +1,27 @@
+<!-- SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ -->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import ProListItem from '@/components/pro-list-item/index.vue'
+import { useDeviceInputStatus } from '@/composables/useDeviceInputStatus'
+
+const { status } = useDeviceInputStatus()
+
+const descriptionKey = computed(() => {
+  if (status.value?.backend === 'wayland-appimage') return 'pages.preference.general.hints.waylandAppImage'
+  if (status.value?.available) return 'pages.preference.general.hints.waylandReady'
+  return 'pages.preference.general.hints.waylandUnavailable'
+})
+</script>
+
+<template>
+  <ProListItem
+    :description="$t(descriptionKey)"
+    :title="$t('pages.preference.general.labels.waylandInput')"
+  >
+    <span>{{ status?.available ? $t('pages.preference.general.status.authorized') : $t('pages.preference.general.status.unavailable') }}</span>
+  </ProListItem>
+</template>

--- a/src/pages/preference/components/general/index.vue
+++ b/src/pages/preference/components/general/index.vue
@@ -11,9 +11,10 @@ import { watch } from 'vue'
 import ProListItem from '@/components/pro-list-item/index.vue'
 import ProList from '@/components/pro-list/index.vue'
 import { useGeneralStore } from '@/stores/general'
-import { isMac, isWindows } from '@/utils/platform'
+import { isLinux, isMac, isWindows } from '@/utils/platform'
 
 import Language from './components/language/index.vue'
+import LinuxInputStatus from './components/linux-input-status/index.vue'
 import MacosPermissions from './components/macos-permissions/index.vue'
 import ThemeMode from './components/theme-mode/index.vue'
 import WindowsPermissions from './components/windows-permissions/index.vue'
@@ -37,6 +38,13 @@ watch(() => generalStore.app.autostart, async (value) => {
   <MacosPermissions v-if="isMac" />
 
   <WindowsPermissions v-if="isWindows" />
+
+  <ProList
+    v-if="isLinux"
+    :title="$t('pages.preference.general.labels.permissionsSettings')"
+  >
+    <LinuxInputStatus />
+  </ProList>
 
   <ProList :title="$t('pages.preference.general.labels.appSettings')">
     <ProListItem :title="$t('pages.preference.general.labels.launchOnStartup')">

--- a/src/utils/subModelRuntime.ts
+++ b/src/utils/subModelRuntime.ts
@@ -15,9 +15,15 @@ export interface CursorPoint {
   y: number
 }
 
+export interface RelativeMouseMove {
+  dx: number
+  dy: number
+}
+
 export type DeviceInputEvent
   = | { kind: 'MousePress' | 'MouseRelease' | 'KeyboardPress' | 'KeyboardRelease', value: string }
     | { kind: 'MouseMove', value: CursorPoint }
+    | { kind: 'MouseRelativeMove', value: RelativeMouseMove }
 
 export interface GamepadInputEvent {
   kind: 'ButtonChanged' | 'AxisChanged'
@@ -90,6 +96,22 @@ export class SubModelInputCoordinator {
 
       if (index !== -1) {
         this.deviceEvents[index] = event
+      } else {
+        this.deviceEvents.push(event)
+      }
+    } else if (event.kind === 'MouseRelativeMove') {
+      const index = this.findLastIndex(this.deviceEvents, item => item.kind === 'MouseRelativeMove')
+
+      if (index !== -1) {
+        const previous = this.deviceEvents[index] as Extract<DeviceInputEvent, { kind: 'MouseRelativeMove' }>
+
+        this.deviceEvents[index] = {
+          kind: 'MouseRelativeMove',
+          value: {
+            dx: previous.value.dx + event.value.dx,
+            dy: previous.value.dy + event.value.dy,
+          },
+        }
       } else {
         this.deviceEvents.push(event)
       }


### PR DESCRIPTION
## Summary

- Add a privileged, session-validated evdev relay for Wayland DEB/RPM installations.
- Route Wayland input through the relay with relative mouse look support.
- Expose input capability status and package the systemd/Polkit integration.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml --lib core::device`
- `cargo check --manifest-path src-tauri/Cargo.toml --bin mochi-paw-inputd --features inputd`
- Targeted ESLint and JSON validation.

Native Linux cross-compilation was not completed because the local Rust target installer stalled.