### PR TITLE
chore(release): prepare v1.1.6-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.5"
+version = "1.1.6-1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.5",
+  "version": "1.1.6-1",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.5"
+version = "1.1.6-1"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary

- Prepare the `v1.1.6-1` prerelease from current `master`.
- Include model import cleanup and versioned animation fingerprints from #65.
- Include Windows administrator relaunch conflict protection from #66.
- Include the best-effort idle WebView2 memory target from #67.
- Keep the Wayland input service in #64 out of this prerelease.

## Verification

- `pnpm exec tsx --test src/**/*.test.ts` (25 passed)
- `pnpm exec eslint src --no-fix` (0 errors; one pre-existing UnoCSS ordering warning)
- `pnpm build:vite`
- `cargo test --workspace`
- `cargo check --workspace --all-targets`

## Release behavior

The `v1.1.6-1` tag will create a draft prerelease. It will remain a draft until every platform build succeeds and the expected macOS, Windows, and Linux assets are attached.

The WebView2 memory target is best effort and does not guarantee a lower working set while Live2D rendering remains active.