### PR TITLE
fix(windows): stabilize admin relaunch and shortcut updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.6-2"
+version = "1.1.6-3"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.6-5"
+version = "1.1.7"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.6-3"
+version = "1.1.6-4"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.6-4"
+version = "1.1.6-5"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.6-3",
+  "version": "1.1.6-4",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.6-4",
+  "version": "1.1.6-5",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.6-5",
+  "version": "1.1.7",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.6-2",
+  "version": "1.1.6-3",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.6-4"
+version = "1.1.6-5"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.6-3"
+version = "1.1.6-4"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.6-2"
+version = "1.1.6-3"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.6-5"
+version = "1.1.7"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"

--- a/src-tauri/src/plugins/admin-status/src/commands/mod.rs
+++ b/src-tauri/src/plugins/admin-status/src/commands/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 InfinityXCat
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
-use tauri::command;
+use tauri::{AppHandle, Runtime, command};
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -54,7 +54,7 @@ pub fn is_running_as_administrator() -> Result<bool, String> {
 }
 
 #[command]
-pub fn relaunch_as_administrator() -> Result<(), String> {
+pub fn relaunch_as_administrator<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         if is_running_as_administrator()? {
@@ -63,9 +63,12 @@ pub fn relaunch_as_administrator() -> Result<(), String> {
 
         schedule_windows_administrator_relaunch()?;
 
-        std::thread::spawn(|| {
+        // Give the elevated helper time to receive the UAC approval before
+        // asking Tauri to release the current instance and its plugins.
+        let app_handle = app.clone();
+        std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(100));
-            std::process::exit(0);
+            app_handle.exit(0);
         });
 
         Ok(())
@@ -73,6 +76,7 @@ pub fn relaunch_as_administrator() -> Result<(), String> {
 
     #[cfg(not(target_os = "windows"))]
     {
+        let _ = app;
         Ok(())
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@ import { useEventListener } from '@vueuse/core'
 import { ConfigProvider, theme } from 'antdv-next'
 import { isString } from 'es-toolkit'
 import isURL from 'is-url'
-import { onMounted, onUnmounted, watch } from 'vue'
+import { nextTick, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { RouterView } from 'vue-router'
 
@@ -29,6 +29,7 @@ import { useGeneralStore } from './stores/general'
 import { useModelStore } from './stores/model'
 import { useShortcutStore } from './stores/shortcut.ts'
 import { logError, logInfo, logStartupDiagnostics, logStep } from './utils/diagnostics'
+import { requestModelStoreSave } from './utils/modelPersistence'
 import { getSubModelRuntimeCapacity } from './utils/subModelRuntime'
 import { openSubModelWindow } from './utils/subModelWindow'
 import { WebviewIdleMemoryController } from './utils/webviewIdleMemory'
@@ -44,6 +45,41 @@ const idleMemory = new WebviewIdleMemoryController({ setTarget: setWebviewMemory
 const { isRestored, restoreState } = useWindowState({ enabled: !isSubModelWindow })
 const { darkAlgorithm, defaultAlgorithm } = theme
 const { locale } = useI18n()
+
+async function queueRecoveredModelCatalogPersistence(result: Awaited<ReturnType<typeof modelStore.init>>) {
+  logStep('model-persistence', 'queue recovered model catalog persistence', {
+    windowLabel: appWindow.label,
+    ...result,
+  })
+
+  try {
+    await nextTick()
+    await requestModelStoreSave()
+    logInfo('[model-persistence] recovered model catalog save queued', {
+      windowLabel: appWindow.label,
+      ...result,
+    })
+  } catch (error) {
+    logError('[model-persistence] failed to persist recovered model catalog', {
+      windowLabel: appWindow.label,
+      ...result,
+      error,
+    })
+  }
+}
+
+async function initializeModelStore() {
+  logStep('app-init', 'start model persistence', { windowLabel: appWindow.label })
+  await modelStore.$tauri.start()
+  logStep('app-init', 'initialize model store', { windowLabel: appWindow.label })
+  const result = await modelStore.init()
+
+  if (result.recoveredModelCount > 0) {
+    void queueRecoveredModelCatalogPersistence(result)
+  }
+
+  return result
+}
 
 void logStartupDiagnostics(appWindow.label).catch((error) => {
   logError('[startup] diagnostic collection failed', { windowLabel: appWindow.label, error })
@@ -122,10 +158,7 @@ useTauriListen<SubModelInputFrame>(LISTEN_KEY.SUB_MODEL_INPUT_FRAME, ({ payload 
 onMounted(async () => {
   logInfo('[app-init] started', { windowLabel: appWindow.label, isSubModelWindow })
   if (isSubModelWindow) {
-    logStep('app-init', 'start submodel persistence', { windowLabel: appWindow.label })
-    await modelStore.$tauri.start()
-    logStep('app-init', 'initialize model store', { windowLabel: appWindow.label })
-    await modelStore.init()
+    await initializeModelStore()
     await catStore.$tauri.start()
     logStep('app-init', 'initialize cat store', { windowLabel: appWindow.label })
     catStore.init()
@@ -141,10 +174,7 @@ onMounted(async () => {
   await appStore.$tauri.start()
   logStep('app-init', 'initialize app store', { windowLabel: appWindow.label })
   await appStore.init()
-  logStep('app-init', 'start model persistence', { windowLabel: appWindow.label })
-  await modelStore.$tauri.start()
-  logStep('app-init', 'initialize model store', { windowLabel: appWindow.label })
-  await modelStore.init()
+  await initializeModelStore()
   logStep('app-init', 'start cat persistence', { windowLabel: appWindow.label })
   await catStore.$tauri.start()
   logStep('app-init', 'initialize cat store', { windowLabel: appWindow.label })

--- a/src/composables/useKeyPress.ts
+++ b/src/composables/useKeyPress.ts
@@ -5,39 +5,92 @@
 import type { ShortcutHandler } from '@tauri-apps/plugin-global-shortcut'
 import type { Ref } from 'vue'
 
-import {
-  isRegistered,
-  register,
-  unregister,
-} from '@tauri-apps/plugin-global-shortcut'
-import { onUnmounted, ref, watch } from 'vue'
+import { message } from '@tauri-apps/plugin-dialog'
+import { onUnmounted, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { logError } from '@/utils/diagnostics'
+import { ShortcutConflictError, shortcutRegistry } from '@/utils/shortcutRegistry'
 
 export function useKeyPress(shortcut: Ref<string | undefined, string>, callback: ShortcutHandler) {
-  const oldShortcut = ref(shortcut.value)
+  const owner = Symbol('shortcut-binding')
+  const { t } = useI18n()
+  let disposed = false
+  let initialSync = true
+  let registeredShortcut: string | undefined
+  let lastAcceptedShortcut = normalizeShortcut(shortcut.value)
+  let rollbackShortcut: string | null = null
 
-  async function unbind() {
-    if (!oldShortcut.value) return
+  const handleShortcut = (event: Parameters<ShortcutHandler>[0]) => {
+    if (event.state === 'Released') return
 
-    const registered = await isRegistered(oldShortcut.value)
-
-    if (!registered) return
-
-    return unregister(oldShortcut.value)
+    callback(event)
   }
 
-  watch(shortcut, async (value) => {
-    await unbind()
+  async function showRegistrationError(error: unknown, value: string) {
+    const isConflict = error instanceof ShortcutConflictError
+    const description = isConflict
+      ? t('components.shortcut.hints.shortcutConflict', { shortcut: value })
+      : t('components.shortcut.hints.shortcutRegistrationFailed')
 
-    if (!value) return
+    try {
+      await message(description, {
+        kind: 'error',
+        title: t('components.shortcut.labels.shortcutRegistrationFailed'),
+      })
+    } catch (dialogError) {
+      logError('[shortcut] failed to show registration error', { error: dialogError })
+    }
+  }
 
-    await register(value, (event) => {
-      if (event.state === 'Released') return
+  async function syncShortcut(value: string, notifyOnError: boolean) {
+    try {
+      await shortcutRegistry.update(owner, value || undefined, handleShortcut)
+      registeredShortcut = value || undefined
+      lastAcceptedShortcut = value
+    } catch (error) {
+      logError('[shortcut] registration failed', {
+        error,
+        requestedShortcut: value,
+        previousShortcut: lastAcceptedShortcut,
+      })
 
-      callback(event)
-    })
+      if (notifyOnError && !disposed && normalizeShortcut(shortcut.value) === value) {
+        rollbackShortcut = lastAcceptedShortcut
+        shortcut.value = lastAcceptedShortcut
+        await showRegistrationError(error, value)
+      }
+    }
+  }
 
-    oldShortcut.value = value
+  const stop = watch(shortcut, (value) => {
+    const nextShortcut = normalizeShortcut(value)
+
+    if (rollbackShortcut !== null && rollbackShortcut === nextShortcut) {
+      rollbackShortcut = null
+      return
+    }
+
+    const notifyOnError = !initialSync
+    initialSync = false
+    void syncShortcut(nextShortcut, notifyOnError)
   }, { immediate: true })
 
-  onUnmounted(unbind)
+  onUnmounted(() => {
+    disposed = true
+    stop()
+
+    void shortcutRegistry.release(owner).then(() => {
+      registeredShortcut = undefined
+    }).catch((error: unknown) => {
+      logError('[shortcut] failed to unregister', {
+        error,
+        shortcut: registeredShortcut,
+      })
+    })
+  })
+}
+
+function normalizeShortcut(shortcut: string | undefined) {
+  return shortcut?.trim() ?? ''
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -20,6 +20,8 @@ export const LISTEN_KEY = {
   UPDATE_SUB_MODEL: 'update-sub-model',
   SUB_MODEL_RUNTIME_READY: 'sub-model-runtime-ready',
   SUB_MODEL_INPUT_FRAME: 'sub-model-input-frame',
+  MODEL_SWITCH_REQUESTED: 'model-switch-requested',
+  MODEL_SWITCH_APPLIED: 'model-switch-applied',
 }
 
 export const INVOKE_KEY = {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -102,6 +102,7 @@
           "deleteModel": "Delete Model",
           "customName": "Custom name",
           "selectedCount": "{count} models selected",
+          "cancelSelection": "Clear selection",
           "deleteSelected": "Delete selected models"
         },
         "hints": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -297,9 +297,14 @@
   },
   "components": {
     "shortcut": {
+      "labels": {
+        "shortcutRegistrationFailed": "Shortcut unavailable"
+      },
       "hints": {
         "pressRecordShortcut": "Press to record shortcut",
-        "clickRecordShortcut": "Click to record shortcut"
+        "clickRecordShortcut": "Click to record shortcut",
+        "shortcutConflict": "The shortcut {shortcut} is already assigned. The previous shortcut was restored.",
+        "shortcutRegistrationFailed": "The shortcut could not be registered. The previous shortcut was restored."
       }
     },
     "updateApp": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -100,11 +100,16 @@
         "title": "Model",
         "labels": {
           "deleteModel": "Delete Model",
-          "customName": "Custom name"
+          "customName": "Custom name",
+          "selectedCount": "{count} models selected",
+          "deleteSelected": "Delete selected models"
         },
         "hints": {
           "deleteSuccess": "Deleted Successfully",
           "deleteModel": "Are you sure you want to delete this model?",
+          "deleteSelectedModels": "Are you sure you want to delete the selected {count} models?",
+          "batchDeleteSuccess": "Successfully deleted {successCount} models",
+          "batchDeletePartial": "Successfully deleted {successCount} models. Failed to delete: {failedModels}",
           "importSuccess": "Imported Successfully",
           "alreadyImported": "Model already imported",
           "clickOrDragToImport": "Click or drag here to import",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -291,9 +291,14 @@
   },
   "components": {
     "shortcut": {
+      "labels": {
+        "shortcutRegistrationFailed": "Atalho indisponível"
+      },
       "hints": {
         "pressRecordShortcut": "Pressione as teclas para gravar atalho",
-        "clickRecordShortcut": "Clique para gravar atalho"
+        "clickRecordShortcut": "Clique para gravar atalho",
+        "shortcutConflict": "O atalho {shortcut} já está atribuído. O atalho anterior foi restaurado.",
+        "shortcutRegistrationFailed": "Não foi possível registrar o atalho. O atalho anterior foi restaurado."
       }
     },
     "updateApp": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -96,6 +96,7 @@
           "deleteModel": "Excluir modelo",
           "customName": "Nome personalizado",
           "selectedCount": "{count} modelos selecionados",
+          "cancelSelection": "Limpar seleção",
           "deleteSelected": "Excluir modelos selecionados"
         },
         "hints": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -94,11 +94,16 @@
         "title": "Modelo",
         "labels": {
           "deleteModel": "Excluir modelo",
-          "customName": "Nome personalizado"
+          "customName": "Nome personalizado",
+          "selectedCount": "{count} modelos selecionados",
+          "deleteSelected": "Excluir modelos selecionados"
         },
         "hints": {
           "deleteSuccess": "Excluído com sucesso",
           "deleteModel": "Tem certeza de que deseja excluir este modelo?",
+          "deleteSelectedModels": "Tem certeza de que deseja excluir os {count} modelos selecionados?",
+          "batchDeleteSuccess": "{successCount} modelos excluídos com sucesso",
+          "batchDeletePartial": "{successCount} modelos excluídos com sucesso. Falha ao excluir: {failedModels}",
           "importSuccess": "Importação bem-sucedida",
           "clickOrDragToImport": "Clique ou arraste para importar",
           "importing": "Importando {current}/{total}",

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -94,11 +94,16 @@
         "title": "Mô hình",
         "labels": {
           "deleteModel": "Xóa mô hình",
-          "customName": "Tên tùy chỉnh"
+          "customName": "Tên tùy chỉnh",
+          "selectedCount": "Đã chọn {count} mô hình",
+          "deleteSelected": "Xóa các mô hình đã chọn"
         },
         "hints": {
           "deleteSuccess": "Xóa thành công",
           "deleteModel": "Bạn chắc muốn xóa mô hình này?",
+          "deleteSelectedModels": "Bạn có chắc muốn xóa {count} mô hình đã chọn không?",
+          "batchDeleteSuccess": "Đã xóa thành công {successCount} mô hình",
+          "batchDeletePartial": "Đã xóa thành công {successCount} mô hình. Không thể xóa: {failedModels}",
           "importSuccess": "Nhập thành công",
           "clickOrDragToImport": "Nhấp hoặc kéo tệp vào đây",
           "importing": "Đang nhập {current}/{total}",

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -291,9 +291,14 @@
   },
   "components": {
     "shortcut": {
+      "labels": {
+        "shortcutRegistrationFailed": "Phím tắt không khả dụng"
+      },
       "hints": {
         "pressRecordShortcut": "Nhấn phím/tổ hợp phím để ghi",
-        "clickRecordShortcut": "Click để ghi phím tắt"
+        "clickRecordShortcut": "Click để ghi phím tắt",
+        "shortcutConflict": "Phím tắt {shortcut} đã được gán. Phím tắt trước đó đã được khôi phục.",
+        "shortcutRegistrationFailed": "Không thể đăng ký phím tắt. Phím tắt trước đó đã được khôi phục."
       }
     },
     "updateApp": {

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -96,6 +96,7 @@
           "deleteModel": "Xóa mô hình",
           "customName": "Tên tùy chỉnh",
           "selectedCount": "Đã chọn {count} mô hình",
+          "cancelSelection": "Bỏ chọn",
           "deleteSelected": "Xóa các mô hình đã chọn"
         },
         "hints": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -297,9 +297,14 @@
   },
   "components": {
     "shortcut": {
+      "labels": {
+        "shortcutRegistrationFailed": "快捷键不可用"
+      },
       "hints": {
         "pressRecordShortcut": "按下录制快捷键",
-        "clickRecordShortcut": "点击录制快捷键"
+        "clickRecordShortcut": "点击录制快捷键",
+        "shortcutConflict": "快捷键 {shortcut} 已被其他项目使用，已恢复之前的快捷键。",
+        "shortcutRegistrationFailed": "快捷键注册失败，已恢复之前的快捷键。"
       }
     },
     "updateApp": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -102,6 +102,7 @@
           "deleteModel": "删除模型",
           "customName": "自定义名称",
           "selectedCount": "已选择 {count} 个模型",
+          "cancelSelection": "取消选择",
           "deleteSelected": "删除所选模型"
         },
         "hints": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -100,11 +100,16 @@
         "title": "模型管理",
         "labels": {
           "deleteModel": "删除模型",
-          "customName": "自定义名称"
+          "customName": "自定义名称",
+          "selectedCount": "已选择 {count} 个模型",
+          "deleteSelected": "删除所选模型"
         },
         "hints": {
           "deleteSuccess": "删除成功",
           "deleteModel": "你确定要删除此模型吗？",
+          "deleteSelectedModels": "确定要删除选中的 {count} 个模型吗？",
+          "batchDeleteSuccess": "成功删除 {successCount} 个模型",
+          "batchDeletePartial": "成功删除 {successCount} 个模型，以下模型删除失败：{failedModels}",
           "importSuccess": "导入成功",
           "clickOrDragToImport": "点击或拖动至此区域导入",
           "importing": "正在导入 {current}/{total}",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -291,9 +291,14 @@
   },
   "components": {
     "shortcut": {
+      "labels": {
+        "shortcutRegistrationFailed": "快速鍵無法使用"
+      },
       "hints": {
         "pressRecordShortcut": "按下錄製快速鍵",
-        "clickRecordShortcut": "點擊錄製快速鍵"
+        "clickRecordShortcut": "點擊錄製快速鍵",
+        "shortcutConflict": "快速鍵 {shortcut} 已被其他項目使用，已恢復先前的快速鍵。",
+        "shortcutRegistrationFailed": "快速鍵註冊失敗，已恢復先前的快速鍵。"
       }
     },
     "updateApp": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -96,6 +96,7 @@
           "deleteModel": "刪除模型",
           "customName": "自訂名稱",
           "selectedCount": "已選擇 {count} 個模型",
+          "cancelSelection": "取消選擇",
           "deleteSelected": "刪除所選模型"
         },
         "hints": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -94,11 +94,16 @@
         "title": "模型管理",
         "labels": {
           "deleteModel": "刪除模型",
-          "customName": "自訂名稱"
+          "customName": "自訂名稱",
+          "selectedCount": "已選擇 {count} 個模型",
+          "deleteSelected": "刪除所選模型"
         },
         "hints": {
           "deleteSuccess": "刪除成功",
           "deleteModel": "您確定要刪除此模型嗎？",
+          "deleteSelectedModels": "您確定要刪除選取的 {count} 個模型嗎？",
+          "batchDeleteSuccess": "成功刪除 {successCount} 個模型",
+          "batchDeletePartial": "成功刪除 {successCount} 個模型，以下模型刪除失敗：{failedModels}",
           "importSuccess": "匯入成功",
           "clickOrDragToImport": "點擊或拖曳至此區域匯入",
           "importing": "正在匯入 {current}/{total}",

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -6,7 +6,7 @@
 <script setup lang="ts">
 import { convertFileSrc } from '@tauri-apps/api/core'
 import { PhysicalSize } from '@tauri-apps/api/dpi'
-import { emit } from '@tauri-apps/api/event'
+import { emit, emitTo } from '@tauri-apps/api/event'
 import { Menu, PredefinedMenuItem } from '@tauri-apps/api/menu'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { exists, readDir } from '@tauri-apps/plugin-fs'
@@ -16,7 +16,7 @@ import { round } from 'es-toolkit'
 import { computed, onMounted, onUnmounted, ref, toRaw, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
-import type { ModelMotionInfo, SubModelInstance } from '@/stores/model'
+import type { Model, ModelMotionInfo, ModelSwitchAcknowledgement, ModelSwitchRequest, SubModelInstance } from '@/stores/model'
 import type { SubModelInputFrame } from '@/utils/subModelRuntime'
 
 import { useAppMenu } from '@/composables/useAppMenu'
@@ -24,12 +24,12 @@ import { useDevice } from '@/composables/useDevice'
 import { useGamepad } from '@/composables/useGamepad'
 import { useModel } from '@/composables/useModel'
 import { useTauriListen } from '@/composables/useTauriListen'
-import { LISTEN_KEY } from '@/constants'
+import { LISTEN_KEY, WINDOW_LABEL } from '@/constants'
 import { hideWindow, setAlwaysOnTop, setTaskbarVisibility, showWindow } from '@/plugins/window'
 import { useCatStore } from '@/stores/cat'
 import { useGeneralStore } from '@/stores/general.ts'
 import { useModelStore } from '@/stores/model'
-import { logDebug, logError, logInfo, logStep, logTrace } from '@/utils/diagnostics'
+import { logDebug, logError, logInfo, logStep, logTrace, logWarn } from '@/utils/diagnostics'
 import { isImage } from '@/utils/is'
 import live2d from '@/utils/live2d'
 import { join } from '@/utils/path'
@@ -134,6 +134,7 @@ let scalingWithShortcut = false
 let scaleSyncTimer: ReturnType<typeof setTimeout> | undefined
 let lastShortcutResizeAt = 0
 let currentModelLoadVersion = 0
+const modelLoadTrigger = ref(0)
 
 const SCALE_DRAG_SENSITIVITY = 0.12
 const SHORTCUT_RESIZE_INTERVAL = 33
@@ -172,6 +173,96 @@ function applyWindowScale(scale: number, modelSizeValue = modelSize.value) {
     }),
   )
 }
+
+function modelKey(model: Model | undefined) {
+  return model ? `${model.id}:${model.path}` : ''
+}
+
+function resolveModelSwitchTarget(request: ModelSwitchRequest) {
+  const storedModel = modelStore.models.find(model => model.id === request.model.id)
+
+  if (!storedModel) {
+    const fallbackModel: Model = { ...request.model }
+    logWarn('[model-switch] target missing from main model list; using event snapshot', {
+      requestId: request.requestId,
+      modelId: fallbackModel.id,
+      modelPath: fallbackModel.path,
+    })
+    return fallbackModel
+  }
+
+  if (storedModel.path === request.model.path) return storedModel
+
+  const mergedModel = { ...storedModel, ...request.model }
+  logWarn('[model-switch] main model path differed from event snapshot', {
+    requestId: request.requestId,
+    modelId: mergedModel.id,
+    storedPath: storedModel.path,
+    requestedPath: mergedModel.path,
+  })
+  return mergedModel
+}
+
+function acknowledgeModelSwitch(acknowledgement: ModelSwitchAcknowledgement) {
+  void emitTo(WINDOW_LABEL.PREFERENCE, LISTEN_KEY.MODEL_SWITCH_APPLIED, acknowledgement)
+    .then(() => logStep('model-switch', 'sent acknowledgement to preference window', acknowledgement))
+    .catch(error => logError('[model-switch] failed to send acknowledgement', { ...acknowledgement, error }))
+}
+
+function requestModelLoad(reason: string, context: Record<string, unknown> = {}) {
+  modelLoadTrigger.value += 1
+  logStep('model-load', 'explicit load requested', {
+    ...context,
+    reason,
+    loadTrigger: modelLoadTrigger.value,
+  })
+}
+
+useTauriListen<ModelSwitchRequest>(LISTEN_KEY.MODEL_SWITCH_REQUESTED, ({ payload }) => {
+  const context = {
+    requestId: payload.requestId,
+    modelId: payload.model.id,
+    modelPath: payload.model.path,
+    modelMode: payload.model.mode,
+    isPreset: payload.model.isPreset,
+  }
+  logInfo('[model-switch] main window received request', context)
+
+  try {
+    const targetModel = resolveModelSwitchTarget(payload)
+    const previousModel = modelStore.currentModel
+
+    modelStore.modelReady = false
+    logStep('model-switch', 'main window set modelReady=false', context)
+
+    if (modelKey(previousModel) !== modelKey(targetModel)) {
+      logStep('model-switch', 'main window applied requested model', {
+        ...context,
+        previousModelId: previousModel?.id,
+        previousModelPath: previousModel?.path,
+      })
+      modelStore.currentModel = targetModel
+    } else {
+      logStep('model-switch', 'main window model already matches request', context)
+      requestModelLoad('model-switch event matched current model', context)
+    }
+
+    acknowledgeModelSwitch({
+      requestId: payload.requestId,
+      modelId: targetModel.id,
+      accepted: true,
+    })
+  } catch (error) {
+    logError('[model-switch] main window failed to apply request', { ...context, error })
+    modelStore.modelReady = true
+    acknowledgeModelSwitch({
+      requestId: payload.requestId,
+      modelId: payload.model.id,
+      accepted: false,
+      reason: String(error),
+    })
+  }
+})
 
 onMounted(() => {
   if (!isSubModel) startListening()
@@ -218,12 +309,20 @@ watch([() => {
   const model = activeModel.value
 
   return model ? `${model.id}:${model.path}` : ''
-}, live2dCanvas], async ([, canvas]) => {
+}, live2dCanvas, modelLoadTrigger], async ([, canvas, loadTrigger]) => {
   const model = activeModel.value
 
   // An immediate watcher can run before the component's canvas is mounted.
   // Watching the template ref retries the current model as soon as it exists.
-  if (!model || !canvas) return
+  if (!model || !canvas) {
+    logTrace('[model-load] watcher skipped because model or canvas is unavailable', {
+      windowLabel: appWindow.label,
+      hasModel: Boolean(model),
+      hasCanvas: Boolean(canvas),
+      loadTrigger,
+    })
+    return
+  }
 
   const loadVersion = ++currentModelLoadVersion
   const modelContext = {
@@ -235,6 +334,7 @@ watch([() => {
     isPreset: model.isPreset,
     importKind: model.importKind,
     proofStatus: model.proofStatus,
+    loadTrigger,
   }
 
   logInfo('[model-load] started', modelContext)

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -286,6 +286,7 @@ watch(selectPaths, async (paths) => {
   logInfo('[model-import] batch started', { count: paths.length, paths })
   importing.value = true
   importProgress.value = { current: 1, total: paths.length }
+  let importedModelCount = 0
 
   for (const [index, fromPath] of paths.entries()) {
     importProgress.value = { current: index + 1, total: paths.length }
@@ -306,7 +307,7 @@ watch(selectPaths, async (paths) => {
       }
 
       const previousModels = modelStore.models.slice()
-      modelStore.models.push(...result.models)
+      modelStore.models = [...modelStore.models, ...result.models]
 
       try {
         for (const model of result.models) {
@@ -344,7 +345,7 @@ watch(selectPaths, async (paths) => {
         throw error
       }
 
-      emit('imported')
+      importedModelCount += result.models.length
       logInfo('[model-import] selected path completed', { fromPath, modelCount: result.models.length })
       message.success(t('pages.preference.model.hints.importSuccess'))
     } catch (error) {
@@ -356,7 +357,13 @@ watch(selectPaths, async (paths) => {
   importing.value = false
   importProgress.value = { current: 0, total: 0 }
   selectPaths.value = []
-  logInfo('[model-import] batch completed', { count: paths.length })
+
+  if (importedModelCount > 0) {
+    await nextTick()
+    emit('imported')
+  }
+
+  logInfo('[model-import] batch completed', { count: paths.length, importedModelCount })
 })
 
 async function importFromPath(fromPath: string) {

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -11,7 +11,7 @@ import { copyFile, exists, mkdir, readDir, readFile, readTextFile, remove, stat 
 import { message } from 'antdv-next'
 import JSON5 from 'json5'
 import { nanoid } from 'nanoid'
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type {
@@ -31,6 +31,7 @@ import {
 } from '@/utils/modelFingerprint'
 import { extractTemporaryImportSource, useImportSource } from '@/utils/modelImportSource'
 import { readNearestControlledRelease, readNearestProofManifest } from '@/utils/modelMetadata'
+import { requestModelStoreSave } from '@/utils/modelPersistence'
 import { join } from '@/utils/path'
 import { ensureRuntimeLease, reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
 
@@ -304,17 +305,43 @@ watch(selectPaths, async (paths) => {
         continue
       }
 
-      for (const model of result.models) {
-        modelStore.models.push(model)
-        logStep('model-import', 'model added to store', {
+      const previousModels = modelStore.models.slice()
+      modelStore.models.push(...result.models)
+
+      try {
+        for (const model of result.models) {
+          logStep('model-import', 'model added to store', {
+            fromPath,
+            modelId: model.id,
+            modelPath: model.path,
+            mode: model.mode,
+            importKind: model.importKind,
+            proofStatus: model.proofStatus,
+          })
+          reportRuntimeEventQuietly(model, 'imported')
+        }
+
+        logStep('model-persistence', 'queue imported model catalog persistence', {
           fromPath,
-          modelId: model.id,
-          modelPath: model.path,
-          mode: model.mode,
-          importKind: model.importKind,
-          proofStatus: model.proofStatus,
+          modelIds: result.models.map(model => model.id),
+          modelCount: modelStore.models.length,
         })
-        reportRuntimeEventQuietly(model, 'imported')
+        await nextTick()
+        await requestModelStoreSave()
+        logInfo('[model-persistence] imported model catalog save queued', {
+          fromPath,
+          modelIds: result.models.map(model => model.id),
+          modelCount: modelStore.models.length,
+        })
+      } catch (error) {
+        modelStore.models = previousModels
+        logError('[model-persistence] failed to persist imported model catalog', {
+          fromPath,
+          modelIds: result.models.map(model => model.id),
+          error,
+        })
+
+        throw error
       }
 
       emit('imported')

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -9,7 +9,7 @@ import { exists, remove } from '@tauri-apps/plugin-fs'
 import { revealItemInDir } from '@tauri-apps/plugin-opener'
 import { useElementSize } from '@vueuse/core'
 import { Button, Card, Checkbox, Input, Masonry, message, Modal, Pagination, Popconfirm } from 'antdv-next'
-import { computed, ref, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { Model, ModelSwitchAcknowledgement, ModelSwitchRequest } from '@/stores/model'
@@ -39,6 +39,7 @@ const renameModelTarget = ref<Model>()
 const renameModelDraft = ref('')
 const selectedModelIds = ref(new Set<string>())
 const batchDeleting = ref(false)
+const masonryRefreshKey = ref(0)
 const pendingModelSwitches = new Map<string, (acknowledgement: ModelSwitchAcknowledgement) => void>()
 
 const PAGE_SIZE = 5
@@ -163,7 +164,7 @@ const currentPageModels = computed(() => {
 })
 
 const selectedModels = computed(() => {
-  return currentPageModels.value.filter(model => selectedModelIds.value.has(model.id))
+  return modelStore.models.filter(model => selectedModelIds.value.has(model.id))
 })
 
 const selectedModelCount = computed(() => selectedModels.value.length)
@@ -183,7 +184,6 @@ watch(pageCount, (count) => {
   currentPage.value = Math.min(currentPage.value, count)
 })
 
-watch(currentPage, clearSelection)
 watch(() => modelStore.currentModel?.id, deselectModel)
 
 function clearSelection() {
@@ -220,8 +220,10 @@ function toggleModelSelection(model: Model) {
   selectedModelIds.value = nextSelection
 }
 
-function showImportedModels() {
+async function showImportedModels() {
+  await nextTick()
   currentPage.value = pageCount.value
+  masonryRefreshKey.value += 1
   clearSelection()
 }
 
@@ -433,7 +435,7 @@ function confirmBatchDelete() {
       </div>
 
       <Masonry
-        :key="currentPage"
+        :key="`${currentPage}-${masonryRefreshKey}`"
         :columns="{ xs: 3, lg: 4, xxl: 6 }"
         :gutter="16"
         :items="masonryItems"

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -8,7 +8,7 @@ import { emitTo } from '@tauri-apps/api/event'
 import { exists, remove } from '@tauri-apps/plugin-fs'
 import { revealItemInDir } from '@tauri-apps/plugin-opener'
 import { useElementSize } from '@vueuse/core'
-import { Card, Input, Masonry, message, Modal, Pagination, Popconfirm } from 'antdv-next'
+import { Button, Card, Checkbox, Input, Masonry, message, Modal, Pagination, Popconfirm } from 'antdv-next'
 import { computed, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -37,6 +37,8 @@ const currentPage = ref(1)
 const renameModelOpen = ref(false)
 const renameModelTarget = ref<Model>()
 const renameModelDraft = ref('')
+const selectedModelIds = ref(new Set<string>())
+const batchDeleting = ref(false)
 const pendingModelSwitches = new Map<string, (acknowledgement: ModelSwitchAcknowledgement) => void>()
 
 const PAGE_SIZE = 5
@@ -155,9 +157,19 @@ const pageCount = computed(() => {
   return Math.max(1, Math.ceil(modelStore.models.length / PAGE_SIZE))
 })
 
-const masonryItems = computed(() => {
+const currentPageModels = computed(() => {
   const start = (currentPage.value - 1) * PAGE_SIZE
-  const items = modelStore.models.slice(start, start + PAGE_SIZE).map((item) => {
+  return modelStore.models.slice(start, start + PAGE_SIZE)
+})
+
+const selectedModels = computed(() => {
+  return currentPageModels.value.filter(model => selectedModelIds.value.has(model.id))
+})
+
+const selectedModelCount = computed(() => selectedModels.value.length)
+
+const masonryItems = computed(() => {
+  const items = currentPageModels.value.map((item) => {
     return {
       key: item.id,
       data: item,
@@ -171,8 +183,46 @@ watch(pageCount, (count) => {
   currentPage.value = Math.min(currentPage.value, count)
 })
 
+watch(currentPage, clearSelection)
+watch(() => modelStore.currentModel?.id, deselectModel)
+
+function clearSelection() {
+  selectedModelIds.value = new Set()
+}
+
+function deselectModel(modelId?: string) {
+  if (!modelId || !selectedModelIds.value.has(modelId)) return
+
+  const nextSelection = new Set(selectedModelIds.value)
+  nextSelection.delete(modelId)
+  selectedModelIds.value = nextSelection
+}
+
+function isCurrentModel(model: Model) {
+  return model.id === modelStore.currentModel?.id
+}
+
+function isModelSelected(model: Model) {
+  return selectedModelIds.value.has(model.id)
+}
+
+function toggleModelSelection(model: Model) {
+  if (model.isPreset || isCurrentModel(model) || batchDeleting.value) return
+
+  const nextSelection = new Set(selectedModelIds.value)
+
+  if (nextSelection.has(model.id)) {
+    nextSelection.delete(model.id)
+  } else {
+    nextSelection.add(model.id)
+  }
+
+  selectedModelIds.value = nextSelection
+}
+
 function showImportedModels() {
   currentPage.value = pageCount.value
+  clearSelection()
 }
 
 function waitForModelSwitchAcknowledgement(requestId: string) {
@@ -188,6 +238,11 @@ function waitForModelSwitchAcknowledgement(requestId: string) {
 }
 
 async function handleToggle(nextModel: Model) {
+  if (batchDeleting.value) {
+    logTrace('[model-switch] ignored selection during batch deletion', { modelId: nextModel.id })
+    return
+  }
+
   if (modelStore.currentModel?.id === nextModel.id) {
     logTrace('[model-switch] ignored selection of current model', { modelId: nextModel.id })
     return
@@ -256,16 +311,17 @@ async function handleToggle(nextModel: Model) {
   logInfo('[model-switch] requested model is now current', { modelId: nextModel.id, modelPath: nextModel.path })
 }
 
-async function handleDelete(item: Model) {
+async function removeModel(item: Model) {
   const { id, path } = item
-  const previousModels = modelStore.models
+  const previousModels = modelStore.models.slice()
   const previousCurrentModel = modelStore.currentModel
+  const previousModelReady = modelStore.modelReady
   const nextModels = previousModels.filter(model => model.id !== id)
-  const isCurrentModel = id === previousCurrentModel?.id
+  const deletingCurrentModel = id === previousCurrentModel?.id
 
   modelStore.models = nextModels
 
-  if (isCurrentModel) {
+  if (deletingCurrentModel) {
     modelStore.modelReady = false
     modelStore.currentModel = nextModels[0]
   }
@@ -281,23 +337,101 @@ async function handleDelete(item: Model) {
 
     await Promise.all(subModels.map(instance => destroySubModelWindow(instance.id)))
     modelStore.removeSubModelsByModelId(id)
-
-    message.success(t('pages.preference.model.hints.deleteSuccess'))
   } catch (error) {
     modelStore.models = previousModels
 
-    if (isCurrentModel) {
+    if (deletingCurrentModel) {
       modelStore.currentModel = previousCurrentModel
+      modelStore.modelReady = previousModelReady
     }
 
-    message.error(String(error))
+    throw error
   }
+}
+
+async function handleDelete(item: Model) {
+  if (batchDeleting.value) return
+
+  try {
+    await removeModel(item)
+    message.success(t('pages.preference.model.hints.deleteSuccess'))
+  } catch (error) {
+    message.error(String(error))
+  } finally {
+    clearSelection()
+  }
+}
+
+async function executeBatchDelete(items: Model[]) {
+  batchDeleting.value = true
+  let successCount = 0
+  const failedModels: string[] = []
+
+  try {
+    for (const item of items) {
+      try {
+        await removeModel(item)
+        successCount += 1
+      } catch (error) {
+        failedModels.push(modelTitle(item))
+        logError('[model-delete] batch item failed', { modelId: item.id, modelPath: item.path, error })
+      }
+    }
+
+    if (failedModels.length) {
+      message.error(t('pages.preference.model.hints.batchDeletePartial', {
+        failedModels: failedModels.join(', '),
+        successCount,
+      }))
+      return
+    }
+
+    message.success(t('pages.preference.model.hints.batchDeleteSuccess', { successCount }))
+  } finally {
+    batchDeleting.value = false
+    clearSelection()
+  }
+}
+
+function confirmBatchDelete() {
+  const items = selectedModels.value.filter(model => !isCurrentModel(model)).slice()
+
+  if (!items.length || batchDeleting.value) return
+
+  Modal.confirm({
+    content: t('pages.preference.model.hints.deleteSelectedModels', { count: items.length }),
+    okText: t('pages.preference.model.labels.deleteSelected'),
+    okType: 'danger',
+    onOk: () => executeBatchDelete(items),
+    title: t('pages.preference.model.labels.deleteSelected'),
+  })
 }
 </script>
 
 <template>
   <section class="model-manager">
     <div class="model-grid">
+      <div class="model-batch-actions">
+        <span
+          aria-live="polite"
+          class="model-selection-count"
+        >
+          {{ $t('pages.preference.model.labels.selectedCount', { count: selectedModelCount }) }}
+        </span>
+
+        <Button
+          danger
+          :disabled="selectedModelCount === 0 || batchDeleting"
+          :loading="batchDeleting"
+          @click="confirmBatchDelete"
+        >
+          <template #icon>
+            <i class="i-lucide:trash-2" />
+          </template>
+          {{ $t('pages.preference.model.labels.deleteSelected') }}
+        </Button>
+      </div>
+
       <Masonry
         :key="currentPage"
         :columns="{ xs: 3, lg: 4, xxl: 6 }"
@@ -328,7 +462,20 @@ async function handleDelete(item: Model) {
 
             <template #title>
               <div class="model-card-title">
-                <span class="model-title-text">{{ modelTitle(data) }}</span>
+                <div class="model-card-title-main">
+                  <span
+                    v-if="!data.isPreset"
+                    class="model-select-control"
+                    @click.stop
+                  >
+                    <Checkbox
+                      :checked="isModelSelected(data)"
+                      :disabled="isCurrentModel(data) || batchDeleting"
+                      @change="toggleModelSelection(data)"
+                    />
+                  </span>
+                  <span class="model-title-text">{{ modelTitle(data) }}</span>
+                </div>
                 <span class="model-proof-pill">{{ proofLabel(data) }}</span>
               </div>
             </template>
@@ -467,6 +614,24 @@ async function handleDelete(item: Model) {
   isolation: isolate;
 }
 
+.model-batch-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  min-height: 40px;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--ant-color-border);
+  border-radius: 6px;
+  background: var(--ant-color-fill-quaternary);
+}
+
+.model-selection-count {
+  color: var(--ant-color-text-secondary);
+  font-size: 13px;
+}
+
 .rename-model-field {
   display: flex;
   flex-direction: column;
@@ -492,6 +657,18 @@ async function handleDelete(item: Model) {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+}
+
+.model-card-title-main {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 8px;
+}
+
+.model-select-control {
+  display: inline-flex;
+  flex-shrink: 0;
 }
 
 .model-title-text {

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -422,6 +422,16 @@ function confirmBatchDelete() {
         </span>
 
         <Button
+          :disabled="selectedModelCount === 0 || batchDeleting"
+          @click="clearSelection"
+        >
+          <template #icon>
+            <i class="i-lucide:x" />
+          </template>
+          {{ $t('pages.preference.model.labels.cancelSelection') }}
+        </Button>
+
+        <Button
           danger
           :disabled="selectedModelCount === 0 || batchDeleting"
           :loading="batchDeleting"

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -316,31 +316,32 @@ async function handleToggle(nextModel: Model) {
 async function removeModel(item: Model) {
   const { id, path } = item
   const previousModels = modelStore.models.slice()
+  const previousSubModels = modelStore.subModels.slice()
   const previousCurrentModel = modelStore.currentModel
   const previousModelReady = modelStore.modelReady
   const nextModels = previousModels.filter(model => model.id !== id)
   const deletingCurrentModel = id === previousCurrentModel?.id
-
-  modelStore.models = nextModels
-
-  if (deletingCurrentModel) {
-    modelStore.modelReady = false
-    modelStore.currentModel = nextModels[0]
-  }
+  const subModels = previousSubModels.filter(instance => instance.modelId === id)
 
   try {
     await waitForFrames()
+
+    await Promise.all(subModels.map(instance => destroySubModelWindow(instance.id)))
+    modelStore.removeSubModelsByModelId(id)
 
     if (await exists(path)) {
       await remove(path, { recursive: true })
     }
 
-    const subModels = modelStore.subModels.filter(instance => instance.modelId === id)
+    modelStore.models = nextModels
 
-    await Promise.all(subModels.map(instance => destroySubModelWindow(instance.id)))
-    modelStore.removeSubModelsByModelId(id)
+    if (deletingCurrentModel) {
+      modelStore.modelReady = false
+      modelStore.currentModel = nextModels[0]
+    }
   } catch (error) {
     modelStore.models = previousModels
+    modelStore.subModels = previousSubModels
 
     if (deletingCurrentModel) {
       modelStore.currentModel = previousCurrentModel

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -4,6 +4,7 @@
  -->
 
 <script setup lang="ts">
+import { emitTo } from '@tauri-apps/api/event'
 import { exists, remove } from '@tauri-apps/plugin-fs'
 import { revealItemInDir } from '@tauri-apps/plugin-opener'
 import { useElementSize } from '@vueuse/core'
@@ -11,12 +12,15 @@ import { Card, Input, Masonry, message, Modal, Pagination, Popconfirm } from 'an
 import { computed, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import type { Model } from '@/stores/model'
+import type { Model, ModelSwitchAcknowledgement, ModelSwitchRequest } from '@/stores/model'
 
+import { useTauriListen } from '@/composables/useTauriListen'
+import { LISTEN_KEY, WINDOW_LABEL } from '@/constants'
 import { useCatStore } from '@/stores/cat'
 import { getModelDisplayName, useModelStore } from '@/stores/model'
 import { logError, logInfo, logStep, logTrace } from '@/utils/diagnostics'
-import { ensureRuntimeLease, reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
+import { withTimeout } from '@/utils/promise'
+import { ensureRuntimeLease } from '@/utils/runtimeTelemetry'
 import { destroySubModelWindow } from '@/utils/subModelWindow'
 
 import BehaviorModal from './components/behavior-modal/index.vue'
@@ -33,8 +37,23 @@ const currentPage = ref(1)
 const renameModelOpen = ref(false)
 const renameModelTarget = ref<Model>()
 const renameModelDraft = ref('')
+const pendingModelSwitches = new Map<string, (acknowledgement: ModelSwitchAcknowledgement) => void>()
 
 const PAGE_SIZE = 5
+const MODEL_SWITCH_ACK_TIMEOUT_MS = 5_000
+
+useTauriListen<ModelSwitchAcknowledgement>(LISTEN_KEY.MODEL_SWITCH_APPLIED, ({ payload }) => {
+  const resolve = pendingModelSwitches.get(payload.requestId)
+
+  if (!resolve) {
+    logTrace('[model-switch] received acknowledgement without pending request', payload)
+    return
+  }
+
+  pendingModelSwitches.delete(payload.requestId)
+  logStep('model-switch', 'received main window acknowledgement', payload)
+  resolve(payload)
+})
 
 function proofLabel(model: Model) {
   if (model.importKind === 'controlled') return t('pages.preference.model.proof.controlled')
@@ -156,6 +175,18 @@ function showImportedModels() {
   currentPage.value = pageCount.value
 }
 
+function waitForModelSwitchAcknowledgement(requestId: string) {
+  return withTimeout(
+    new Promise<ModelSwitchAcknowledgement>((resolve) => {
+      pendingModelSwitches.set(requestId, resolve)
+    }),
+    MODEL_SWITCH_ACK_TIMEOUT_MS,
+    `Main window did not acknowledge model switch within ${MODEL_SWITCH_ACK_TIMEOUT_MS / 1000} seconds.`,
+  ).finally(() => {
+    pendingModelSwitches.delete(requestId)
+  })
+}
+
 async function handleToggle(nextModel: Model) {
   if (modelStore.currentModel?.id === nextModel.id) {
     logTrace('[model-switch] ignored selection of current model', { modelId: nextModel.id })
@@ -163,6 +194,7 @@ async function handleToggle(nextModel: Model) {
   }
 
   const previousModel = modelStore.currentModel
+  const previousModelReady = modelStore.modelReady
   logInfo('[model-switch] requested', {
     previousModelId: previousModel?.id,
     previousModelPath: previousModel?.path,
@@ -183,15 +215,44 @@ async function handleToggle(nextModel: Model) {
     return
   }
 
-  logStep('model-switch', 'set modelReady=false', { modelId: nextModel.id })
-  modelStore.modelReady = false
-
   logStep('model-switch', 'update current model', {
     previousModelId: previousModel?.id,
     nextModelId: nextModel.id,
   })
   modelStore.currentModel = nextModel
-  reportRuntimeEventQuietly(nextModel, 'opened')
+
+  const request: ModelSwitchRequest = {
+    requestId: `${Date.now()}-${nextModel.id}`,
+    model: {
+      id: nextModel.id,
+      path: nextModel.path,
+      mode: nextModel.mode,
+      isPreset: nextModel.isPreset,
+      importKind: nextModel.importKind,
+      proofStatus: nextModel.proofStatus,
+    },
+  }
+
+  try {
+    const acknowledgement = waitForModelSwitchAcknowledgement(request.requestId)
+    logStep('model-switch', 'notify main window', request)
+    await emitTo(WINDOW_LABEL.MAIN, LISTEN_KEY.MODEL_SWITCH_REQUESTED, request)
+    logStep('model-switch', 'main window notification sent', request)
+    const result = await acknowledgement
+
+    if (!result.accepted) {
+      throw new Error(result.reason || 'Main window rejected the model switch.')
+    }
+
+    logStep('model-switch', 'main window accepted model switch', result)
+  } catch (error) {
+    modelStore.currentModel = previousModel
+    modelStore.modelReady = previousModelReady
+    logError('[model-switch] main window notification failed', { ...request, error })
+    message.error(String(error))
+    return
+  }
+
   logInfo('[model-switch] requested model is now current', { modelId: nextModel.id, modelPath: nextModel.path })
 }
 

--- a/src/stores/model.test.ts
+++ b/src/stores/model.test.ts
@@ -2,7 +2,22 @@ import assert from 'node:assert/strict'
 // eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
 import test from 'node:test'
 
-import { getModelDisplayName, getSubModelDisplayName } from './model'
+import { getModelDisplayName, getSubModelDisplayName, mergeModelCatalog } from './model'
+
+test('recovers custom model directories missing from persisted catalog', () => {
+  const persisted = [
+    { id: 'existing', path: 'C:/old/existing', mode: 'standard' as const, isPreset: false },
+  ]
+  const discovered = [
+    { id: 'existing', path: 'C:/app-data/existing', mode: 'standard' as const, isPreset: false },
+    { id: 'recovered', path: 'C:/app-data/recovered', mode: 'keyboard' as const, isPreset: false },
+  ]
+
+  assert.deepEqual(mergeModelCatalog(persisted, discovered), [
+    { id: 'existing', path: 'C:/app-data/existing', mode: 'standard', isPreset: false },
+    { id: 'recovered', path: 'C:/app-data/recovered', mode: 'keyboard', isPreset: false },
+  ])
+})
 
 test('uses custom, metadata, and internal model names in priority order', () => {
   assert.equal(getModelDisplayName({ id: 'preset-standard', displayName: 'Standard', customName: 'Desk cat' }), 'Desk cat')

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -75,6 +75,20 @@ export interface Model {
   runtimeLease?: ModelRuntimeLease
 }
 
+export type ModelSwitchSnapshot = Pick<Model, 'id' | 'path' | 'mode' | 'isPreset' | 'importKind' | 'proofStatus'>
+
+export interface ModelSwitchRequest {
+  requestId: string
+  model: ModelSwitchSnapshot
+}
+
+export interface ModelSwitchAcknowledgement {
+  requestId: string
+  modelId: string
+  accepted: boolean
+  reason?: string
+}
+
 export interface ModelSupportKeyLayer {
   path: string
   type: 'left' | 'right' | 'overlay'

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 InfinityXCat
 // SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
 
-import { resolveResource } from '@tauri-apps/api/path'
+import { appDataDir, resolveResource } from '@tauri-apps/api/path'
 import { readDir, readTextFile } from '@tauri-apps/plugin-fs'
 import { filter, find } from 'es-toolkit/compat'
 import JSON5 from 'json5'
@@ -12,6 +12,7 @@ import { reactive, ref } from 'vue'
 
 import type { ExpressionInfo, MotionInfo } from '@/vendor/easy-live2d'
 
+import { logInfo, logStep, logTrace } from '@/utils/diagnostics'
 import { readNearestControlledRelease, readNearestProofManifest } from '@/utils/modelMetadata'
 import { join } from '@/utils/path'
 
@@ -205,8 +206,20 @@ export const useModelStore = defineStore('model', () => {
   const init = async () => {
     const modelsPath = await resolveResource('assets/models')
 
-    const nextModels = filter(models.value, { isPreset: false })
+    const persistedCustomModels = filter(models.value, { isPreset: false })
     const presetModels = filter(models.value, { isPreset: true })
+    const customModelsPath = join(await appDataDir(), 'custom-models')
+    const discoveredCustomModels = await discoverStoredCustomModels(customModelsPath)
+    const nextModels = mergeModelCatalog(persistedCustomModels, discoveredCustomModels)
+    const persistedModelIds = new Set(persistedCustomModels.map(model => model.id))
+    const recoveredModelCount = discoveredCustomModels.filter(model => !persistedModelIds.has(model.id)).length
+
+    logStep('model-persistence', 'model catalog discovered', {
+      customModelsPath,
+      persistedCustomModelCount: persistedCustomModels.length,
+      discoveredCustomModelCount: discoveredCustomModels.length,
+      recoveredModelCount,
+    })
 
     await Promise.all(nextModels.map(fillModelMetadata))
 
@@ -232,6 +245,19 @@ export const useModelStore = defineStore('model', () => {
     currentModel.value = matched ?? nextModels[0]
 
     models.value = nextModels
+
+    logInfo('[model-persistence] model catalog initialized', {
+      modelCount: nextModels.length,
+      customModelCount: nextModels.filter(model => !model.isPreset).length,
+      recoveredModelCount,
+      currentModelId: currentModel.value?.id,
+    })
+
+    return {
+      modelCount: nextModels.length,
+      customModelCount: nextModels.filter(model => !model.isPreset).length,
+      recoveredModelCount,
+    }
   }
 
   const createSubModel = (modelId: string) => {
@@ -304,8 +330,75 @@ export const useModelStore = defineStore('model', () => {
 }, {
   tauri: {
     filterKeys: ['supportKeys', 'pressedKeys', 'activeKeys'],
+    saveInterval: 500,
+    saveStrategy: 'debounce',
   },
 })
+
+export function mergeModelCatalog(persistedModels: Model[], discoveredModels: Model[]) {
+  const discoveredById = new Map(discoveredModels.map(model => [model.id, model]))
+  const mergedModels = persistedModels.map((model) => {
+    const discoveredModel = discoveredById.get(model.id)
+
+    if (!discoveredModel) return model
+
+    return {
+      ...discoveredModel,
+      ...model,
+      path: discoveredModel.path,
+    }
+  })
+  const persistedIds = new Set(persistedModels.map(model => model.id))
+
+  return [
+    ...mergedModels,
+    ...discoveredModels.filter(model => !persistedIds.has(model.id)),
+  ]
+}
+
+async function discoverStoredCustomModels(customModelsPath: string) {
+  const entries = await readDir(customModelsPath).catch((error) => {
+    logTrace('[model-persistence] custom model directory unavailable', { customModelsPath, error })
+    return []
+  })
+  const discoveredModels: Model[] = []
+
+  for (const entry of entries) {
+    if (!entry.isDirectory || !entry.name) continue
+
+    const modelPath = join(customModelsPath, entry.name)
+    const modelFile = await findStoredModelFile(modelPath)
+
+    if (!modelFile) {
+      logTrace('[model-persistence] skipped custom model directory without model JSON', { modelPath })
+      continue
+    }
+
+    const model = {
+      id: entry.name,
+      displayName: await readStoredCubismModelName(modelFile),
+      path: modelPath,
+      mode: await inferStoredModelMode(modelPath),
+      isPreset: false,
+      importKind: 'standard' as const,
+      proofStatus: 'unsigned' as const,
+    }
+
+    discoveredModels.push(model)
+    logTrace('[model-persistence] discovered custom model directory', {
+      modelId: model.id,
+      modelPath,
+      mode: model.mode,
+    })
+  }
+
+  logInfo('[model-persistence] custom model directory scan completed', {
+    customModelsPath,
+    discoveredModelCount: discoveredModels.length,
+  })
+
+  return discoveredModels
+}
 
 async function fillModelMetadata(model: Model) {
   const proofManifest = await readNearestProofManifest(model.path)
@@ -352,6 +445,18 @@ async function findStoredModelFile(modelPath: string) {
   const modelFile = files.find(file => file.isFile && file.name.endsWith('.model3.json'))
 
   return modelFile ? join(modelPath, modelFile.name) : undefined
+}
+
+async function inferStoredModelMode(modelPath: string): Promise<ModelMode> {
+  const files = await readDir(join(modelPath, 'resources', 'right-keys')).catch((error) => {
+    logTrace('[model-persistence] failed to inspect model mode resources', { modelPath, error })
+    return []
+  })
+
+  if (!files.length) return 'standard'
+
+  const fileNames = files.map(file => file.name.split('.')[0])
+  return fileNames.includes('East') ? 'gamepad' : 'keyboard'
 }
 
 function normalizeDisplayName(value: unknown) {

--- a/src/utils/modelPersistence.ts
+++ b/src/utils/modelPersistence.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import { save } from '@tauri-store/pinia'
+
+const MODEL_STORE_ID = 'model'
+
+export function requestModelStoreSave() {
+  return save(MODEL_STORE_ID)
+}

--- a/src/utils/shortcutRegistry.test.ts
+++ b/src/utils/shortcutRegistry.test.ts
@@ -1,0 +1,121 @@
+import type { ShortcutHandler } from '@tauri-apps/plugin-global-shortcut'
+
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import { ShortcutConflictError, ShortcutRegistry } from './shortcutRegistry'
+
+const handler = (() => undefined) as ShortcutHandler
+
+function createAdapter() {
+  const registered = new Set<string>()
+  const calls: string[] = []
+  let activeOperations = 0
+  let maxActiveOperations = 0
+  let failingShortcut: string | undefined
+
+  const adapter = {
+    async register(shortcut: string, callback: ShortcutHandler) {
+      void callback
+      calls.push(`register:${shortcut}`)
+      activeOperations += 1
+      maxActiveOperations = Math.max(maxActiveOperations, activeOperations)
+      await new Promise(resolve => setTimeout(resolve, 1))
+
+      try {
+        if (shortcut === failingShortcut) {
+          throw new Error(`failed to register ${shortcut}`)
+        }
+
+        registered.add(shortcut)
+      } finally {
+        activeOperations -= 1
+      }
+    },
+    async unregister(shortcut: string) {
+      calls.push(`unregister:${shortcut}`)
+      activeOperations += 1
+      maxActiveOperations = Math.max(maxActiveOperations, activeOperations)
+      await new Promise(resolve => setTimeout(resolve, 1))
+
+      try {
+        registered.delete(shortcut)
+      } finally {
+        activeOperations -= 1
+      }
+    },
+  }
+
+  return {
+    adapter,
+    calls,
+    registered,
+    get maxActiveOperations() {
+      return maxActiveOperations
+    },
+    setFailingShortcut(value: string | undefined) {
+      failingShortcut = value
+    },
+  }
+}
+
+test('replaces a binding only after the new shortcut is registered', async () => {
+  const mock = createAdapter()
+  const registry = new ShortcutRegistry(mock.adapter)
+  const owner = Symbol('owner')
+
+  await registry.update(owner, 'Control+A', handler)
+  await registry.update(owner, 'Control+B', handler)
+
+  assert.deepEqual([...mock.registered], ['Control+B'])
+  assert.deepEqual(mock.calls, [
+    'register:Control+A',
+    'register:Control+B',
+    'unregister:Control+A',
+  ])
+})
+
+test('rejects a shortcut already owned by another binding', async () => {
+  const mock = createAdapter()
+  const registry = new ShortcutRegistry(mock.adapter)
+  const firstOwner = Symbol('first-owner')
+  const secondOwner = Symbol('second-owner')
+
+  await registry.update(firstOwner, 'F1', handler)
+
+  await assert.rejects(
+    registry.update(secondOwner, 'F1', handler),
+    error => error instanceof ShortcutConflictError && error.shortcut === 'F1',
+  )
+
+  assert.deepEqual([...mock.registered], ['F1'])
+})
+
+test('keeps the previous binding when the new registration fails', async () => {
+  const mock = createAdapter()
+  const registry = new ShortcutRegistry(mock.adapter)
+  const owner = Symbol('owner')
+
+  await registry.update(owner, 'F2', handler)
+  mock.setFailingShortcut('F3')
+
+  await assert.rejects(registry.update(owner, 'F3', handler), /failed to register F3/)
+
+  assert.deepEqual([...mock.registered], ['F2'])
+})
+
+test('serializes concurrent binding updates', async () => {
+  const mock = createAdapter()
+  const registry = new ShortcutRegistry(mock.adapter)
+  const firstOwner = Symbol('first-owner')
+  const secondOwner = Symbol('second-owner')
+
+  await Promise.all([
+    registry.update(firstOwner, 'F4', handler),
+    registry.update(secondOwner, 'F5', handler),
+  ])
+
+  assert.equal(mock.maxActiveOperations, 1)
+  assert.deepEqual([...mock.registered].sort(), ['F4', 'F5'])
+})

--- a/src/utils/shortcutRegistry.ts
+++ b/src/utils/shortcutRegistry.ts
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import type { ShortcutHandler } from '@tauri-apps/plugin-global-shortcut'
+
+import { register, unregister } from '@tauri-apps/plugin-global-shortcut'
+
+export interface ShortcutAdapter {
+  register: (shortcut: string, handler: ShortcutHandler) => Promise<void>
+  unregister: (shortcut: string) => Promise<void>
+}
+
+interface ShortcutBinding {
+  shortcut: string
+  handler: ShortcutHandler
+}
+
+export class ShortcutConflictError extends Error {
+  readonly shortcut: string
+
+  constructor(shortcut: string) {
+    super(`The shortcut is already assigned: ${shortcut}`)
+    this.name = 'ShortcutConflictError'
+    this.shortcut = shortcut
+  }
+}
+
+export class ShortcutRegistry {
+  private readonly bindings = new Map<symbol, ShortcutBinding>()
+  private readonly owners = new Map<string, symbol>()
+  private queue = Promise.resolve()
+
+  constructor(private readonly adapter: ShortcutAdapter) {}
+
+  update(owner: symbol, shortcut: string | undefined, handler: ShortcutHandler) {
+    return this.enqueue(async () => {
+      const nextShortcut = shortcut || undefined
+      const current = this.bindings.get(owner)
+
+      if (current && current.shortcut === nextShortcut) {
+        current.handler = handler
+        return
+      }
+
+      if (nextShortcut) {
+        const currentOwner = this.owners.get(nextShortcut)
+
+        if (currentOwner && currentOwner !== owner) {
+          throw new ShortcutConflictError(nextShortcut)
+        }
+
+        await this.adapter.register(nextShortcut, handler)
+      }
+
+      if (current) {
+        try {
+          await this.adapter.unregister(current.shortcut)
+        } catch (error) {
+          if (nextShortcut) {
+            await this.adapter.unregister(nextShortcut).catch(() => undefined)
+          }
+
+          throw error
+        }
+
+        this.owners.delete(current.shortcut)
+      }
+
+      if (!nextShortcut) {
+        this.bindings.delete(owner)
+        return
+      }
+
+      this.owners.set(nextShortcut, owner)
+      this.bindings.set(owner, {
+        shortcut: nextShortcut,
+        handler,
+      })
+    })
+  }
+
+  release(owner: symbol) {
+    return this.enqueue(async () => {
+      const current = this.bindings.get(owner)
+
+      if (!current) return
+
+      await this.adapter.unregister(current.shortcut)
+      this.owners.delete(current.shortcut)
+      this.bindings.delete(owner)
+    })
+  }
+
+  private enqueue<T>(operation: () => Promise<T>) {
+    const next = this.queue.then(operation, operation)
+    this.queue = next.then(() => undefined, () => undefined)
+    return next
+  }
+}
+
+export const shortcutRegistry = new ShortcutRegistry({
+  register,
+  unregister,
+})

--- a/src/vendor/easy-live2d/Framework/cubismmodelsettingjson.ts
+++ b/src/vendor/easy-live2d/Framework/cubismmodelsettingjson.ts
@@ -22,6 +22,10 @@ export enum FrequestNode {
   FrequestNode_HitAreas // getRoot().getValueByString(HitAreas)
 }
 
+function isPresentValue(value: Value | null | undefined): boolean {
+  return Boolean(value && !value.isNull() && !value.isError())
+}
+
 /**
  * Model3Jsonパーサー
  *
@@ -529,7 +533,7 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    */
   protected isExistModelFile(): boolean {
     const node: Value = this._jsonValue[FrequestNode.FrequestNode_Moc];
-    return !node.isNull() && !node.isError();
+    return isPresentValue(node);
   }
 
   /**
@@ -539,7 +543,7 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    */
   protected isExistTextureFiles(): boolean {
     const node: Value = this._jsonValue[FrequestNode.FrequestNode_Textures];
-    return !node.isNull() && !node.isError();
+    return isPresentValue(node);
   }
 
   /**
@@ -549,7 +553,7 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    */
   protected isExistHitAreas(): boolean {
     const node: Value = this._jsonValue[FrequestNode.FrequestNode_HitAreas];
-    return !node.isNull() && !node.isError();
+    return isPresentValue(node);
   }
 
   /**
@@ -559,7 +563,7 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    */
   protected isExistPhysicsFile(): boolean {
     const node: Value = this._jsonValue[FrequestNode.FrequestNode_Physics];
-    return !node.isNull() && !node.isError();
+    return isPresentValue(node);
   }
 
   /**
@@ -569,7 +573,7 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    */
   protected isExistPoseFile(): boolean {
     const node: Value = this._jsonValue[FrequestNode.FrequestNode_Pose];
-    return !node.isNull() && !node.isError();
+    return isPresentValue(node);
   }
 
   /**
@@ -579,7 +583,7 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    */
   protected isExistExpressionFile(): boolean {
     const node: Value = this._jsonValue[FrequestNode.FrequestNode_Expressions];
-    return !node.isNull() && !node.isError();
+    return isPresentValue(node);
   }
 
   /**
@@ -589,7 +593,7 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    */
   protected isExistMotionGroups(): boolean {
     const node: Value = this._jsonValue[FrequestNode.FrequestNode_Motions];
-    return !node.isNull() && !node.isError();
+    return isPresentValue(node);
   }
 
   /**
@@ -599,11 +603,9 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    * @return false キーが存在しない
    */
   protected isExistMotionGroupName(groupName: string): boolean {
-    const node: Value =
-      this._jsonValue[FrequestNode.FrequestNode_Motions].getValueByString(
-        groupName
-      );
-    return !node.isNull() && !node.isError();
+    const node: Value = this._jsonValue[FrequestNode.FrequestNode_Motions]
+      ?.getValueByString(groupName);
+    return isPresentValue(node);
   }
 
   /**
@@ -615,10 +617,10 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    */
   protected isExistMotionSoundFile(groupName: string, index: number): boolean {
     const node: Value = this._jsonValue[FrequestNode.FrequestNode_Motions]
-      .getValueByString(groupName)
-      .getValueByIndex(index)
-      .getValueByString(this.soundPath);
-    return !node.isNull() && !node.isError();
+      ?.getValueByString(groupName)
+      ?.getValueByIndex(index)
+      ?.getValueByString(this.soundPath);
+    return isPresentValue(node);
   }
 
   /**
@@ -630,10 +632,10 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    */
   protected isExistMotionFadeIn(groupName: string, index: number): boolean {
     const node: Value = this._jsonValue[FrequestNode.FrequestNode_Motions]
-      .getValueByString(groupName)
-      .getValueByIndex(index)
-      .getValueByString(this.fadeInTime);
-    return !node.isNull() && !node.isError();
+      ?.getValueByString(groupName)
+      ?.getValueByIndex(index)
+      ?.getValueByString(this.fadeInTime);
+    return isPresentValue(node);
   }
 
   /**
@@ -645,10 +647,10 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    */
   protected isExistMotionFadeOut(groupName: string, index: number): boolean {
     const node: Value = this._jsonValue[FrequestNode.FrequestNode_Motions]
-      .getValueByString(groupName)
-      .getValueByIndex(index)
-      .getValueByString(this.fadeOutTime);
-    return !node.isNull() && !node.isError();
+      ?.getValueByString(groupName)
+      ?.getValueByIndex(index)
+      ?.getValueByString(this.fadeOutTime);
+    return isPresentValue(node);
   }
 
   /**
@@ -660,8 +662,8 @@ export class CubismModelSettingJson extends ICubismModelSetting {
     const node: Value = this.getJson()
       .getRoot()
       .getValueByString(this.fileReferences)
-      .getValueByString(this.userData);
-    return !node.isNull() && !node.isError();
+      ?.getValueByString(this.userData);
+    return isPresentValue(node);
   }
 
   /**
@@ -670,24 +672,19 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    * @return false キーが存在しない
    */
   protected isExistEyeBlinkParameters(): boolean {
-    if (
-      this._jsonValue[FrequestNode.FrequestNode_Groups].isNull() ||
-      this._jsonValue[FrequestNode.FrequestNode_Groups].isError()
-    ) {
+    const groups = this._jsonValue[FrequestNode.FrequestNode_Groups];
+    if (!isPresentValue(groups)) {
       return false;
     }
 
     for (
       let i = 0;
-      i < this._jsonValue[FrequestNode.FrequestNode_Groups].getSize();
+      i < groups.getSize();
       ++i
     ) {
-      if (
-        this._jsonValue[FrequestNode.FrequestNode_Groups]
-          .getValueByIndex(i)
-          .getValueByString(this.name)
-          .getRawString() == this.eyeBlink
-      ) {
+      const group = groups.getValueByIndex(i);
+      const name = group?.getValueByString(this.name);
+      if (isPresentValue(name) && name.getRawString() == this.eyeBlink) {
         return true;
       }
     }
@@ -701,23 +698,18 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    * @return false キーが存在しない
    */
   protected isExistLipSyncParameters(): boolean {
-    if (
-      this._jsonValue[FrequestNode.FrequestNode_Groups].isNull() ||
-      this._jsonValue[FrequestNode.FrequestNode_Groups].isError()
-    ) {
+    const groups = this._jsonValue[FrequestNode.FrequestNode_Groups];
+    if (!isPresentValue(groups)) {
       return false;
     }
     for (
       let i = 0;
-      i < this._jsonValue[FrequestNode.FrequestNode_Groups].getSize();
+      i < groups.getSize();
       ++i
     ) {
-      if (
-        this._jsonValue[FrequestNode.FrequestNode_Groups]
-          .getValueByIndex(i)
-          .getValueByString(this.name)
-          .getRawString() == this.lipSync
-      ) {
+      const group = groups.getValueByIndex(i);
+      const name = group?.getValueByString(this.name);
+      if (isPresentValue(name) && name.getRawString() == this.lipSync) {
         return true;
       }
     }

--- a/src/vendor/easy-live2d/utils/cubismSetting.test.ts
+++ b/src/vendor/easy-live2d/utils/cubismSetting.test.ts
@@ -33,3 +33,24 @@ test('parses model resources used by 5.2 and 5.3 model3.json files', () => {
   assert.equal(setting.getPoseFileName(), 'model.pose3.json')
   assert.equal(setting.getUserDataFile(), 'model.userdata3.json')
 })
+
+test('treats optional model resources as absent without breaking path redirection', () => {
+  const setting = new CubismSetting({
+    modelJSON: {
+      Version: 3,
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['texture.png'],
+        Motions: {
+          Idle: [{ File: 'idle.motion3.json' }],
+        },
+      },
+    },
+  })
+
+  assert.equal(setting.getPhysicsFileName(), '')
+  assert.equal(setting.getPoseFileName(), '')
+  assert.equal(setting.getUserDataFile(), '')
+  assert.equal(setting.getHitAreasCount(), 0)
+  assert.doesNotThrow(() => setting.redirectPath(({ file }) => `/models/${file}`))
+})


### PR DESCRIPTION
## Summary
- use Tauri graceful shutdown when relaunching as administrator on Windows
- serialize global shortcut registration and reject conflicting bindings
- restore the previous shortcut when native registration fails
- add localized shortcut registration errors and focused registry tests

## Verification
- pnpm test
- pnpm exec tsc --noEmit
- pnpm exec eslint src
- pnpm run build:vite
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml