### PR TITLE
fix(wayland): match owned session fields as text

### DIFF
--- a/src-tauri/src/bin/mochi-paw-inputd.rs
+++ b/src-tauri/src/bin/mochi-paw-inputd.rs
@@ -116,7 +116,10 @@ mod linux {
                 .map(str::to_owned)
                 .collect::<Vec<_>>();
 
-            if fields.len() < 3 || fields[0] != "yes" || !matches!(fields[1], "wayland" | "x11") {
+            if fields.len() < 3
+                || fields[0] != "yes"
+                || !matches!(fields[1].as_str(), "wayland" | "x11")
+            {
                 continue;
             }
 


### PR DESCRIPTION
## Summary\n- fix the remaining Rust type mismatch after owning loginctl session fields\n- compare the owned session type via s_str()\n\n## Validation\n- cargo check --manifest-path src-tauri/Cargo.toml --bin mochi-paw-inputd --features inputd\n- rustfmt --edition 2024 --check src-tauri/src/bin/mochi-paw-inputd.rs\n\nFixes the Linux release CI failure in run 30752858816 and keeps the v1.1.6-2 preview version.