### PR TITLE
fix(windows): prevent admin launch conflicts

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,13 @@ use utils::fs_extra::{copy_dir, extract_zip};
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let app = tauri::Builder::default()
+        // This must run before other plugins can open shared resources. It is
+        // especially important when a second instance has a different integrity level.
+        .plugin(tauri_plugin_single_instance::init(
+            |app_handle, _argv, _cwd| {
+                show_preference_window(app_handle);
+            },
+        ))
         .setup(|app| {
             let app_handle = app.handle();
 
@@ -64,11 +71,6 @@ pub fn run() {
         .plugin(tauri_plugin_pinia::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(prevent_default::init())
-        .plugin(tauri_plugin_single_instance::init(
-            |app_handle, _argv, _cwd| {
-                show_preference_window(app_handle);
-            },
-        ))
         .plugin(
             tauri_plugin_log::Builder::new()
                 .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -34,9 +34,11 @@ fn run_admin_relaunch_helper() -> bool {
 
     let original_args = args.collect::<Vec<_>>();
 
-    wait_for_process_exit(parent_process_id);
+    let result =
+        wait_for_process_exit(parent_process_id).and_then(|_| relaunch_current_exe(&original_args));
 
-    if relaunch_current_exe(&original_args).is_err() {
+    if let Err(error) = result {
+        show_admin_relaunch_error(&error);
         std::process::exit(1);
     }
 
@@ -44,25 +46,88 @@ fn run_admin_relaunch_helper() -> bool {
 }
 
 #[cfg(target_os = "windows")]
-fn wait_for_process_exit(process_id: u32) {
+fn wait_for_process_exit(process_id: u32) -> Result<(), String> {
     if process_id == 0 {
-        return;
+        return Ok(());
     }
 
-    use windows::Win32::{
-        Foundation::CloseHandle,
-        System::Threading::{OpenProcess, WaitForSingleObject},
+    use windows::{
+        Win32::{
+            Foundation::{CloseHandle, ERROR_INVALID_PARAMETER},
+            System::Threading::{OpenProcess, WaitForSingleObject},
+        },
+        core::HRESULT,
     };
 
     const SYNCHRONIZE: windows::Win32::System::Threading::PROCESS_ACCESS_RIGHTS =
         windows::Win32::System::Threading::PROCESS_ACCESS_RIGHTS(0x0010_0000);
 
-    if let Ok(process) = unsafe { OpenProcess(SYNCHRONIZE, false, process_id) } {
-        unsafe {
-            let _ = WaitForSingleObject(process, 10_000);
-            let _ = CloseHandle(process);
+    let process = match unsafe { OpenProcess(SYNCHRONIZE, false, process_id) } {
+        Ok(process) => process,
+        // The original process can exit before the elevated helper opens it.
+        Err(error) if error.code() == HRESULT::from_win32(ERROR_INVALID_PARAMETER.0) => {
+            return Ok(());
         }
+        Err(error) => {
+            return Err(format!(
+                "Opening the existing MochiPaw process failed: {error}"
+            ));
+        }
+    };
+    let wait_result = unsafe { WaitForSingleObject(process, 10_000) };
+    unsafe {
+        let _ = CloseHandle(process);
     }
+
+    parse_process_wait_result(wait_result)
+}
+
+#[cfg(target_os = "windows")]
+fn parse_process_wait_result(
+    wait_result: windows::Win32::Foundation::WAIT_EVENT,
+) -> Result<(), String> {
+    use windows::Win32::Foundation::{WAIT_OBJECT_0, WAIT_TIMEOUT};
+
+    match wait_result {
+        WAIT_OBJECT_0 => Ok(()),
+        WAIT_TIMEOUT => Err("The existing MochiPaw process did not exit in time.".to_string()),
+        result => Err(format!(
+            "Waiting for the existing MochiPaw process failed with code {}.",
+            result.0
+        )),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn show_admin_relaunch_error(error: &str) {
+    use windows::{
+        Win32::UI::WindowsAndMessaging::{MB_ICONERROR, MB_OK, MessageBoxW},
+        core::PCWSTR,
+    };
+
+    let title = to_wide_str("MochiPaw administrator relaunch failed");
+    let message = to_wide_str(&format!(
+        "{error}\n\nClose every MochiPaw process in Task Manager, then try again."
+    ));
+
+    unsafe {
+        let _ = MessageBoxW(
+            None,
+            PCWSTR(message.as_ptr()),
+            PCWSTR(title.as_ptr()),
+            MB_OK | MB_ICONERROR,
+        );
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn to_wide_str(value: &str) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+
+    std::ffi::OsStr::new(value)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
 }
 
 #[cfg(target_os = "windows")]
@@ -83,4 +148,33 @@ fn relaunch_current_exe(args: &[std::ffi::OsString]) -> Result<(), String> {
         .spawn()
         .map(|_| ())
         .map_err(|error| error.to_string())
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::parse_process_wait_result;
+    use windows::Win32::Foundation::{WAIT_EVENT, WAIT_OBJECT_0, WAIT_TIMEOUT};
+
+    #[test]
+    fn accepts_parent_process_exit() {
+        assert!(parse_process_wait_result(WAIT_OBJECT_0).is_ok());
+    }
+
+    #[test]
+    fn rejects_parent_process_timeout() {
+        assert!(
+            parse_process_wait_result(WAIT_TIMEOUT)
+                .unwrap_err()
+                .contains("did not exit in time")
+        );
+    }
+
+    #[test]
+    fn rejects_unexpected_wait_result() {
+        assert!(
+            parse_process_wait_result(WAIT_EVENT(1))
+                .unwrap_err()
+                .contains("code 1")
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Initialize the single-instance plugin before every other Tauri plugin.
- Stop elevated relaunches when the existing process does not exit cleanly.
- Show a native error instead of silently starting another conflicting instance.
- Cover Windows process wait outcomes with unit tests.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml --bin mochi-paw`
- `cargo check --manifest-path src-tauri/Cargo.toml --bin mochi-paw`
- `rustfmt --edition 2024 --check src-tauri/src/main.rs`

Strict Clippy remains blocked by the pre-existing `needless_return` warning in the admin-status plugin.

Approved for merge as part of the v1.1.6-1 prerelease.