### PR TITLE
chore(release): prepare v1.1.6-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.6-1"
+version = "1.1.6-2"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.6-1",
+  "version": "1.1.6-2",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.6-1"
+version = "1.1.6-2"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary

- Prepare the `v1.1.6-2` preview from current `master`.
- Include the Wayland privileged evdev input relay from #64 and build its Linux service binary before DEB/RPM packaging.
- Include model import cleanup and versioned animation fingerprints from #65.
- Include Windows administrator relaunch conflict protection from #66.
- Include the best-effort idle WebView2 memory target from #67.

## Verification

- `pnpm exec tsx --test src/**/*.test.ts` (25 passed)
- `pnpm exec eslint src --no-fix` (0 errors; one pre-existing UnoCSS ordering warning)
- `pnpm build:vite`
- `cargo test --workspace`
- `cargo check --workspace --all-targets`
- `cargo check --manifest-path src-tauri/Cargo.toml --bin mochi-paw-inputd --features inputd`

## Release behavior

The `v1.1.6-2` tag will create a draft prerelease. It will remain a draft until every platform build succeeds and all expected assets are attached.

The Wayland service is only packaged in DEB/RPM bundles. AppImage continues to report that global Wayland input is unavailable. The WebView2 memory target remains best effort and does not guarantee a lower working set while Live2D rendering remains active.