### PR TITLE
perf(windows): reduce idle WebView2 memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5644,10 +5644,12 @@ dependencies = [
 name = "tauri-plugin-custom-window"
 version = "0.1.0"
 dependencies = [
+ "futures-channel",
  "serde",
  "tauri",
  "tauri-nspanel",
  "tauri-plugin",
+ "webview2-com",
  "windows",
 ]
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,7 +17,8 @@ use core::{
 use tauri::{Manager, WindowEvent, generate_handler};
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_custom_window::{
-    MAIN_WINDOW_LABEL, PREFERENCE_WINDOW_LABEL, show_preference_window,
+    MAIN_WINDOW_LABEL, PREFERENCE_WINDOW_LABEL, WebviewMemoryTarget, request_webview_memory_target,
+    show_preference_window,
 };
 use utils::fs_extra::{copy_dir, extract_zip};
 
@@ -40,6 +41,8 @@ pub fn run() {
             let main_window = app.get_webview_window(MAIN_WINDOW_LABEL).unwrap();
 
             let preference_window = app.get_webview_window(PREFERENCE_WINDOW_LABEL).unwrap();
+
+            request_webview_memory_target(&preference_window, WebviewMemoryTarget::Low);
 
             setup::default(&app_handle, main_window.clone(), preference_window.clone());
 
@@ -88,6 +91,11 @@ pub fn run() {
         .plugin(tauri_plugin_self_protect::init())
         .on_window_event(|window, event| match event {
             WindowEvent::CloseRequested { api, .. } => {
+                if let Some(webview_window) = window.app_handle().get_webview_window(window.label())
+                {
+                    request_webview_memory_target(&webview_window, WebviewMemoryTarget::Low);
+                }
+
                 let _ = window.hide();
 
                 api.prevent_close();

--- a/src-tauri/src/plugins/window/Cargo.toml
+++ b/src-tauri/src/plugins/window/Cargo.toml
@@ -12,7 +12,7 @@ links = "tauri-plugin-custom-window"
 
 [dependencies]
 tauri.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 [build-dependencies]
 tauri-plugin.workspace = true
@@ -21,4 +21,6 @@ tauri-plugin.workspace = true
 tauri-nspanel.workspace = true
 
 [target."cfg(target_os = \"windows\")".dependencies]
+futures-channel = "0.3"
+webview2-com = "0.38"
 windows.workspace = true

--- a/src-tauri/src/plugins/window/build.rs
+++ b/src-tauri/src/plugins/window/build.rs
@@ -6,6 +6,7 @@ const COMMANDS: &[&str] = &[
     "hide_window",
     "set_always_on_top",
     "set_taskbar_visibility",
+    "set_webview_memory_target",
 ];
 
 fn main() {

--- a/src-tauri/src/plugins/window/permissions/default.toml
+++ b/src-tauri/src/plugins/window/permissions/default.toml
@@ -5,4 +5,4 @@
 
 [default]
 description = "Default permissions for the plugin"
-permissions = ["allow-show-window", "allow-hide-window", "allow-set-always-on-top", "allow-set-taskbar-visibility"]
+permissions = ["allow-show-window", "allow-hide-window", "allow-set-always-on-top", "allow-set-taskbar-visibility", "allow-set-webview-memory-target"]

--- a/src-tauri/src/plugins/window/src/commands/linux.rs
+++ b/src-tauri/src/plugins/window/src/commands/linux.rs
@@ -3,6 +3,8 @@
 
 use tauri::{AppHandle, Runtime, WebviewWindow, command};
 
+use super::WebviewMemoryTarget;
+
 #[command]
 pub async fn show_window<R: Runtime>(_app_handle: AppHandle<R>, window: WebviewWindow<R>) {
     let _ = window.show();
@@ -33,4 +35,18 @@ pub async fn set_always_on_top<R: Runtime>(
 #[command]
 pub async fn set_taskbar_visibility<R: Runtime>(window: WebviewWindow<R>, visible: bool) {
     let _ = window.set_skip_taskbar(!visible);
+}
+
+#[command]
+pub async fn set_webview_memory_target<R: Runtime>(
+    _window: WebviewWindow<R>,
+    _target: WebviewMemoryTarget,
+) -> bool {
+    false
+}
+
+pub fn request_webview_memory_target<R: Runtime>(
+    _window: &WebviewWindow<R>,
+    _target: WebviewMemoryTarget,
+) {
 }

--- a/src-tauri/src/plugins/window/src/commands/macos.rs
+++ b/src-tauri/src/plugins/window/src/commands/macos.rs
@@ -6,6 +6,8 @@ use crate::MAIN_WINDOW_LABEL;
 use tauri::{AppHandle, Runtime, WebviewWindow, command};
 use tauri_nspanel::{CollectionBehavior, ManagerExt, PanelLevel};
 
+use super::WebviewMemoryTarget;
+
 enum MacOSPanelStatus {
     Show,
     Hide,
@@ -108,4 +110,18 @@ pub async fn set_always_on_top<R: Runtime>(
 #[command]
 pub async fn set_taskbar_visibility<R: Runtime>(app_handle: AppHandle<R>, visible: bool) {
     let _ = app_handle.set_dock_visibility(visible);
+}
+
+#[command]
+pub async fn set_webview_memory_target<R: Runtime>(
+    _window: WebviewWindow<R>,
+    _target: WebviewMemoryTarget,
+) -> bool {
+    false
+}
+
+pub fn request_webview_memory_target<R: Runtime>(
+    _window: &WebviewWindow<R>,
+    _target: WebviewMemoryTarget,
+) {
 }

--- a/src-tauri/src/plugins/window/src/commands/mod.rs
+++ b/src-tauri/src/plugins/window/src/commands/mod.rs
@@ -1,10 +1,18 @@
 // SPDX-FileCopyrightText: 2026 InfinityXCat
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
+use serde::Deserialize;
 use tauri::{AppHandle, Manager, async_runtime::spawn};
 
 pub static MAIN_WINDOW_LABEL: &str = "main";
 pub static PREFERENCE_WINDOW_LABEL: &str = "preference";
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WebviewMemoryTarget {
+    Normal,
+    Low,
+}
 
 #[cfg(target_os = "macos")]
 mod macos;

--- a/src-tauri/src/plugins/window/src/commands/windows.rs
+++ b/src-tauri/src/plugins/window/src/commands/windows.rs
@@ -1,21 +1,29 @@
 // SPDX-FileCopyrightText: 2026 InfinityXCat
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
+use futures_channel::oneshot;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
-use tauri::{AppHandle, Runtime, WebviewWindow, command};
+use tauri::{AppHandle, Runtime, WebviewWindow, command, webview::PlatformWebview};
+use webview2_com::Microsoft::Web::WebView2::Win32::{
+    COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL, ICoreWebView2_19,
+};
 use windows::Win32::Foundation::HWND;
 use windows::Win32::UI::WindowsAndMessaging::{
     HWND_NOTOPMOST, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SetWindowPos,
 };
+use windows::core::Interface;
+
+use super::WebviewMemoryTarget;
 
 static TOPMOST_WINDOWS: OnceLock<Mutex<HashMap<isize, Arc<AtomicBool>>>> = OnceLock::new();
 
 #[command]
 pub async fn show_window<R: Runtime>(_app_handle: AppHandle<R>, window: WebviewWindow<R>) {
+    let _ = set_webview_memory_target(window.clone(), WebviewMemoryTarget::Normal).await;
     let _ = window.show();
     let _ = window.unminimize();
     let _ = window.set_focus();
@@ -23,6 +31,7 @@ pub async fn show_window<R: Runtime>(_app_handle: AppHandle<R>, window: WebviewW
 
 #[command]
 pub async fn hide_window<R: Runtime>(_app_handle: AppHandle<R>, window: WebviewWindow<R>) {
+    let _ = set_webview_memory_target(window.clone(), WebviewMemoryTarget::Low).await;
     let _ = window.hide();
 }
 
@@ -110,4 +119,46 @@ pub async fn set_always_on_top<R: Runtime>(
 #[command]
 pub async fn set_taskbar_visibility<R: Runtime>(window: WebviewWindow<R>, visible: bool) {
     let _ = window.set_skip_taskbar(!visible);
+}
+
+#[command]
+pub async fn set_webview_memory_target<R: Runtime>(
+    window: WebviewWindow<R>,
+    target: WebviewMemoryTarget,
+) -> bool {
+    let (sender, receiver) = oneshot::channel();
+    let scheduled = window.with_webview(move |webview| {
+        let _ = sender.send(apply_webview_memory_target(webview, target));
+    });
+
+    if scheduled.is_err() {
+        return false;
+    }
+
+    receiver.await.unwrap_or(false)
+}
+
+pub fn request_webview_memory_target<R: Runtime>(
+    window: &WebviewWindow<R>,
+    target: WebviewMemoryTarget,
+) {
+    let _ = window.with_webview(move |webview| {
+        apply_webview_memory_target(webview, target);
+    });
+}
+
+fn apply_webview_memory_target(webview: PlatformWebview, target: WebviewMemoryTarget) -> bool {
+    let level = match target {
+        WebviewMemoryTarget::Normal => COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL(0),
+        WebviewMemoryTarget::Low => COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL(1),
+    };
+
+    unsafe {
+        webview
+            .controller()
+            .CoreWebView2()
+            .and_then(|webview| webview.cast::<ICoreWebView2_19>())
+            .and_then(|webview| webview.SetMemoryUsageTargetLevel(level))
+            .is_ok()
+    }
 }

--- a/src-tauri/src/plugins/window/src/lib.rs
+++ b/src-tauri/src/plugins/window/src/lib.rs
@@ -17,6 +17,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::hide_window,
             commands::set_always_on_top,
             commands::set_taskbar_visibility,
+            commands::set_webview_memory_target,
         ])
         .build()
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,15 +12,17 @@ import { useEventListener } from '@vueuse/core'
 import { ConfigProvider, theme } from 'antdv-next'
 import { isString } from 'es-toolkit'
 import isURL from 'is-url'
-import { onMounted, watch } from 'vue'
+import { onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { RouterView } from 'vue-router'
+
+import type { DeviceInputEvent, SubModelInputFrame } from './utils/subModelRuntime'
 
 import { useTauriListen } from './composables/useTauriListen'
 import { useWindowState } from './composables/useWindowState'
 import { LANGUAGE, LISTEN_KEY } from './constants'
 import { getAntdLocale } from './locales/index.ts'
-import { hideWindow, showWindow } from './plugins/window'
+import { hideWindow, setWebviewMemoryTarget, showWindow } from './plugins/window'
 import { useAppStore } from './stores/app'
 import { useCatStore } from './stores/cat'
 import { useGeneralStore } from './stores/general'
@@ -28,6 +30,7 @@ import { useModelStore } from './stores/model'
 import { useShortcutStore } from './stores/shortcut.ts'
 import { getSubModelRuntimeCapacity } from './utils/subModelRuntime'
 import { openSubModelWindow } from './utils/subModelWindow'
+import { WebviewIdleMemoryController } from './utils/webviewIdleMemory'
 
 const appStore = useAppStore()
 const modelStore = useModelStore()
@@ -36,6 +39,7 @@ const generalStore = useGeneralStore()
 const shortcutStore = useShortcutStore()
 const appWindow = getCurrentWebviewWindow()
 const isSubModelWindow = appWindow.label.startsWith('sub-model-')
+const idleMemory = new WebviewIdleMemoryController({ setTarget: setWebviewMemoryTarget })
 const { isRestored, restoreState } = useWindowState({ enabled: !isSubModelWindow })
 const { darkAlgorithm, defaultAlgorithm } = theme
 const { locale } = useI18n()
@@ -50,6 +54,65 @@ function formatError(reason: unknown) {
 
   return JSON.stringify(reason, Object.getOwnPropertyNames(reason)) ?? String(reason)
 }
+
+function handleInputFrame(frame: SubModelInputFrame) {
+  const onlyMouseMoves = frame.deviceEvents.length > 0
+    && frame.gamepadEvents.length === 0
+    && frame.deviceEvents.every(event => event.kind === 'MouseMove')
+
+  if (onlyMouseMoves) {
+    idleMemory.mouseMove()
+  } else if (frame.deviceEvents.length || frame.gamepadEvents.length) {
+    idleMemory.activity()
+  }
+}
+
+let unlistenFocus: (() => void) | undefined
+let idleMemoryDisposed = false
+
+onMounted(async () => {
+  idleMemory.start(document.hidden)
+
+  const unlisten = await appWindow.onFocusChanged(({ payload: focused }) => {
+    if (focused) idleMemory.activate()
+  })
+
+  if (idleMemoryDisposed) {
+    unlisten()
+  } else {
+    unlistenFocus = unlisten
+  }
+})
+
+onUnmounted(() => {
+  idleMemoryDisposed = true
+  unlistenFocus?.()
+  idleMemory.dispose()
+})
+
+useEventListener(document, 'visibilitychange', () => {
+  idleMemory.setHidden(document.hidden)
+})
+
+useEventListener(window, 'keydown', () => idleMemory.activity())
+useEventListener(window, 'pointerdown', () => idleMemory.activity())
+useEventListener(window, 'pointermove', () => idleMemory.mouseMove())
+useEventListener(window, 'touchstart', () => idleMemory.activity(), { passive: true })
+useEventListener(window, 'wheel', () => idleMemory.activity(), { passive: true })
+
+useTauriListen<DeviceInputEvent>(LISTEN_KEY.DEVICE_CHANGED, ({ payload }) => {
+  if (payload.kind === 'MouseMove') {
+    idleMemory.mouseMove()
+  } else {
+    idleMemory.activity()
+  }
+})
+
+useTauriListen(LISTEN_KEY.GAMEPAD_CHANGED, () => idleMemory.activity())
+
+useTauriListen<SubModelInputFrame>(LISTEN_KEY.SUB_MODEL_INPUT_FRAME, ({ payload }) => {
+  handleInputFrame(payload)
+})
 
 onMounted(async () => {
   if (isSubModelWindow) {
@@ -103,12 +166,14 @@ watch(() => generalStore.appearance.language, (value) => {
 useTauriListen(LISTEN_KEY.SHOW_WINDOW, ({ payload }) => {
   if (appWindow.label !== payload) return
 
+  idleMemory.activate()
   showWindow()
 })
 
 useTauriListen(LISTEN_KEY.HIDE_WINDOW, ({ payload }) => {
   if (appWindow.label !== payload) return
 
+  idleMemory.setHidden(true)
   hideWindow()
 })
 

--- a/src/plugins/window.ts
+++ b/src/plugins/window.ts
@@ -12,12 +12,14 @@ import type { WINDOW_LABEL } from '../constants'
 import { LISTEN_KEY } from '../constants'
 
 export type WindowLabel = typeof WINDOW_LABEL[keyof typeof WINDOW_LABEL]
+export type WebviewMemoryTarget = 'normal' | 'low'
 
 const COMMAND = {
   SHOW_WINDOW: 'plugin:custom-window|show_window',
   HIDE_WINDOW: 'plugin:custom-window|hide_window',
   SET_ALWAYS_ON_TOP: 'plugin:custom-window|set_always_on_top',
   SET_TASKBAR_VISIBILITY: 'plugin:custom-window|set_taskbar_visibility',
+  SET_WEBVIEW_MEMORY_TARGET: 'plugin:custom-window|set_webview_memory_target',
 }
 
 function formatWindowError(error: unknown) {
@@ -72,4 +74,13 @@ export async function toggleWindowVisible(label?: WindowLabel) {
 
 export async function setTaskbarVisibility(visible: boolean) {
   return invoke(COMMAND.SET_TASKBAR_VISIBILITY, { visible }).catch(catchWindowError('taskbar'))
+}
+
+export async function setWebviewMemoryTarget(target: WebviewMemoryTarget): Promise<boolean> {
+  try {
+    return await invoke<boolean>(COMMAND.SET_WEBVIEW_MEMORY_TARGET, { target })
+  } catch (reason) {
+    catchWindowError('webview-memory-target')(reason)
+    return false
+  }
 }

--- a/src/utils/webviewIdleMemory.test.ts
+++ b/src/utils/webviewIdleMemory.test.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import type { WebviewMemoryTarget } from '@/plugins/window'
+
+import { WEBVIEW_IDLE_TIMEOUT, WebviewIdleMemoryController } from './webviewIdleMemory'
+
+class FakeTimers {
+  now = 0
+  private nextId = 1
+  private timers = new Map<number, { callback: () => void, dueAt: number }>()
+
+  setTimeout = (callback: () => void, delay: number) => {
+    const id = this.nextId++
+    this.timers.set(id, { callback, dueAt: this.now + delay })
+    return id as unknown as ReturnType<typeof setTimeout>
+  }
+
+  clearTimeout = (timer: ReturnType<typeof setTimeout>) => {
+    this.timers.delete(timer as unknown as number)
+  }
+
+  advanceBy(duration: number) {
+    const destination = this.now + duration
+
+    while (true) {
+      const next = [...this.timers.entries()]
+        .filter(([, timer]) => timer.dueAt <= destination)
+        .sort((left, right) => left[1].dueAt - right[1].dueAt)[0]
+
+      if (!next) break
+
+      const [id, timer] = next
+      this.now = timer.dueAt
+      this.timers.delete(id)
+      timer.callback()
+    }
+
+    this.now = destination
+  }
+}
+
+function createController() {
+  const timers = new FakeTimers()
+  const targets: WebviewMemoryTarget[] = []
+  const controller = new WebviewIdleMemoryController({
+    setTarget: async (target) => {
+      targets.push(target)
+      return true
+    },
+    now: () => timers.now,
+    setTimeout: timers.setTimeout,
+    clearTimeout: timers.clearTimeout,
+  })
+
+  return { controller, targets, timers }
+}
+
+test('switches to low after 60 seconds of inactivity', () => {
+  const { controller, targets, timers } = createController()
+  controller.start()
+
+  timers.advanceBy(WEBVIEW_IDLE_TIMEOUT - 1)
+  assert.deepEqual(targets, [])
+
+  timers.advanceBy(1)
+  assert.deepEqual(targets, ['low'])
+})
+
+test('input restores normal and resets the idle timeout', () => {
+  const { controller, targets, timers } = createController()
+  controller.start()
+  timers.advanceBy(WEBVIEW_IDLE_TIMEOUT)
+
+  controller.activity()
+  timers.advanceBy(WEBVIEW_IDLE_TIMEOUT - 1)
+  assert.deepEqual(targets, ['low', 'normal'])
+
+  timers.advanceBy(1)
+  assert.deepEqual(targets, ['low', 'normal', 'low'])
+})
+
+test('hidden windows switch to low immediately and restore when shown', () => {
+  const { controller, targets } = createController()
+  controller.start()
+
+  controller.setHidden(true)
+  controller.setHidden(false)
+
+  assert.deepEqual(targets, ['low', 'normal'])
+})
+
+test('deduplicates repeated target changes', () => {
+  const { controller, targets, timers } = createController()
+  controller.start()
+
+  controller.activity()
+  controller.activity()
+  controller.setHidden(true)
+  controller.setHidden(true)
+  controller.activity()
+  assert.deepEqual(targets, ['low'])
+
+  controller.activate()
+  controller.activity()
+  timers.advanceBy(WEBVIEW_IDLE_TIMEOUT)
+  assert.deepEqual(targets, ['low', 'normal', 'low'])
+})
+
+test('throttles repeated mouse movement', () => {
+  const { controller, targets, timers } = createController()
+  controller.start()
+
+  controller.mouseMove()
+  timers.advanceBy(500)
+  controller.mouseMove()
+  timers.advanceBy(WEBVIEW_IDLE_TIMEOUT - 500)
+
+  assert.deepEqual(targets, ['low'])
+})
+
+test('dispose clears the pending idle timer', () => {
+  const { controller, targets, timers } = createController()
+  controller.start()
+  controller.dispose()
+
+  timers.advanceBy(WEBVIEW_IDLE_TIMEOUT)
+  assert.deepEqual(targets, [])
+})
+
+test('uses browser timers with the global receiver', () => {
+  const originalSetTimeout = globalThis.setTimeout
+  const originalClearTimeout = globalThis.clearTimeout
+  const timer = {} as ReturnType<typeof setTimeout>
+
+  globalThis.setTimeout = function (this: typeof globalThis) {
+    assert.equal(this, globalThis)
+    return timer
+  } as typeof setTimeout
+  globalThis.clearTimeout = function (this: typeof globalThis, receivedTimer) {
+    assert.equal(this, globalThis)
+    assert.equal(receivedTimer, timer)
+  } as typeof clearTimeout
+
+  try {
+    const controller = new WebviewIdleMemoryController({ setTarget: async () => true })
+    controller.start()
+    controller.dispose()
+  } finally {
+    globalThis.setTimeout = originalSetTimeout
+    globalThis.clearTimeout = originalClearTimeout
+  }
+})

--- a/src/utils/webviewIdleMemory.ts
+++ b/src/utils/webviewIdleMemory.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import type { WebviewMemoryTarget } from '@/plugins/window'
+
+export const WEBVIEW_IDLE_TIMEOUT = 60_000
+export const WEBVIEW_MOUSE_MOVE_THROTTLE = 1_000
+
+export interface WebviewIdleMemoryOptions {
+  setTarget: (target: WebviewMemoryTarget) => Promise<boolean>
+  idleTimeout?: number
+  mouseMoveThrottle?: number
+  now?: () => number
+  setTimeout?: (callback: () => void, delay: number) => ReturnType<typeof setTimeout>
+  clearTimeout?: (timer: ReturnType<typeof setTimeout>) => void
+}
+
+export class WebviewIdleMemoryController {
+  private readonly setTarget: WebviewIdleMemoryOptions['setTarget']
+  private readonly idleTimeout: number
+  private readonly mouseMoveThrottle: number
+  private readonly now: () => number
+  private readonly scheduleTimeout: NonNullable<WebviewIdleMemoryOptions['setTimeout']>
+  private readonly cancelTimeout: NonNullable<WebviewIdleMemoryOptions['clearTimeout']>
+  private target: WebviewMemoryTarget = 'normal'
+  private idleTimer?: ReturnType<typeof setTimeout>
+  private lastMouseMoveAt?: number
+  private hidden = false
+  private disposed = false
+
+  constructor(options: WebviewIdleMemoryOptions) {
+    this.setTarget = options.setTarget
+    this.idleTimeout = options.idleTimeout ?? WEBVIEW_IDLE_TIMEOUT
+    this.mouseMoveThrottle = options.mouseMoveThrottle ?? WEBVIEW_MOUSE_MOVE_THROTTLE
+    this.now = options.now ?? Date.now
+    this.scheduleTimeout = options.setTimeout ?? ((callback, delay) => globalThis.setTimeout(callback, delay))
+    this.cancelTimeout = options.clearTimeout ?? (timer => globalThis.clearTimeout(timer))
+  }
+
+  start(hidden = false) {
+    if (this.disposed) return
+
+    this.hidden = hidden
+
+    if (hidden) {
+      this.changeTarget('low')
+    } else {
+      this.scheduleIdleTarget()
+    }
+  }
+
+  activity() {
+    if (this.disposed || this.hidden) return
+
+    this.changeTarget('normal')
+    this.scheduleIdleTarget()
+  }
+
+  mouseMove() {
+    if (this.disposed || this.hidden) return
+
+    const now = this.now()
+
+    if (this.lastMouseMoveAt !== undefined && now - this.lastMouseMoveAt < this.mouseMoveThrottle) return
+
+    this.lastMouseMoveAt = now
+    this.activity()
+  }
+
+  setHidden(hidden: boolean) {
+    if (this.disposed) return
+
+    this.hidden = hidden
+
+    if (hidden) {
+      this.clearIdleTimer()
+      this.changeTarget('low')
+    } else {
+      this.activity()
+    }
+  }
+
+  activate() {
+    if (this.disposed) return
+
+    this.hidden = false
+    this.activity()
+  }
+
+  dispose() {
+    if (this.disposed) return
+
+    this.disposed = true
+    this.clearIdleTimer()
+  }
+
+  private scheduleIdleTarget() {
+    this.clearIdleTimer()
+    this.idleTimer = this.scheduleTimeout(() => {
+      this.idleTimer = undefined
+      this.changeTarget('low')
+    }, this.idleTimeout)
+  }
+
+  private clearIdleTimer() {
+    if (this.idleTimer === undefined) return
+
+    this.cancelTimeout(this.idleTimer)
+    this.idleTimer = undefined
+  }
+
+  private changeTarget(target: WebviewMemoryTarget) {
+    if (this.target === target) return
+
+    this.target = target
+    void this.setTarget(target).catch(() => false)
+  }
+}


### PR DESCRIPTION
## Summary
- add a Windows WebView2 memory target command backed by ICoreWebView2_19
- switch every WebView to Low after 60 seconds of inactivity and restore Normal on input, focus, or show
- set hidden windows to Low immediately while preserving rendering quality, frame rate, audio, tray, shortcuts, and existing window behavior
- return false without disrupting the app when the WebView2 runtime does not support the interface

## Verification
- cargo check --workspace --all-targets
- cargo test --workspace
- pnpm exec tsx --test src/stores/model.test.ts src/utils/monitor.test.ts src/utils/windowPosition.test.ts src/utils/webviewIdleMemory.test.ts (13 passed)
- pnpm exec eslint src (0 errors; 1 pre-existing UnoCSS ordering warning)
- pnpm build:vite
- Windows development runtime completed startup, 75-second idle, input recovery, and shutdown without WebView command errors

## Runtime observation
A stabilized local run with the current Live2D workload measured 1931.1 MiB at Normal, 2055.7 MiB after 75 seconds idle, and 2081.7 MiB 10 seconds after interaction. The WebView2 API is best-effort and this run did not satisfy the working-set decrease criterion under continuous Live2D rendering; no active working-set trimming, rendering suspension, frame-rate reduction, or quality reduction was added to manufacture a decrease.