### PR TITLE
chore(release): prepare v1.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.7"
+version = "1.1.8"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary

- Bump package and Rust metadata from 1.1.7 to 1.1.8.
- Prepare the formal v1.1.8 release after the Windows administrator and shortcut reliability fixes in PR #76.

## What's New

- **Reliable Windows administrator relaunch:** Restarting as administrator from General settings now schedules the elevated helper and exits through Tauri's normal application lifecycle, releasing window, single-instance, and global-shortcut resources before the elevated instance starts. Cancelling UAC leaves the current instance running. (#76)
- **Reliable shortcut editing:** Global shortcut register and unregister operations are serialized, so changing several preference, motion, or expression shortcuts at the same time cannot race and invalidate each other's bindings. (#76)
- **Conflict-safe shortcut changes:** A shortcut already assigned to another MochiPaw action is rejected before native registration changes, and the previous configuration is restored. (#76)
- **Registration failure recovery:** If Windows or the native shortcut plugin rejects a new binding, the previous shortcut remains registered and the setting is rolled back with a localized error message. (#76)
- **Dynamic behavior cleanup:** Motion and expression shortcut bindings are released when their configuration items are removed, preventing stale global shortcuts after closing or rebuilding the behavior editor. (#76)

## Verification

- pnpm test (36 passing tests)
- pnpm exec tsc --noEmit
- cargo check --manifest-path src-tauri/Cargo.toml
- git diff --check

## Release behavior

The v1.1.8 tag will create the formal GitHub release after platform builds and expected assets are available.