### PR TITLE
fix(model): clean imports and fingerprint animations

### DIFF
--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -23,6 +23,12 @@ import type {
 
 import { INVOKE_KEY } from '@/constants'
 import { useModelStore } from '@/stores/model'
+import {
+  collectCubismResourceReferences,
+  createCubismFingerprint,
+  resolveCubismFingerprint,
+} from '@/utils/modelFingerprint'
+import { extractTemporaryImportSource, useImportSource } from '@/utils/modelImportSource'
 import { readNearestControlledRelease, readNearestProofManifest } from '@/utils/modelMetadata'
 import { join } from '@/utils/path'
 import { ensureRuntimeLease, reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
@@ -61,6 +67,10 @@ interface CubismModelJSON {
     Textures?: string[]
     Physics?: string
     DisplayInfo?: string
+    Expressions?: Array<{ File?: string }>
+    Motions?: Record<string, Array<{ File?: string, Sound?: string }>>
+    Pose?: string
+    UserData?: string
   }
 }
 
@@ -290,7 +300,17 @@ watch(selectPaths, async (paths) => {
 })
 
 async function importFromPath(fromPath: string) {
-  const sourcePath = await prepareImportSource(fromPath)
+  const source = await prepareImportSource(fromPath)
+
+  return await useImportSource(
+    source,
+    importFromSource,
+    path => remove(path, { recursive: true }),
+    error => console.warn('[mochi-paw] failed to clean temporary model import:', error),
+  )
+}
+
+async function importFromSource(sourcePath: string) {
   const variants = await discoverImportVariants(sourcePath)
 
   if (!variants.length) {
@@ -368,20 +388,21 @@ function createImportedModel(model: {
 async function prepareImportSource(fromPath: string) {
   const info = await stat(fromPath)
 
-  if (info.isDirectory) return fromPath
+  if (info.isDirectory) return { path: fromPath }
 
   if (!fromPath.toLowerCase().endsWith('.zip')) {
-    return await getModelDirectoryFromFile(fromPath)
+    return { path: await getModelDirectoryFromFile(fromPath) }
   }
 
   const importPath = join(await appDataDir(), 'model-imports', nanoid())
 
-  await invoke(INVOKE_KEY.EXTRACT_ZIP, {
+  return await extractTemporaryImportSource(
     fromPath,
-    toPath: importPath,
-  })
-
-  return importPath
+    importPath,
+    async (source, target) => invoke(INVOKE_KEY.EXTRACT_ZIP, { fromPath: source, toPath: target }),
+    path => remove(path, { recursive: true }),
+    error => console.warn('[mochi-paw] failed to clean failed model extraction:', error),
+  )
 }
 
 async function getModelDirectoryFromFile(filePath: string) {
@@ -597,7 +618,10 @@ async function getImportedFingerprints() {
   const fingerprints = new Set<string>()
 
   for (const model of modelStore.models) {
-    const fingerprint = model.fingerprint ?? await getModelFingerprint(model.path, model.mode).catch(() => undefined)
+    const fingerprint = await resolveCubismFingerprint(
+      model.fingerprint,
+      () => getModelFingerprint(model.path, model.mode),
+    ).catch(() => undefined)
 
     if (!fingerprint) continue
 
@@ -611,54 +635,17 @@ async function getImportedFingerprints() {
 async function getModelFingerprint(modelPath: string, mode: ModelMode) {
   const modelFile = await findModelFile(modelPath)
   const modelJSON = await readCubismModelJSON(modelFile)
-  const references = modelJSON.FileReferences
-  const files = [
-    { key: modelFile.split(/[\\/]/).at(-1) ?? 'model3.json', path: modelFile },
-    references?.Moc ? { key: references.Moc, path: join(modelPath, references.Moc) } : undefined,
-    references?.Physics ? { key: references.Physics, path: join(modelPath, references.Physics) } : undefined,
-    references?.DisplayInfo ? { key: references.DisplayInfo, path: join(modelPath, references.DisplayInfo) } : undefined,
-    ...references?.Textures?.map(texture => ({ key: texture, path: join(modelPath, texture) })) ?? [],
-  ].filter(file => file !== undefined)
-  const encoder = new TextEncoder()
-  const chunks: Uint8Array[] = []
-  let totalLength = 0
+  const files = collectCubismResourceReferences(modelFile, modelJSON)
 
-  for (const file of files) {
-    const keyBytes = encoder.encode(file.key)
+  return await createCubismFingerprint(mode, files, async (path) => {
+    if (!await exists(path)) return
 
-    chunks.push(keyBytes)
-    totalLength += keyBytes.length
-
-    if (!await exists(file.path)) continue
-
-    const fileBytes = await readFile(file.path)
-
-    chunks.push(fileBytes)
-    totalLength += fileBytes.length
-  }
-
-  const digest = await crypto.subtle.digest('SHA-256', concatBytes(chunks, totalLength))
-  const hash = [...new Uint8Array(digest)]
-    .map(value => value.toString(16).padStart(2, '0'))
-    .join('')
-
-  return `${mode}:${hash}`
+    return await readFile(path)
+  })
 }
 
 async function readCubismModelJSON(modelFile: string) {
   return JSON5.parse(await readTextFile(modelFile)) as CubismModelJSON
-}
-
-function concatBytes(chunks: Uint8Array[], totalLength: number) {
-  const bytes = new Uint8Array(totalLength)
-  let offset = 0
-
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset)
-    offset += chunk.length
-  }
-
-  return bytes
 }
 
 async function findModelFile(modelPath: string) {

--- a/src/utils/modelFingerprint.test.ts
+++ b/src/utils/modelFingerprint.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import {
+  collectCubismResourceReferences,
+  createCubismFingerprint,
+  isCurrentCubismFingerprint,
+  resolveCubismFingerprint,
+} from './modelFingerprint'
+
+const modelFile = '/models/cat.model3.json'
+
+function references() {
+  return collectCubismResourceReferences(modelFile, {
+    FileReferences: {
+      Moc: 'cat.moc3',
+      Textures: ['texture.png'],
+      Physics: 'cat.physics3.json',
+      DisplayInfo: 'cat.cdi3.json',
+      Expressions: [{ File: 'happy.exp3.json' }],
+      Motions: { Idle: [{ File: 'idle.motion3.json', Sound: 'idle.wav' }] },
+      Pose: 'cat.pose3.json',
+      UserData: 'cat.userdata3.json',
+    },
+  })
+}
+
+test('collects optional Cubism resources and skips absent references', () => {
+  const keys = references().map(resource => resource.key)
+
+  assert.deepEqual(keys, [
+    'model:cat.model3.json',
+    'moc:cat.moc3',
+    'physics:cat.physics3.json',
+    'displayInfo:cat.cdi3.json',
+    'pose:cat.pose3.json',
+    'userData:cat.userdata3.json',
+    'texture:texture.png',
+    'expression:happy.exp3.json',
+    'motion:Idle:idle.motion3.json',
+    'motionSound:Idle:idle.wav',
+  ])
+})
+
+test('fingerprint changes when motion, expression, or sound content changes', async () => {
+  const original = new Map(references().map(resource => [resource.path, new TextEncoder().encode(resource.key)]))
+  const fingerprint = async (changes: Record<string, string> = {}) => {
+    const files = new Map(original)
+    for (const [path, content] of Object.entries(changes)) {
+      files.set(path, new TextEncoder().encode(content))
+    }
+    return await createCubismFingerprint('standard', references(), async path => files.get(path))
+  }
+  const first = await fingerprint()
+  assert.equal(await fingerprint(), first)
+
+  const changedMotion = await fingerprint({ '/models/idle.motion3.json': 'changed' })
+  assert.notEqual(changedMotion, first)
+
+  const changedExpression = await fingerprint({ '/models/happy.exp3.json': 'changed' })
+  assert.notEqual(changedExpression, first)
+
+  const changedSound = await fingerprint({ '/models/idle.wav': 'changed' })
+  assert.notEqual(changedSound, first)
+})
+
+test('missing optional files produce a stable fingerprint', async () => {
+  const fingerprint = () => createCubismFingerprint('keyboard', references(), async () => undefined)
+
+  assert.equal(await fingerprint(), await fingerprint())
+})
+
+test('fingerprint version identifies current and legacy cache values', () => {
+  assert.equal(isCurrentCubismFingerprint('v2:standard:abc'), true)
+  assert.equal(isCurrentCubismFingerprint('standard:abc'), false)
+  assert.equal(isCurrentCubismFingerprint(undefined), false)
+})
+
+test('recalculates legacy fingerprints and reuses current fingerprints', async () => {
+  let calculations = 0
+  const calculate = async () => {
+    calculations += 1
+    return 'v2:standard:calculated'
+  }
+
+  assert.equal(await resolveCubismFingerprint('standard:legacy', calculate), 'v2:standard:calculated')
+  assert.equal(calculations, 1)
+  assert.equal(await resolveCubismFingerprint('v2:standard:cached', calculate), 'v2:standard:cached')
+  assert.equal(calculations, 1)
+})

--- a/src/utils/modelFingerprint.ts
+++ b/src/utils/modelFingerprint.ts
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+export interface CubismResourceReference {
+  key: string
+  path: string
+}
+
+export interface CubismModelReferences {
+  Moc?: string
+  Textures?: string[]
+  Physics?: string
+  DisplayInfo?: string
+  Expressions?: Array<{ File?: string }>
+  Motions?: Record<string, Array<{ File?: string, Sound?: string }>>
+  Pose?: string
+  UserData?: string
+}
+
+export interface CubismModelDocument {
+  FileReferences?: CubismModelReferences
+}
+
+export const CUBISM_FINGERPRINT_VERSION = 'v2'
+
+/** Collect every file whose content contributes to a Cubism model identity. */
+export function collectCubismResourceReferences(
+  modelFile: string,
+  modelJSON: CubismModelDocument,
+): CubismResourceReference[] {
+  const modelPath = modelFile.replace(/[\\/][^\\/]*$/, '')
+  const modelName = modelFile.split(/[\\/]/).at(-1) ?? 'model3.json'
+  const references = modelJSON.FileReferences
+  const files: CubismResourceReference[] = [{
+    key: `model:${modelName}`,
+    path: modelFile,
+  }]
+
+  const add = (type: string, path?: string) => {
+    if (!path) return
+    files.push({ key: `${type}:${path}`, path: joinResourcePath(modelPath, path) })
+  }
+
+  add('moc', references?.Moc)
+  add('physics', references?.Physics)
+  add('displayInfo', references?.DisplayInfo)
+  add('pose', references?.Pose)
+  add('userData', references?.UserData)
+
+  for (const texture of references?.Textures ?? []) add('texture', texture)
+  for (const expression of references?.Expressions ?? []) add('expression', expression.File)
+  for (const [group, motions] of Object.entries(references?.Motions ?? {})) {
+    for (const motion of motions ?? []) {
+      add(`motion:${group}`, motion.File)
+      add(`motionSound:${group}`, motion.Sound)
+    }
+  }
+
+  return files
+}
+
+export function isCurrentCubismFingerprint(value: string | undefined) {
+  return value?.startsWith(`${CUBISM_FINGERPRINT_VERSION}:`) ?? false
+}
+
+export async function resolveCubismFingerprint(
+  cached: string | undefined,
+  calculate: () => Promise<string>,
+) {
+  if (isCurrentCubismFingerprint(cached)) return cached
+
+  return await calculate()
+}
+
+export async function createCubismFingerprint(
+  mode: string,
+  references: CubismResourceReference[],
+  readResource: (path: string) => Promise<Uint8Array | undefined>,
+) {
+  const encoder = new TextEncoder()
+  const chunks: Uint8Array[] = []
+  let totalLength = 0
+
+  for (const resource of references) {
+    const keyBytes = encoder.encode(resource.key)
+    chunks.push(keyBytes)
+    totalLength += keyBytes.length
+
+    const bytes = await readResource(resource.path)
+    if (!bytes) continue
+
+    chunks.push(bytes)
+    totalLength += bytes.length
+  }
+
+  const input = new Uint8Array(totalLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    input.set(chunk, offset)
+    offset += chunk.length
+  }
+
+  const digest = await crypto.subtle.digest('SHA-256', input)
+  const hash = [...new Uint8Array(digest)]
+    .map(value => value.toString(16).padStart(2, '0'))
+    .join('')
+
+  return `${CUBISM_FINGERPRINT_VERSION}:${mode}:${hash}`
+}
+
+function joinResourcePath(directory: string, resource: string) {
+  const separator = directory.includes('\\') ? '\\' : '/'
+  return `${directory.replace(/[\\/]$/, '')}${separator}${resource.replace(/^[\\/]+/, '')}`
+}

--- a/src/utils/modelImportSource.test.ts
+++ b/src/utils/modelImportSource.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import { extractTemporaryImportSource, useImportSource } from './modelImportSource'
+
+for (const outcome of ['imported', 'duplicate'] as const) {
+  test(`cleans a ZIP source after an ${outcome} result`, async () => {
+    const cleaned: string[] = []
+    const result = await useImportSource(
+      { path: '/temp/import', temporaryDirectory: '/temp/import' },
+      async () => outcome,
+      async (path) => {
+        cleaned.push(path)
+      },
+      () => undefined,
+    )
+
+    assert.equal(result, outcome)
+    assert.deepEqual(cleaned, ['/temp/import'])
+  })
+}
+
+for (const failure of ['parse failed', 'copy failed']) {
+  test(`cleans a ZIP source when ${failure}`, async () => {
+    const cleaned: string[] = []
+
+    await assert.rejects(useImportSource(
+      { path: '/temp/import', temporaryDirectory: '/temp/import' },
+      async () => {
+        throw new Error(failure)
+      },
+      async (path) => {
+        cleaned.push(path)
+      },
+      () => undefined,
+    ), new RegExp(failure))
+    assert.deepEqual(cleaned, ['/temp/import'])
+  })
+}
+
+test('cleans partial extraction and preserves the extraction error', async () => {
+  const cleaned: string[] = []
+
+  await assert.rejects(extractTemporaryImportSource(
+    '/models/cat.zip',
+    '/temp/import',
+    async () => {
+      throw new Error('extract failed')
+    },
+    async (path) => {
+      cleaned.push(path)
+    },
+    () => undefined,
+  ), /extract failed/)
+  assert.deepEqual(cleaned, ['/temp/import'])
+})
+
+test('does not clean user-selected directories', async () => {
+  const cleaned: string[] = []
+
+  await useImportSource(
+    { path: '/models/cat' },
+    async () => undefined,
+    async (path) => {
+      cleaned.push(path)
+    },
+    () => undefined,
+  )
+  assert.deepEqual(cleaned, [])
+})
+
+test('cleanup failures are warnings and do not replace import results', async () => {
+  const warnings: unknown[] = []
+  const result = await useImportSource(
+    { path: '/temp/import', temporaryDirectory: '/temp/import' },
+    async () => 'imported',
+    async () => {
+      throw new Error('cleanup failed')
+    },
+    (error) => {
+      warnings.push(error)
+    },
+  )
+
+  assert.equal(result, 'imported')
+  assert.equal(warnings.length, 1)
+})

--- a/src/utils/modelImportSource.ts
+++ b/src/utils/modelImportSource.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+export interface ImportSource {
+  path: string
+  temporaryDirectory?: string
+}
+
+type Cleanup = (path: string) => Promise<void>
+type Warn = (error: unknown) => void
+
+export async function extractTemporaryImportSource(
+  fromPath: string,
+  temporaryDirectory: string,
+  extract: (fromPath: string, toPath: string) => Promise<void>,
+  cleanup: Cleanup,
+  warn: Warn,
+): Promise<ImportSource> {
+  try {
+    await extract(fromPath, temporaryDirectory)
+  } catch (error) {
+    await cleanup(temporaryDirectory).catch(warn)
+    throw error
+  }
+
+  return { path: temporaryDirectory, temporaryDirectory }
+}
+
+export async function useImportSource<T>(
+  source: ImportSource,
+  importSource: (path: string) => Promise<T>,
+  cleanup: Cleanup,
+  warn: Warn,
+) {
+  try {
+    return await importSource(source.path)
+  } finally {
+    if (source.temporaryDirectory) {
+      await cleanup(source.temporaryDirectory).catch(warn)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Clean ZIP extraction directories on every import outcome.
- Include Cubism expressions, motions, sounds, pose, and user data in versioned fingerprints.
- Recompute legacy fingerprints and cover resource collection with Node tests.

## Verification

- `pnpm exec tsx --test src/**/*.test.ts`
- `pnpm exec eslint src --no-fix` (passes with one pre-existing UnoCSS warning)
- `pnpm build:vite`

This PR is intentionally left open for review.