### PR TITLE
fix(linux): correct custom package file mappings

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -64,9 +64,9 @@
     "linux": {
       "deb": {
         "files": {
-          "../target/release/mochi-paw-inputd": "/usr/lib/mochi-paw/mochi-paw-inputd",
-          "packaging/linux/mochi-paw-inputd.service": "/usr/lib/systemd/system/mochi-paw-inputd.service",
-          "packaging/linux/com.catstack.mochipaw.inputd.policy": "/usr/share/polkit-1/actions/com.catstack.mochipaw.inputd.policy"
+          "/usr/lib/mochi-paw/mochi-paw-inputd": "../target/release/mochi-paw-inputd",
+          "/usr/lib/systemd/system/mochi-paw-inputd.service": "packaging/linux/mochi-paw-inputd.service",
+          "/usr/share/polkit-1/actions/com.catstack.mochipaw.inputd.policy": "packaging/linux/com.catstack.mochipaw.inputd.policy"
         },
         "postInstallScript": "packaging/linux/postinstall.sh",
         "preRemoveScript": "packaging/linux/preremove.sh",
@@ -74,9 +74,9 @@
       },
       "rpm": {
         "files": {
-          "../target/release/mochi-paw-inputd": "/usr/lib/mochi-paw/mochi-paw-inputd",
-          "packaging/linux/mochi-paw-inputd.service": "/usr/lib/systemd/system/mochi-paw-inputd.service",
-          "packaging/linux/com.catstack.mochipaw.inputd.policy": "/usr/share/polkit-1/actions/com.catstack.mochipaw.inputd.policy"
+          "/usr/lib/mochi-paw/mochi-paw-inputd": "../target/release/mochi-paw-inputd",
+          "/usr/lib/systemd/system/mochi-paw-inputd.service": "packaging/linux/mochi-paw-inputd.service",
+          "/usr/share/polkit-1/actions/com.catstack.mochipaw.inputd.policy": "packaging/linux/com.catstack.mochipaw.inputd.policy"
         },
         "postInstallScript": "packaging/linux/postinstall.sh",
         "preRemoveScript": "packaging/linux/preremove.sh",


### PR DESCRIPTION
## Summary\n- correct the Tauri deb/rpm iles mapping direction\n- keep the generated input service, systemd unit, and polkit policy in their intended package paths\n\n## Validation\n- tauri.conf.json parses as JSON\n- cargo check --manifest-path src-tauri/Cargo.toml --bin mochi-paw-inputd --features inputd\n- git diff --check\n\nFixes Linux packaging in release run 30753187488 and keeps the v1.1.6-2 preview version.