### PR TITLE
fix(ci): generate icons before Wayland service build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,6 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build Wayland input service
-        if: startsWith(matrix.platform, 'ubuntu')
-        run: cargo build --manifest-path src-tauri/Cargo.toml --release --features inputd --bin mochi-paw-inputd
-
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -77,6 +73,14 @@ jobs:
         run: |
           pnpm config set registry https://registry.npmjs.org
           pnpm install --no-frozen-lockfile
+
+      - name: Generate Tauri icons
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: pnpm build:icon
+
+      - name: Build Wayland input service
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: cargo build --manifest-path src-tauri/Cargo.toml --release --features inputd --bin mochi-paw-inputd
 
       - name: Generate contributors manifest
         run: pnpm generate:contributors


### PR DESCRIPTION
## Summary

- Generate Tauri icons before compiling the Linux-only Wayland input service.
- Keep the service binary build after front-end dependencies are installed.

## Verification

- `pnpm build:icon`
- `cargo check --manifest-path src-tauri/Cargo.toml --bin mochi-paw-inputd --features inputd`
- `git diff --check`

This fixes the `failed to open icon ... src-tauri/icons/32x32.png` failure observed in release run 30751691277.