### PR TITLE
fix(wayland): own login session fields for Linux CI

### DIFF
--- a/src-tauri/src/bin/mochi-paw-inputd.rs
+++ b/src-tauri/src/bin/mochi-paw-inputd.rs
@@ -113,6 +113,7 @@ mod linux {
                 .map_err(|error| format!("failed to inspect login session: {error}"))?;
             let fields = String::from_utf8_lossy(&output.stdout)
                 .lines()
+                .map(str::to_owned)
                 .collect::<Vec<_>>();
 
             if fields.len() < 3 || fields[0] != "yes" || !matches!(fields[1], "wayland" | "x11") {


### PR DESCRIPTION
## Summary\n- fix Rust E0716 in the Wayland input service session discovery\n- own loginctl fields before storing them in the vector\n\n## Validation\n- cargo check --manifest-path src-tauri/Cargo.toml --bin mochi-paw-inputd --features inputd\n- rustfmt --edition 2024 --check src-tauri/src/bin/mochi-paw-inputd.rs\n\nFixes Linux release CI run 30752312963 while preserving the v1.1.6-2 preview tag.