### PR TITLE
fix(model): support Unicode paths and persist selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5969,6 +5969,7 @@ dependencies = [
  "dashmap",
  "futures",
  "itertools",
+ "semver",
  "serde",
  "serde_json",
  "tauri",
@@ -5996,6 +5997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baed2bbdce143a0b6e8105a0c9c7d9bfaa9c5689c3632bff12085c7209365d3f"
 dependencies = [
  "bon",
+ "semver",
  "serde",
  "serde_json",
  "tauri",

--- a/scripts/packagePortable.mjs
+++ b/scripts/packagePortable.mjs
@@ -6,7 +6,7 @@ import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, resolve } from 'node:path'
-import { arch, argv, pid, platform } from 'node:process'
+import { arch, argv, execPath, pid, platform } from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -17,7 +17,7 @@ const targetDir = target ? resolve(rootDir, 'target', target) : resolve(rootDir,
 const releaseDir = resolve(targetDir, 'release')
 const bundleDir = resolve(releaseDir, 'bundle', 'portable')
 const portableConfigPath = resolve(rootDir, 'target', 'portable-tauri.conf.json')
-const tauriCliPath = resolve(rootDir, 'node_modules', '.bin', 'tauri.CMD')
+const tauriCliPath = resolve(rootDir, 'node_modules', '@tauri-apps', 'cli', 'tauri.js')
 const sourceAssetsDir = resolve(rootDir, 'src-tauri', 'assets')
 const packageJson = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf-8'))
 const tauriConfig = JSON.parse(readFileSync(resolve(rootDir, 'src-tauri', 'tauri.conf.json'), 'utf-8'))
@@ -37,28 +37,6 @@ if (targetIndex !== -1 && !target) {
 
 function quotePowerShell(value) {
   return `'${value.replace(/'/g, '\'\'')}'`
-}
-
-function quoteCommand(value) {
-  return `"${value.replace(/"/g, '\\"')}"`
-}
-
-function run(command, options = {}) {
-  const result = spawnSync(command, {
-    cwd: rootDir,
-    shell: true,
-    stdio: 'inherit',
-  })
-
-  if (result.status && !options.allowFailure) {
-    throw new Error(`Command failed with exit code ${result.status}: ${command}`)
-  }
-
-  if (result.error && !options.allowFailure) {
-    throw result.error
-  }
-
-  return result
 }
 
 function runPowerShell(command) {
@@ -109,8 +87,12 @@ writeFileSync(portableConfigPath, JSON.stringify({
 if (!skipBuild) {
   rmSync(exePath, { force: true })
   rmSync(legacyExePath, { force: true })
-  const targetArg = target ? ` --target ${quoteCommand(target)}` : ''
-  run(`${quoteCommand(tauriCliPath)} build --no-bundle${targetArg} --config ${quoteCommand(portableConfigPath)}`)
+  const args = ['build', '--no-bundle']
+
+  if (target) args.push('--target', target)
+  args.push('--config', portableConfigPath)
+
+  runFile(execPath, [tauriCliPath, ...args])
 }
 
 const builtExePath = existsSync(exePath) ? exePath : legacyExePath

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,7 +40,7 @@ tauri-plugin-self-protect = { path = "src/plugins/self-protect" }
 tauri-plugin-os = "2"
 tauri-plugin-process = "2"
 tauri-plugin-opener = "2"
-tauri-plugin-pinia = "3"
+tauri-plugin-pinia = { version = "3", features = ["unstable-migration"] }
 tauri-plugin-log = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-prevent-default = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,66 @@ use tauri_plugin_custom_window::{
 };
 use utils::fs_extra::{copy_dir, extract_zip};
 
+const MODEL_STORE_SCHEMA_VERSION: u64 = 2;
+
+fn migrate_model_store_state(
+    state: &mut tauri_plugin_pinia::StoreState,
+) -> tauri_plugin_pinia::Result<()> {
+    let legacy_current_model = state.get("currentModel").cloned();
+    let mut selection_migration_pending = false;
+
+    if !state.has("currentModelId") {
+        if let Some(model_id) = legacy_current_model
+            .as_ref()
+            .and_then(|model| model.get("id"))
+            .and_then(serde_json::Value::as_str)
+        {
+            state.set("currentModelId", model_id);
+            selection_migration_pending = true;
+        }
+    }
+
+    if !state.has("currentModelFingerprint") {
+        if let Some(fingerprint) = legacy_current_model
+            .as_ref()
+            .and_then(|model| model.get("fingerprint"))
+            .and_then(serde_json::Value::as_str)
+        {
+            state.set("currentModelFingerprint", fingerprint);
+        }
+    }
+
+    if selection_migration_pending {
+        state.set("selectionMigrationPending", true);
+    }
+
+    if let Some(serde_json::Value::Array(models)) = state.get_mut("models") {
+        for model in models {
+            if let Some(model) = model.as_object_mut() {
+                model.remove("runtimeLease");
+            }
+        }
+    }
+
+    state.retain(|key, _| {
+        matches!(
+            key.as_str(),
+            "schemaVersion"
+                | "currentModelId"
+                | "currentModelFingerprint"
+                | "selectionMigrationPending"
+                | "models"
+                | "shortcuts"
+                | "behaviorNames"
+                | "behaviorGroups"
+                | "subModels"
+        )
+    });
+    state.set("schemaVersion", MODEL_STORE_SCHEMA_VERSION);
+
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let app = tauri::Builder::default()
@@ -72,7 +132,14 @@ pub fn run() {
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_pinia::init())
+        .plugin(
+            tauri_plugin_pinia::Builder::default()
+                .migration(
+                    "model",
+                    tauri_plugin_pinia::Migration::new("2.0.0", migrate_model_store_state),
+                )
+                .build(),
+        )
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(prevent_default::init())
         .plugin(
@@ -118,4 +185,59 @@ pub fn run() {
             let _ = app_handle;
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MODEL_STORE_SCHEMA_VERSION, migrate_model_store_state};
+    use serde_json::json;
+    use tauri_plugin_pinia::StoreState;
+
+    #[test]
+    fn migrates_legacy_model_selection_and_removes_runtime_state() {
+        let mut state = StoreState::new();
+        state.set(
+            "currentModel",
+            json!({
+                "id": "中文-model",
+                "path": "C:\\用户 目录\\模型#100%",
+                "fingerprint": "v2:standard:abc"
+            }),
+        );
+        state.set(
+            "models",
+            json!([{ "id": "中文-model", "runtimeLease": { "expiresAt": 1 } }]),
+        );
+        state.set("modelReady", false);
+        state.set("currentMotions", json!([["Idle", []]]));
+
+        migrate_model_store_state(&mut state).unwrap();
+
+        assert_eq!(
+            state.get("schemaVersion"),
+            Some(&json!(MODEL_STORE_SCHEMA_VERSION))
+        );
+        assert_eq!(state.get("currentModelId"), Some(&json!("中文-model")));
+        assert_eq!(
+            state.get("currentModelFingerprint"),
+            Some(&json!("v2:standard:abc"))
+        );
+        assert_eq!(state.get("selectionMigrationPending"), Some(&json!(true)));
+        assert_eq!(state.get("models"), Some(&json!([{ "id": "中文-model" }])));
+        assert!(!state.has("currentModel"));
+        assert!(!state.has("modelReady"));
+        assert!(!state.has("currentMotions"));
+    }
+
+    #[test]
+    fn preserves_an_existing_stable_model_id() {
+        let mut state = StoreState::new();
+        state.set("currentModelId", "new-selection");
+        state.set("currentModel", json!({ "id": "legacy-selection" }));
+
+        migrate_model_store_state(&mut state).unwrap();
+
+        assert_eq!(state.get("currentModelId"), Some(&json!("new-selection")));
+        assert!(!state.has("currentModel"));
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,7 +25,8 @@ fn run_admin_relaunch_helper() -> bool {
 
     let parent_process_id = args
         .next()
-        .and_then(|value| value.to_string_lossy().parse::<u32>().ok())
+        .and_then(|value| value.into_string().ok())
+        .and_then(|value| value.parse::<u32>().ok())
         .unwrap_or(0);
 
     if args.next().as_deref() != Some(std::ffi::OsStr::new("--")) {

--- a/src-tauri/src/plugins/admin-status/src/commands/mod.rs
+++ b/src-tauri/src/plugins/admin-status/src/commands/mod.rs
@@ -105,8 +105,8 @@ pub fn get_process_metrics() -> Result<ProcessMetrics, String> {
 pub fn compact_process_memory() -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
-        use windows::Win32::{
-            System::{ProcessStatus::EmptyWorkingSet, Threading::GetCurrentProcess},
+        use windows::Win32::System::{
+            ProcessStatus::EmptyWorkingSet, Threading::GetCurrentProcess,
         };
 
         unsafe {
@@ -119,6 +119,7 @@ pub fn compact_process_memory() -> Result<(), String> {
 
 #[cfg(target_os = "windows")]
 fn schedule_windows_administrator_relaunch() -> Result<(), String> {
+    use std::ffi::OsString;
     use windows::{
         Win32::UI::{Shell::ShellExecuteW, WindowsAndMessaging::SW_HIDE},
         core::PCWSTR,
@@ -133,21 +134,17 @@ fn schedule_windows_administrator_relaunch() -> Result<(), String> {
         .parent()
         .ok_or_else(|| "current executable has no parent directory".to_string())?;
     let parameters = [
-        quote_windows_argument(ADMIN_RELAUNCH_HELPER_ARG),
-        quote_windows_argument(&current_process_id.to_string()),
-        quote_windows_argument("--"),
+        OsString::from(ADMIN_RELAUNCH_HELPER_ARG),
+        OsString::from(current_process_id.to_string()),
+        OsString::from("--"),
     ]
     .into_iter()
-    .chain(
-        std::env::args_os()
-            .skip(1)
-            .map(|argument| quote_windows_argument(&argument.to_string_lossy())),
-    )
-    .collect::<Vec<_>>()
-    .join(" ");
+    .chain(std::env::args_os().skip(1))
+    .map(|argument| quote_windows_argument(&argument))
+    .collect::<Vec<_>>();
     let operation = to_wide_str("runas");
     let file = to_wide_os_str(exe_path.as_os_str());
-    let parameters = to_wide_str(&parameters);
+    let parameters = join_windows_arguments(&parameters);
     let directory = to_wide_os_str(working_directory.as_os_str());
     let result = unsafe {
         ShellExecuteW(
@@ -169,45 +166,68 @@ fn schedule_windows_administrator_relaunch() -> Result<(), String> {
         return Err("administrator relaunch was cancelled".to_string());
     }
 
-    Err(format!("ShellExecuteW runas failed with code {result_code}"))
+    Err(format!(
+        "ShellExecuteW runas failed with code {result_code}"
+    ))
 }
 
 #[cfg(target_os = "windows")]
-fn quote_windows_argument(argument: &str) -> String {
+fn quote_windows_argument(argument: &std::ffi::OsStr) -> std::ffi::OsString {
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    let argument = argument.encode_wide().collect::<Vec<_>>();
+
     if argument.is_empty() {
-        return "\"\"".to_string();
+        return std::ffi::OsString::from("\"\"");
     }
 
     let needs_quotes = argument
-        .chars()
-        .any(|character| character.is_whitespace() || character == '"');
+        .iter()
+        .any(|character| matches!(character, 9..=13 | 32 | 34));
 
     if !needs_quotes {
-        return argument.to_string();
+        return std::ffi::OsString::from_wide(&argument);
     }
 
-    let mut quoted = String::from("\"");
+    let mut quoted = vec![u16::from(b'"')];
     let mut backslashes = 0;
 
-    for character in argument.chars() {
+    for character in argument {
         match character {
-            '\\' => backslashes += 1,
-            '"' => {
-                quoted.push_str(&"\\".repeat(backslashes * 2 + 1));
-                quoted.push('"');
+            value if value == u16::from(b'\\') => backslashes += 1,
+            value if value == u16::from(b'"') => {
+                quoted.extend(std::iter::repeat_n(u16::from(b'\\'), backslashes * 2 + 1));
+                quoted.push(value);
                 backslashes = 0;
             }
             _ => {
-                quoted.push_str(&"\\".repeat(backslashes));
+                quoted.extend(std::iter::repeat_n(u16::from(b'\\'), backslashes));
                 backslashes = 0;
                 quoted.push(character);
             }
         }
     }
 
-    quoted.push_str(&"\\".repeat(backslashes * 2));
-    quoted.push('"');
-    quoted
+    quoted.extend(std::iter::repeat_n(u16::from(b'\\'), backslashes * 2));
+    quoted.push(u16::from(b'"'));
+    std::ffi::OsString::from_wide(&quoted)
+}
+
+#[cfg(target_os = "windows")]
+fn join_windows_arguments(arguments: &[std::ffi::OsString]) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+
+    let mut joined = Vec::new();
+
+    for (index, argument) in arguments.iter().enumerate() {
+        if index > 0 {
+            joined.push(u16::from(b' '));
+        }
+        joined.extend(argument.encode_wide());
+    }
+
+    joined.push(0);
+    joined
 }
 
 #[cfg(target_os = "windows")]
@@ -286,7 +306,10 @@ fn windows_process_metrics() -> Result<ProcessMetrics, String> {
         memory_bytes: memory_counters.WorkingSetSize as u64,
         virtual_memory_bytes: memory_counters.PagefileUsage as u64,
         thread_count: current_process_thread_count().map_err(|_| unsafe {
-            format!("GetCurrentProcess thread snapshot failed: {:?}", GetLastError())
+            format!(
+                "GetCurrentProcess thread snapshot failed: {:?}",
+                GetLastError()
+            )
         })?,
         uptime_seconds,
     })
@@ -341,12 +364,53 @@ fn filetime_to_u64(filetime: windows::Win32::Foundation::FILETIME) -> u64 {
     (u64::from(filetime.dwHighDateTime) << 32) | u64::from(filetime.dwLowDateTime)
 }
 
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::{join_windows_arguments, quote_windows_argument};
+    use std::{
+        ffi::{OsStr, OsString},
+        os::windows::ffi::{OsStrExt, OsStringExt},
+    };
+
+    #[test]
+    fn quotes_unicode_paths_and_shell_metacharacters_as_native_windows_text() {
+        let path = OsStr::new("C:\\中文 目录#100%\\模型🐾\\");
+
+        assert_eq!(
+            quote_windows_argument(path),
+            OsString::from("\"C:\\中文 目录#100%\\模型🐾\\\\\"")
+        );
+    }
+
+    #[test]
+    fn quotes_embedded_double_quotes_and_backslashes() {
+        assert_eq!(
+            quote_windows_argument(OsStr::new("模型 \\\"测试\"")),
+            OsString::from("\"模型 \\\\\\\"测试\\\"\"")
+        );
+    }
+
+    #[test]
+    fn preserves_unpaired_utf16_units_without_lossy_conversion() {
+        let argument = OsString::from_wide(&[u16::from(b'a'), 0xd800, u16::from(b'b')]);
+        let quoted = quote_windows_argument(&argument);
+
+        assert_eq!(
+            quoted.encode_wide().collect::<Vec<_>>(),
+            vec![u16::from(b'a'), 0xd800, u16::from(b'b')]
+        );
+        assert_eq!(
+            join_windows_arguments(&[quoted]),
+            vec![u16::from(b'a'), 0xd800, u16::from(b'b'), 0]
+        );
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn current_process_thread_count() -> Result<u32, windows::core::Error> {
     use windows::Win32::{
         System::Diagnostics::ToolHelp::{
-            CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First,
-            Thread32Next,
+            CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
         },
         System::Threading::GetCurrentProcessId,
     };

--- a/src-tauri/src/utils/fs_extra.rs
+++ b/src-tauri/src/utils/fs_extra.rs
@@ -5,17 +5,23 @@
 use fs_extra::dir::{CopyOptions, copy};
 use std::{
     fs::{File, create_dir_all},
-    path::{Component, Path},
+    path::{Component, Path, PathBuf},
 };
 use tauri::command;
 use zip::ZipArchive;
 
 #[command]
 pub async fn copy_dir(from_path: String, to_path: String) -> Result<(), String> {
+    copy_dir_paths(PathBuf::from(from_path), PathBuf::from(to_path))
+}
+
+fn copy_dir_paths(from_path: impl AsRef<Path>, to_path: impl AsRef<Path>) -> Result<(), String> {
+    let from_path = from_path.as_ref();
+    let to_path = to_path.as_ref();
     let mut options = CopyOptions::new();
     options.content_only = true;
 
-    create_dir_all(&to_path).map_err(|err| err.to_string())?;
+    create_dir_all(to_path).map_err(|err| err.to_string())?;
 
     copy(from_path, to_path, &options).map_err(|err| err.to_string())?;
 
@@ -24,19 +30,27 @@ pub async fn copy_dir(from_path: String, to_path: String) -> Result<(), String> 
 
 #[command]
 pub async fn extract_zip(from_path: String, to_path: String) -> Result<(), String> {
-    let archive_file = File::open(&from_path).map_err(|err| err.to_string())?;
+    extract_zip_paths(PathBuf::from(from_path), PathBuf::from(to_path))
+}
+
+fn extract_zip_paths(from_path: impl AsRef<Path>, to_path: impl AsRef<Path>) -> Result<(), String> {
+    let archive_file = File::open(from_path.as_ref()).map_err(|err| err.to_string())?;
     let mut archive = ZipArchive::new(archive_file).map_err(|err| err.to_string())?;
-    let destination = Path::new(&to_path);
+    let destination = to_path.as_ref();
 
     create_dir_all(destination).map_err(|err| err.to_string())?;
 
     for index in 0..archive.len() {
         let mut file = archive.by_index(index).map_err(|err| err.to_string())?;
+        validate_zip_entry_name(&file)?;
         let Some(safe_name) = file.enclosed_name() else {
             continue;
         };
 
-        if safe_name.components().any(|component| matches!(component, Component::Prefix(_))) {
+        if safe_name
+            .components()
+            .any(|component| matches!(component, Component::Prefix(_)))
+        {
             continue;
         }
 
@@ -57,4 +71,164 @@ pub async fn extract_zip(from_path: String, to_path: String) -> Result<(), Strin
     }
 
     Ok(())
+}
+
+fn validate_zip_entry_name<R: std::io::Read>(
+    file: &zip::read::ZipFile<'_, R>,
+) -> Result<(), String> {
+    let raw_name = file.name_raw();
+    let utf8_name =
+        std::str::from_utf8(raw_name).map_err(|_| unsupported_zip_filename_encoding())?;
+
+    if utf8_name.as_bytes() != file.name().as_bytes() {
+        return Err(unsupported_zip_filename_encoding());
+    }
+
+    Ok(())
+}
+
+fn unsupported_zip_filename_encoding() -> String {
+    "unsupported ZIP filename encoding (only UTF-8 is supported)".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{copy_dir_paths, extract_zip_paths};
+    use std::{
+        fs,
+        io::Write,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use zip::{ZipWriter, write::SimpleFileOptions};
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(name: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should follow UNIX epoch")
+                .as_nanos();
+            let path = std::env::temp_dir()
+                .join(format!("mochi-paw-{name}-{}-{unique}", std::process::id()));
+            fs::create_dir_all(&path).expect("test directory should be created");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_zip(path: &Path, entries: &[(&str, &[u8])]) {
+        let file = fs::File::create(path).expect("ZIP file should be created");
+        let mut writer = ZipWriter::new(file);
+
+        for (name, contents) in entries {
+            writer
+                .start_file(*name, SimpleFileOptions::default())
+                .expect("ZIP entry should be created");
+            writer
+                .write_all(contents)
+                .expect("ZIP entry should be written");
+        }
+
+        writer.finish().expect("ZIP should be finalized");
+    }
+
+    #[test]
+    fn copies_files_in_unicode_directories_without_changing_bytes() {
+        let root = TestDirectory::new("复制 中文 空格#%🐾");
+        let source = root.path().join("源模型");
+        let destination = root.path().join("目标 模型#100%");
+        let contents = [0, 1, 2, 0x7f, 0x80, 0xff];
+        let source_file = source.join("纹理").join("猫咪.png");
+
+        fs::create_dir_all(source_file.parent().unwrap()).unwrap();
+        fs::write(&source_file, contents).unwrap();
+
+        copy_dir_paths(&source, &destination).unwrap();
+
+        assert_eq!(
+            fs::read(destination.join("纹理").join("猫咪.png")).unwrap(),
+            contents
+        );
+    }
+
+    #[test]
+    fn extracts_utf8_unicode_entries_without_changing_bytes() {
+        let root = TestDirectory::new("解压 中文 空格#%🐾");
+        let archive = root.path().join("中文 模型#100%.zip");
+        let destination = root.path().join("输出 目录");
+        let contents = [0, 1, 2, 0x80, 0xff];
+
+        write_zip(&archive, &[("中文 模型#%🐾/纹理/猫咪.png", &contents)]);
+        extract_zip_paths(&archive, &destination).unwrap();
+
+        assert_eq!(
+            fs::read(
+                destination
+                    .join("中文 模型#%🐾")
+                    .join("纹理")
+                    .join("猫咪.png")
+            )
+            .unwrap(),
+            contents
+        );
+    }
+
+    #[test]
+    fn rejects_legacy_non_utf8_entry_names() {
+        let root = TestDirectory::new("legacy-encoding");
+        let archive = root.path().join("legacy.zip");
+        let destination = root.path().join("output");
+
+        write_zip(&archive, &[("name", b"contents")]);
+        let mut bytes = fs::read(&archive).unwrap();
+        let replacement = [0xd6, 0xd0, 0xce, 0xc4];
+        let mut replacements = 0;
+
+        for index in 0..=bytes.len() - 4 {
+            if &bytes[index..index + 4] == b"name" {
+                bytes[index..index + 4].copy_from_slice(&replacement);
+                replacements += 1;
+            }
+        }
+
+        assert_eq!(
+            replacements, 2,
+            "local and central ZIP names should both be replaced"
+        );
+        fs::write(&archive, bytes).unwrap();
+
+        let error = extract_zip_paths(&archive, &destination).unwrap_err();
+        assert!(error.contains("unsupported ZIP filename encoding"));
+    }
+
+    #[test]
+    fn ignores_zip_slip_entries() {
+        let root = TestDirectory::new("zip-slip");
+        let archive = root.path().join("unsafe.zip");
+        let destination = root.path().join("output");
+        let escaped = root.path().join("escaped.bin");
+
+        write_zip(
+            &archive,
+            &[("../escaped.bin", b"unsafe"), ("safe/file.bin", b"safe")],
+        );
+        extract_zip_paths(&archive, &destination).unwrap();
+
+        assert!(!escaped.exists());
+        assert_eq!(
+            fs::read(destination.join("safe").join("file.bin")).unwrap(),
+            b"safe"
+        );
+    }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ import type { DeviceInputEvent, SubModelInputFrame } from './utils/subModelRunti
 
 import { useTauriListen } from './composables/useTauriListen'
 import { useWindowState } from './composables/useWindowState'
-import { LANGUAGE, LISTEN_KEY } from './constants'
+import { LANGUAGE, LISTEN_KEY, WINDOW_LABEL } from './constants'
 import { getAntdLocale } from './locales/index.ts'
 import { hideWindow, setWebviewMemoryTarget, showWindow } from './plugins/window'
 import { useAppStore } from './stores/app'
@@ -30,6 +30,7 @@ import { useModelStore } from './stores/model'
 import { useShortcutStore } from './stores/shortcut.ts'
 import { logError, logInfo, logStartupDiagnostics, logStep } from './utils/diagnostics'
 import { requestModelStoreSave } from './utils/modelPersistence'
+import { setCoreStoresPersistenceWritable } from './utils/persistence'
 import { getSubModelRuntimeCapacity } from './utils/subModelRuntime'
 import { openSubModelWindow } from './utils/subModelWindow'
 import { WebviewIdleMemoryController } from './utils/webviewIdleMemory'
@@ -41,26 +42,29 @@ const generalStore = useGeneralStore()
 const shortcutStore = useShortcutStore()
 const appWindow = getCurrentWebviewWindow()
 const isSubModelWindow = appWindow.label.startsWith('sub-model-')
+setCoreStoresPersistenceWritable(!isSubModelWindow)
 const idleMemory = new WebviewIdleMemoryController({ setTarget: setWebviewMemoryTarget })
 const { isRestored, restoreState } = useWindowState({ enabled: !isSubModelWindow })
 const { darkAlgorithm, defaultAlgorithm } = theme
 const { locale } = useI18n()
 
-async function queueRecoveredModelCatalogPersistence(result: Awaited<ReturnType<typeof modelStore.init>>) {
-  logStep('model-persistence', 'queue recovered model catalog persistence', {
+async function persistInitializedModelState(result: Awaited<ReturnType<typeof modelStore.init>>) {
+  logStep('model-persistence', 'persist initialized model state', {
     windowLabel: appWindow.label,
     ...result,
   })
 
   try {
     await nextTick()
-    await requestModelStoreSave()
-    logInfo('[model-persistence] recovered model catalog save queued', {
+    await requestModelStoreSave(modelStore.$state, {
+      persistModelCatalog: result.customModelScanSucceeded,
+    })
+    logInfo('[model-persistence] initialized model state saved', {
       windowLabel: appWindow.label,
       ...result,
     })
   } catch (error) {
-    logError('[model-persistence] failed to persist recovered model catalog', {
+    logError('[model-persistence] failed to persist initialized model state', {
       windowLabel: appWindow.label,
       ...result,
       error,
@@ -74,8 +78,8 @@ async function initializeModelStore() {
   logStep('app-init', 'initialize model store', { windowLabel: appWindow.label })
   const result = await modelStore.init()
 
-  if (result.recoveredModelCount > 0) {
-    void queueRecoveredModelCatalogPersistence(result)
+  if (appWindow.label === WINDOW_LABEL.MAIN) {
+    void persistInitializedModelState(result)
   }
 
   return result

--- a/src/components/update-app/index.vue
+++ b/src/components/update-app/index.vue
@@ -19,6 +19,7 @@ import { useTauriListen } from '@/composables/useTauriListen'
 import { GITHUB_LINK, LISTEN_KEY, UPGRADE_LINK_ACCESS_KEY } from '@/constants'
 import { showWindow } from '@/plugins/window'
 import { useGeneralStore } from '@/stores/general'
+import { saveAllPersistentStoresNow } from '@/utils/persistence'
 
 dayjs.extend(utc)
 
@@ -129,7 +130,8 @@ async function handleOk() {
       }
     })
 
-    relaunch()
+    await saveAllPersistentStoresNow()
+    await relaunch()
   } catch (error) {
     message.error(String(error))
   } finally {

--- a/src/composables/useAppMenu.ts
+++ b/src/composables/useAppMenu.ts
@@ -15,6 +15,7 @@ import type { CatStore } from '@/stores/cat'
 import { WINDOW_LABEL } from '@/constants'
 import { showWindow } from '@/plugins/window'
 import { useCatStore } from '@/stores/cat'
+import { saveAllPersistentStoresNow } from '@/utils/persistence'
 import { isMac } from '@/utils/platform'
 
 type AppMenuWindowSettings = Pick<CatStore['window'], 'passThrough' | 'scale' | 'opacity'>
@@ -127,15 +128,24 @@ export function useAppMenu(options: AppMenuOptions = {}) {
   }
 
   const getExitMenu = async () => {
+    const restartApp = async () => {
+      await saveAllPersistentStoresNow()
+      await relaunch()
+    }
+    const quitApp = async () => {
+      await saveAllPersistentStoresNow()
+      await exit(0)
+    }
+
     return await Promise.all([
       MenuItem.new({
         text: t('composables.useAppMenu.labels.restartApp'),
-        action: relaunch,
+        action: restartApp,
       }),
       MenuItem.new({
         text: t('composables.useAppMenu.labels.quitApp'),
         accelerator: isMac ? 'Cmd+Q' : '',
-        action: () => exit(0),
+        action: quitApp,
       }),
     ])
   }

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -13,7 +13,7 @@ import { exists, readDir } from '@tauri-apps/plugin-fs'
 import { useDebounceFn, useEventListener } from '@vueuse/core'
 import { message } from 'antdv-next'
 import { round } from 'es-toolkit'
-import { computed, onMounted, onUnmounted, ref, toRaw, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, toRaw, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
 import type { Model, ModelMotionInfo, ModelSwitchAcknowledgement, ModelSwitchRequest, SubModelInstance } from '@/stores/model'
@@ -32,6 +32,8 @@ import { useModelStore } from '@/stores/model'
 import { logDebug, logError, logInfo, logStep, logTrace, logWarn } from '@/utils/diagnostics'
 import { isImage } from '@/utils/is'
 import live2d from '@/utils/live2d'
+import { requestModelStoreSave } from '@/utils/modelPersistence'
+import { executeModelSwitchTransaction } from '@/utils/modelSwitch'
 import { join } from '@/utils/path'
 import { isWindows } from '@/utils/platform'
 import { ensureRuntimeLease, reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
@@ -134,6 +136,8 @@ let scalingWithShortcut = false
 let scaleSyncTimer: ReturnType<typeof setTimeout> | undefined
 let lastShortcutResizeAt = 0
 let currentModelLoadVersion = 0
+let explicitModelSwitchInProgress = false
+let modelSwitchRequestInProgress = false
 const modelLoadTrigger = ref(0)
 
 const SCALE_DRAG_SENSITIVITY = 0.12
@@ -174,33 +178,23 @@ function applyWindowScale(scale: number, modelSizeValue = modelSize.value) {
   )
 }
 
-function modelKey(model: Model | undefined) {
-  return model ? `${model.id}:${model.path}` : ''
-}
-
 function resolveModelSwitchTarget(request: ModelSwitchRequest) {
   const storedModel = modelStore.models.find(model => model.id === request.model.id)
 
   if (!storedModel) {
-    const fallbackModel: Model = { ...request.model }
-    logWarn('[model-switch] target missing from main model list; using event snapshot', {
-      requestId: request.requestId,
-      modelId: fallbackModel.id,
-      modelPath: fallbackModel.path,
-    })
-    return fallbackModel
+    throw new Error(`Model ${request.model.id} is not installed in the main window.`)
   }
 
-  if (storedModel.path === request.model.path) return storedModel
+  if (storedModel.path !== request.model.path) {
+    logWarn('[model-switch] ignored stale model path from event snapshot', {
+      requestId: request.requestId,
+      modelId: storedModel.id,
+      storedPath: storedModel.path,
+      requestedPath: request.model.path,
+    })
+  }
 
-  const mergedModel = { ...storedModel, ...request.model }
-  logWarn('[model-switch] main model path differed from event snapshot', {
-    requestId: request.requestId,
-    modelId: mergedModel.id,
-    storedPath: storedModel.path,
-    requestedPath: mergedModel.path,
-  })
-  return mergedModel
+  return storedModel
 }
 
 function acknowledgeModelSwitch(acknowledgement: ModelSwitchAcknowledgement) {
@@ -209,16 +203,7 @@ function acknowledgeModelSwitch(acknowledgement: ModelSwitchAcknowledgement) {
     .catch(error => logError('[model-switch] failed to send acknowledgement', { ...acknowledgement, error }))
 }
 
-function requestModelLoad(reason: string, context: Record<string, unknown> = {}) {
-  modelLoadTrigger.value += 1
-  logStep('model-load', 'explicit load requested', {
-    ...context,
-    reason,
-    loadTrigger: modelLoadTrigger.value,
-  })
-}
-
-useTauriListen<ModelSwitchRequest>(LISTEN_KEY.MODEL_SWITCH_REQUESTED, ({ payload }) => {
+useTauriListen<ModelSwitchRequest>(LISTEN_KEY.MODEL_SWITCH_REQUESTED, async ({ payload }) => {
   const context = {
     requestId: payload.requestId,
     modelId: payload.model.id,
@@ -228,29 +213,68 @@ useTauriListen<ModelSwitchRequest>(LISTEN_KEY.MODEL_SWITCH_REQUESTED, ({ payload
   }
   logInfo('[model-switch] main window received request', context)
 
+  if (modelSwitchRequestInProgress) {
+    acknowledgeModelSwitch({
+      requestId: payload.requestId,
+      modelId: payload.model.id,
+      accepted: false,
+      reason: 'Another model switch is already in progress.',
+    })
+    return
+  }
+
+  modelSwitchRequestInProgress = true
+
   try {
     const targetModel = resolveModelSwitchTarget(payload)
     const previousModel = modelStore.currentModel
+    const previousModelId = modelStore.currentModelId
+    const previousModelFingerprint = modelStore.currentModelFingerprint
+    const previousSelectionMigrationPending = modelStore.selectionMigrationPending
+    const canvas = live2dCanvas.value
 
-    modelStore.modelReady = false
-    logStep('model-switch', 'main window set modelReady=false', context)
+    if (!canvas) throw new Error('The main model canvas is not ready.')
 
-    if (modelKey(previousModel) !== modelKey(targetModel)) {
-      logStep('model-switch', 'main window applied requested model', {
-        ...context,
-        previousModelId: previousModel?.id,
-        previousModelPath: previousModel?.path,
-      })
-      modelStore.currentModel = targetModel
-    } else {
-      logStep('model-switch', 'main window model already matches request', context)
-      requestModelLoad('model-switch event matched current model', context)
-    }
+    explicitModelSwitchInProgress = true
+    modelStore.currentModel = targetModel
+    await nextTick()
+
+    const result = await executeModelSwitchTransaction({
+      loadTarget: async () => {
+        const loaded = await loadModel(targetModel, canvas, modelLoadTrigger.value)
+        if (!loaded) throw new Error('The model load was superseded before it completed.')
+      },
+      commitSelection: () => {
+        modelStore.currentModelId = targetModel.id
+        modelStore.currentModelFingerprint = targetModel.fingerprint ?? null
+        modelStore.selectionMigrationPending = false
+      },
+      persistSelection: () => requestModelStoreSave(modelStore.$state, {
+        persistModelCatalog: modelStore.customModelScanSucceeded,
+      }),
+      rollbackSelection: async (selectionCommitted) => {
+        modelStore.currentModel = previousModel
+        modelStore.currentModelId = previousModelId
+        modelStore.currentModelFingerprint = previousModelFingerprint
+        modelStore.selectionMigrationPending = previousSelectionMigrationPending
+
+        if (selectionCommitted) {
+          await requestModelStoreSave(modelStore.$state, {
+            persistModelCatalog: modelStore.customModelScanSucceeded,
+          })
+        }
+      },
+      restorePrevious: async () => {
+        if (!previousModel) return
+        await nextTick()
+        await loadModel(previousModel, canvas, modelLoadTrigger.value)
+      },
+    })
 
     acknowledgeModelSwitch({
       requestId: payload.requestId,
       modelId: targetModel.id,
-      accepted: true,
+      ...result,
     })
   } catch (error) {
     logError('[model-switch] main window failed to apply request', { ...context, error })
@@ -261,6 +285,9 @@ useTauriListen<ModelSwitchRequest>(LISTEN_KEY.MODEL_SWITCH_REQUESTED, ({ payload
       accepted: false,
       reason: String(error),
     })
+  } finally {
+    explicitModelSwitchInProgress = false
+    modelSwitchRequestInProgress = false
   }
 })
 
@@ -305,25 +332,7 @@ useEventListener('resize', () => {
   debouncedResize()
 })
 
-watch([() => {
-  const model = activeModel.value
-
-  return model ? `${model.id}:${model.path}` : ''
-}, live2dCanvas, modelLoadTrigger], async ([, canvas, loadTrigger]) => {
-  const model = activeModel.value
-
-  // An immediate watcher can run before the component's canvas is mounted.
-  // Watching the template ref retries the current model as soon as it exists.
-  if (!model || !canvas) {
-    logTrace('[model-load] watcher skipped because model or canvas is unavailable', {
-      windowLabel: appWindow.label,
-      hasModel: Boolean(model),
-      hasCanvas: Boolean(canvas),
-      loadTrigger,
-    })
-    return
-  }
-
+async function loadModel(model: Model, canvas: HTMLCanvasElement, loadTrigger: number) {
   const loadVersion = ++currentModelLoadVersion
   const modelContext = {
     windowLabel: appWindow.label,
@@ -352,7 +361,7 @@ watch([() => {
         ...modelContext,
         currentLoadVersion: currentModelLoadVersion,
       })
-      return
+      return false
     }
 
     logStep('model-load', 'initialize Live2D', modelContext)
@@ -364,7 +373,7 @@ watch([() => {
         ...modelContext,
         currentLoadVersion: currentModelLoadVersion,
       })
-      return
+      return false
     }
 
     logStep('model-load', 'report opened event', modelContext)
@@ -379,7 +388,7 @@ watch([() => {
         ...modelContext,
         currentLoadVersion: currentModelLoadVersion,
       })
-      return
+      return false
     }
 
     backgroundImagePath.value = existed ? convertFileSrc(path) : void 0
@@ -420,7 +429,7 @@ watch([() => {
             currentLoadVersion: currentModelLoadVersion,
             group: group.name,
           })
-          return
+          return false
         }
 
         const fileName = file.name.split('.')[0]
@@ -447,12 +456,13 @@ watch([() => {
         currentLoadVersion: currentModelLoadVersion,
         error,
       })
-      return
+      return false
     }
 
     console.warn('[mochi-paw] failed to load current model:', error)
     logError('[model-load] failed', { ...modelContext, error })
     message.error(String(error))
+    throw error
   } finally {
     if (loadVersion === currentModelLoadVersion) {
       modelStore.modelReady = true
@@ -463,6 +473,43 @@ watch([() => {
         currentLoadVersion: currentModelLoadVersion,
       })
     }
+  }
+
+  return true
+}
+
+watch([() => {
+  const model = activeModel.value
+
+  return model ? `${model.id}:${model.path}` : ''
+}, live2dCanvas, modelLoadTrigger], async ([, canvas, loadTrigger]) => {
+  const model = activeModel.value
+
+  if (explicitModelSwitchInProgress) {
+    logTrace('[model-load] watcher deferred to explicit model switch', {
+      windowLabel: appWindow.label,
+      modelId: model?.id,
+      loadTrigger,
+    })
+    return
+  }
+
+  // An immediate watcher can run before the component's canvas is mounted.
+  // Watching the template ref retries the current model as soon as it exists.
+  if (!model || !canvas) {
+    logTrace('[model-load] watcher skipped because model or canvas is unavailable', {
+      windowLabel: appWindow.label,
+      hasModel: Boolean(model),
+      hasCanvas: Boolean(canvas),
+      loadTrigger,
+    })
+    return
+  }
+
+  try {
+    await loadModel(model, canvas, loadTrigger)
+  } catch {
+    // loadModel already reports user-visible and diagnostic errors.
   }
 }, { flush: 'post', immediate: true })
 

--- a/src/pages/preference/components/general/components/windows-permissions/index.vue
+++ b/src/pages/preference/components/general/components/windows-permissions/index.vue
@@ -12,6 +12,7 @@ import { useI18n } from 'vue-i18n'
 import ProListItem from '@/components/pro-list-item/index.vue'
 import ProList from '@/components/pro-list/index.vue'
 import { isRunningAsAdministrator, relaunchAsAdministrator } from '@/plugins/adminStatus'
+import { saveAllPersistentStoresNow } from '@/utils/persistence'
 
 const authorized = ref(true)
 const restarting = ref(false)
@@ -40,6 +41,7 @@ async function showAdministratorGuide() {
   try {
     restarting.value = true
 
+    await saveAllPersistentStoresNow()
     await relaunchAsAdministrator()
   } catch (error) {
     console.error(error)

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -328,7 +328,9 @@ watch(selectPaths, async (paths) => {
           modelCount: modelStore.models.length,
         })
         await nextTick()
-        await requestModelStoreSave()
+        await requestModelStoreSave(modelStore.$state, {
+          persistModelCatalog: modelStore.customModelScanSucceeded,
+        })
         logInfo('[model-persistence] imported model catalog save queued', {
           fromPath,
           modelIds: result.models.map(model => model.id),

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -20,7 +20,6 @@ import { useCatStore } from '@/stores/cat'
 import { getModelDisplayName, useModelStore } from '@/stores/model'
 import { logError, logInfo, logStep, logTrace } from '@/utils/diagnostics'
 import { withTimeout } from '@/utils/promise'
-import { ensureRuntimeLease } from '@/utils/runtimeTelemetry'
 import { destroySubModelWindow } from '@/utils/subModelWindow'
 
 import BehaviorModal from './components/behavior-modal/index.vue'
@@ -39,23 +38,27 @@ const renameModelTarget = ref<Model>()
 const renameModelDraft = ref('')
 const selectedModelIds = ref(new Set<string>())
 const batchDeleting = ref(false)
+const switchingModelId = ref<string>()
 const masonryRefreshKey = ref(0)
-const pendingModelSwitches = new Map<string, (acknowledgement: ModelSwitchAcknowledgement) => void>()
+const pendingModelSwitches = new Map<string, {
+  resolve: (acknowledgement: ModelSwitchAcknowledgement) => void
+  reject: (reason: unknown) => void
+}>()
 
 const PAGE_SIZE = 5
-const MODEL_SWITCH_ACK_TIMEOUT_MS = 5_000
+const MODEL_SWITCH_ACK_TIMEOUT_MS = 120_000
 
 useTauriListen<ModelSwitchAcknowledgement>(LISTEN_KEY.MODEL_SWITCH_APPLIED, ({ payload }) => {
-  const resolve = pendingModelSwitches.get(payload.requestId)
+  const pending = pendingModelSwitches.get(payload.requestId)
 
-  if (!resolve) {
+  if (!pending) {
     logTrace('[model-switch] received acknowledgement without pending request', payload)
     return
   }
 
   pendingModelSwitches.delete(payload.requestId)
   logStep('model-switch', 'received main window acknowledgement', payload)
-  resolve(payload)
+  pending.resolve(payload)
 })
 
 function proofLabel(model: Model) {
@@ -229,8 +232,8 @@ async function showImportedModels() {
 
 function waitForModelSwitchAcknowledgement(requestId: string) {
   return withTimeout(
-    new Promise<ModelSwitchAcknowledgement>((resolve) => {
-      pendingModelSwitches.set(requestId, resolve)
+    new Promise<ModelSwitchAcknowledgement>((resolve, reject) => {
+      pendingModelSwitches.set(requestId, { resolve, reject })
     }),
     MODEL_SWITCH_ACK_TIMEOUT_MS,
     `Main window did not acknowledge model switch within ${MODEL_SWITCH_ACK_TIMEOUT_MS / 1000} seconds.`,
@@ -240,14 +243,14 @@ function waitForModelSwitchAcknowledgement(requestId: string) {
 }
 
 async function handleToggle(nextModel: Model) {
-  if (batchDeleting.value) {
-    logTrace('[model-switch] ignored selection during batch deletion', { modelId: nextModel.id })
-    return
+  if (batchDeleting.value || switchingModelId.value) {
+    logTrace('[model-switch] ignored selection while model operations are locked', { modelId: nextModel.id })
+    return false
   }
 
-  if (modelStore.currentModel?.id === nextModel.id) {
+  if (modelStore.currentModelId === nextModel.id) {
     logTrace('[model-switch] ignored selection of current model', { modelId: nextModel.id })
-    return
+    return true
   }
 
   const previousModel = modelStore.currentModel
@@ -262,22 +265,6 @@ async function handleToggle(nextModel: Model) {
     nextModelProofStatus: nextModel.proofStatus,
   })
 
-  try {
-    logStep('model-switch', 'prepare runtime lease', { modelId: nextModel.id, modelPath: nextModel.path })
-    await ensureRuntimeLease(nextModel)
-    logStep('model-switch', 'runtime lease ready', { modelId: nextModel.id, modelPath: nextModel.path })
-  } catch (error) {
-    logError('[model-switch] runtime preparation failed', { modelId: nextModel.id, modelPath: nextModel.path, error })
-    message.error(String(error))
-    return
-  }
-
-  logStep('model-switch', 'update current model', {
-    previousModelId: previousModel?.id,
-    nextModelId: nextModel.id,
-  })
-  modelStore.currentModel = nextModel
-
   const request: ModelSwitchRequest = {
     requestId: `${Date.now()}-${nextModel.id}`,
     model: {
@@ -290,8 +277,12 @@ async function handleToggle(nextModel: Model) {
     },
   }
 
+  switchingModelId.value = nextModel.id
+  modelStore.modelReady = false
+  let acknowledgement: Promise<ModelSwitchAcknowledgement> | undefined
+
   try {
-    const acknowledgement = waitForModelSwitchAcknowledgement(request.requestId)
+    acknowledgement = waitForModelSwitchAcknowledgement(request.requestId)
     logStep('model-switch', 'notify main window', request)
     await emitTo(WINDOW_LABEL.MAIN, LISTEN_KEY.MODEL_SWITCH_REQUESTED, request)
     logStep('model-switch', 'main window notification sent', request)
@@ -302,15 +293,23 @@ async function handleToggle(nextModel: Model) {
     }
 
     logStep('model-switch', 'main window accepted model switch', result)
+    modelStore.currentModelId = result.modelId
+    modelStore.currentModel = modelStore.models.find(model => model.id === result.modelId) ?? nextModel
+    modelStore.currentModelFingerprint = modelStore.currentModel.fingerprint ?? null
+    modelStore.selectionMigrationPending = false
   } catch (error) {
-    modelStore.currentModel = previousModel
-    modelStore.modelReady = previousModelReady
+    pendingModelSwitches.get(request.requestId)?.reject(error)
+    await acknowledgement?.catch(() => undefined)
     logError('[model-switch] main window notification failed', { ...request, error })
     message.error(String(error))
-    return
+    return false
+  } finally {
+    switchingModelId.value = undefined
+    modelStore.modelReady = previousModelReady
   }
 
   logInfo('[model-switch] requested model is now current', { modelId: nextModel.id, modelPath: nextModel.path })
+  return true
 }
 
 async function removeModel(item: Model) {
@@ -322,8 +321,17 @@ async function removeModel(item: Model) {
   const nextModels = previousModels.filter(model => model.id !== id)
   const deletingCurrentModel = id === previousCurrentModel?.id
   const subModels = previousSubModels.filter(instance => instance.modelId === id)
+  let switchedAway = false
 
   try {
+    if (deletingCurrentModel) {
+      const fallbackModel = nextModels[0]
+      if (!fallbackModel) throw new Error('No fallback model is available.')
+
+      switchedAway = await handleToggle(fallbackModel)
+      if (!switchedAway) throw new Error('The current model could not be replaced before deletion.')
+    }
+
     await waitForFrames()
 
     await Promise.all(subModels.map(instance => destroySubModelWindow(instance.id)))
@@ -334,18 +342,23 @@ async function removeModel(item: Model) {
     }
 
     modelStore.models = nextModels
-
-    if (deletingCurrentModel) {
-      modelStore.modelReady = false
-      modelStore.currentModel = nextModels[0]
-    }
   } catch (error) {
     modelStore.models = previousModels
     modelStore.subModels = previousSubModels
 
     if (deletingCurrentModel) {
-      modelStore.currentModel = previousCurrentModel
-      modelStore.modelReady = previousModelReady
+      if (switchedAway && previousCurrentModel) {
+        const restored = await handleToggle(previousCurrentModel)
+
+        if (!restored) {
+          logError('[model-delete] failed to restore selection after deletion error', {
+            modelId: previousCurrentModel.id,
+          })
+        }
+      } else {
+        modelStore.currentModel = previousCurrentModel
+        modelStore.modelReady = previousModelReady
+      }
     }
 
     throw error
@@ -353,7 +366,7 @@ async function removeModel(item: Model) {
 }
 
 async function handleDelete(item: Model) {
-  if (batchDeleting.value) return
+  if (batchDeleting.value || switchingModelId.value) return
 
   try {
     await removeModel(item)
@@ -399,7 +412,7 @@ async function executeBatchDelete(items: Model[]) {
 function confirmBatchDelete() {
   const items = selectedModels.value.filter(model => !isCurrentModel(model)).slice()
 
-  if (!items.length || batchDeleting.value) return
+  if (!items.length || batchDeleting.value || switchingModelId.value) return
 
   Modal.confirm({
     content: t('pages.preference.model.hints.deleteSelectedModels', { count: items.length }),
@@ -423,7 +436,7 @@ function confirmBatchDelete() {
         </span>
 
         <Button
-          :disabled="selectedModelCount === 0 || batchDeleting"
+          :disabled="selectedModelCount === 0 || batchDeleting || Boolean(switchingModelId)"
           @click="clearSelection"
         >
           <template #icon>
@@ -434,7 +447,7 @@ function confirmBatchDelete() {
 
         <Button
           danger
-          :disabled="selectedModelCount === 0 || batchDeleting"
+          :disabled="selectedModelCount === 0 || batchDeleting || Boolean(switchingModelId)"
           :loading="batchDeleting"
           @click="confirmBatchDelete"
         >
@@ -447,6 +460,7 @@ function confirmBatchDelete() {
 
       <Masonry
         :key="`${currentPage}-${masonryRefreshKey}`"
+        :class="{ 'pointer-events-none opacity-70': Boolean(switchingModelId) }"
         :columns="{ xs: 3, lg: 4, xxl: 6 }"
         :gutter="16"
         :items="masonryItems"
@@ -483,7 +497,7 @@ function confirmBatchDelete() {
                   >
                     <Checkbox
                       :checked="isModelSelected(data)"
-                      :disabled="isCurrentModel(data) || batchDeleting"
+                      :disabled="isCurrentModel(data) || batchDeleting || Boolean(switchingModelId)"
                       @change="toggleModelSelection(data)"
                     />
                   </span>

--- a/src/stores/cat.ts
+++ b/src/stores/cat.ts
@@ -5,6 +5,8 @@
 import { defineStore } from 'pinia'
 import { reactive, ref } from 'vue'
 
+import { persistStateWhenWritable } from '@/utils/persistence'
+
 export interface CatStore {
   model: {
     mirror: boolean
@@ -101,4 +103,10 @@ export const useCatStore = defineStore('cat', () => {
     window,
     init,
   }
+}, {
+  tauri: {
+    hooks: {
+      beforeBackendSync: persistStateWhenWritable,
+    },
+  },
 })

--- a/src/stores/general.ts
+++ b/src/stores/general.ts
@@ -7,6 +7,7 @@ import { getLocale } from 'tauri-plugin-locale-api'
 import { reactive, ref } from 'vue'
 
 import { LANGUAGE } from '@/constants'
+import { persistStateWhenWritable } from '@/utils/persistence'
 
 export type Theme = 'auto' | 'light' | 'dark'
 export type Language = typeof LANGUAGE[keyof typeof LANGUAGE]
@@ -96,4 +97,10 @@ export const useGeneralStore = defineStore('general', () => {
     update,
     init,
   }
+}, {
+  tauri: {
+    hooks: {
+      beforeBackendSync: persistStateWhenWritable,
+    },
+  },
 })

--- a/src/stores/model.test.ts
+++ b/src/stores/model.test.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict'
 // eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
 import test from 'node:test'
 
-import { getModelDisplayName, getSubModelDisplayName, mergeModelCatalog } from './model'
+import {
+  getModelDisplayName,
+  getSubModelDisplayName,
+  inspectStoredModelDirectory,
+  mergeModelCatalog,
+} from './model'
 
 test('recovers custom model directories missing from persisted catalog', () => {
   const persisted = [
@@ -17,6 +22,30 @@ test('recovers custom model directories missing from persisted catalog', () => {
     { id: 'existing', path: 'C:/app-data/existing', mode: 'standard', isPreset: false },
     { id: 'recovered', path: 'C:/app-data/recovered', mode: 'keyboard', isPreset: false },
   ])
+})
+
+test('drops persisted custom models that are no longer installed', () => {
+  const persisted = [
+    { id: 'missing', path: 'C:/app-data/missing', mode: 'standard' as const, isPreset: false },
+  ]
+
+  assert.deepEqual(mergeModelCatalog(persisted, []), [])
+})
+
+test('marks an unreadable custom model directory as an incomplete scan', async () => {
+  const result = await inspectStoredModelDirectory('C:\\应用 数据\\custom-models\\猫#100%', async () => {
+    throw new Error('access denied')
+  })
+
+  assert.deepEqual(result, { modelFile: undefined, succeeded: false })
+})
+
+test('distinguishes a readable directory without a model file from an I/O failure', async () => {
+  const result = await inspectStoredModelDirectory('C:\\应用 数据\\custom-models\\empty', async () => [
+    { isFile: true, name: 'readme.txt' },
+  ])
+
+  assert.deepEqual(result, { modelFile: undefined, succeeded: true })
 })
 
 test('uses custom, metadata, and internal model names in priority order', () => {

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -3,18 +3,26 @@
 // SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
 
 import { appDataDir, resolveResource } from '@tauri-apps/api/path'
-import { readDir, readTextFile } from '@tauri-apps/plugin-fs'
+import { exists, mkdir, readDir, readFile, readTextFile } from '@tauri-apps/plugin-fs'
 import { filter, find } from 'es-toolkit/compat'
 import JSON5 from 'json5'
 import { nanoid } from 'nanoid'
 import { defineStore } from 'pinia'
-import { reactive, ref } from 'vue'
+import { reactive, ref, watch } from 'vue'
 
 import type { ExpressionInfo, MotionInfo } from '@/vendor/easy-live2d'
 
 import { logInfo, logStep, logTrace } from '@/utils/diagnostics'
+import { collectCubismResourceReferences, createCubismFingerprint } from '@/utils/modelFingerprint'
 import { readNearestControlledRelease, readNearestProofManifest } from '@/utils/modelMetadata'
+import {
+  MODEL_STORE_SCHEMA_VERSION,
+  prepareModelStoreStateForBackend,
+  prepareModelStoreStateForFrontend,
+  resolvePersistedModelSelection,
+} from '@/utils/modelStorePersistence'
 import { join } from '@/utils/path'
+import { isCoreStoresPersistenceWritable } from '@/utils/persistence'
 
 export type ModelMode = 'standard' | 'keyboard' | 'gamepad'
 export type ModelImportKind = 'standard' | 'controlled'
@@ -86,6 +94,7 @@ export interface ModelSwitchRequest {
 export interface ModelSwitchAcknowledgement {
   requestId: string
   modelId: string
+  /** True only after the main window has loaded and persisted the model selection. */
   accepted: boolean
   reason?: string
 }
@@ -171,6 +180,8 @@ interface StoredCubismModelJSON {
   DisplayName?: string
 }
 
+let modelCatalogPersistenceWritable = true
+
 const PRESET_MODELS: PresetModel[] = [
   {
     id: 'preset-gamepad',
@@ -190,9 +201,14 @@ const PRESET_MODELS: PresetModel[] = [
 ]
 
 export const useModelStore = defineStore('model', () => {
+  const schemaVersion = ref(MODEL_STORE_SCHEMA_VERSION)
   const modelReady = ref(true)
   const models = ref<Model[]>([])
   const currentModel = ref<Model>()
+  const currentModelId = ref<string>()
+  const currentModelFingerprint = ref<string | null>()
+  const selectionMigrationPending = ref(false)
+  const customModelScanSucceeded = ref(true)
   const supportKeys = reactive<Record<string, ModelSupportKeyLayer[]>>({})
   const pressedKeys = reactive<Record<string, ModelSupportKeyLayer[]>>({})
   const activeKeys = reactive<Record<string, boolean>>({})
@@ -209,16 +225,25 @@ export const useModelStore = defineStore('model', () => {
     const persistedCustomModels = filter(models.value, { isPreset: false })
     const presetModels = filter(models.value, { isPreset: true })
     const customModelsPath = join(await appDataDir(), 'custom-models')
-    const discoveredCustomModels = await discoverStoredCustomModels(customModelsPath)
+    const discovery = await discoverStoredCustomModels(customModelsPath)
+    const discoveredCustomModels = discovery.models
+    modelCatalogPersistenceWritable = discovery.succeeded
+    customModelScanSucceeded.value = discovery.succeeded
     const nextModels = mergeModelCatalog(persistedCustomModels, discoveredCustomModels)
     const persistedModelIds = new Set(persistedCustomModels.map(model => model.id))
     const recoveredModelCount = discoveredCustomModels.filter(model => !persistedModelIds.has(model.id)).length
+    const catalogChanged = discovery.succeeded && (persistedCustomModels.length !== nextModels.length
+      || nextModels.some((model) => {
+        const persisted = persistedCustomModels.find(candidate => candidate.id === model.id)
+        return !persisted || persisted.path !== model.path
+      }))
 
     logStep('model-persistence', 'model catalog discovered', {
       customModelsPath,
       persistedCustomModelCount: persistedCustomModels.length,
       discoveredCustomModelCount: discoveredCustomModels.length,
       recoveredModelCount,
+      customModelScanSucceeded: discovery.succeeded,
     })
 
     await Promise.all(nextModels.map(fillModelMetadata))
@@ -240,25 +265,60 @@ export const useModelStore = defineStore('model', () => {
       })
     }
 
-    const matched = find(nextModels, { id: currentModel.value?.id })
-
-    currentModel.value = matched ?? nextModels[0]
-
     models.value = nextModels
+
+    const legacyCurrentModel = currentModel.value
+    const selectionFingerprint = currentModelFingerprint.value ?? legacyCurrentModel?.fingerprint
+    const fingerprintMigrationPending = selectionMigrationPending.value
+      || (!currentModelId.value && Boolean(legacyCurrentModel))
+
+    if (
+      (fingerprintMigrationPending || !currentModelId.value)
+      && selectionFingerprint
+      && !nextModels.some(model => model.id === currentModelId.value)
+    ) {
+      await fillMissingModelFingerprints(nextModels)
+    }
+
+    const selection = resolvePersistedModelSelection(nextModels, currentModelId.value, {
+      id: legacyCurrentModel?.id ?? currentModelId.value ?? '',
+      fingerprint: selectionFingerprint,
+    }, fingerprintMigrationPending || !currentModelId.value)
+
+    currentModel.value = selection.model
+    currentModelId.value = selection.currentModelId
+    currentModelFingerprint.value = selection.currentModelFingerprint ?? null
+    selectionMigrationPending.value = fingerprintMigrationPending && selection.usedRuntimeFallback
 
     logInfo('[model-persistence] model catalog initialized', {
       modelCount: nextModels.length,
       customModelCount: nextModels.filter(model => !model.isPreset).length,
       recoveredModelCount,
       currentModelId: currentModel.value?.id,
+      persistedCurrentModelId: currentModelId.value,
+      selectionMigrated: selection.selectionMigrated,
+      usedRuntimeFallback: selection.usedRuntimeFallback,
+      persistenceChanged: catalogChanged || selection.selectionMigrated,
+      customModelScanSucceeded: discovery.succeeded,
     })
 
     return {
       modelCount: nextModels.length,
       customModelCount: nextModels.filter(model => !model.isPreset).length,
       recoveredModelCount,
+      selectionMigrated: selection.selectionMigrated,
+      usedRuntimeFallback: selection.usedRuntimeFallback,
+      persistenceChanged: catalogChanged || selection.selectionMigrated,
+      customModelScanSucceeded: discovery.succeeded,
     }
   }
+
+  watch(currentModelId, (modelId) => {
+    if (!modelId) return
+
+    const resolved = models.value.find(model => model.id === modelId)
+    if (resolved) currentModel.value = resolved
+  })
 
   const createSubModel = (modelId: string) => {
     const instance: SubModelInstance = {
@@ -309,9 +369,14 @@ export const useModelStore = defineStore('model', () => {
   }
 
   return {
+    schemaVersion,
     modelReady,
     models,
     currentModel,
+    currentModelId,
+    currentModelFingerprint,
+    selectionMigrationPending,
+    customModelScanSucceeded,
     supportKeys,
     pressedKeys,
     activeKeys,
@@ -329,45 +394,62 @@ export const useModelStore = defineStore('model', () => {
   }
 }, {
   tauri: {
-    filterKeys: ['supportKeys', 'pressedKeys', 'activeKeys'],
+    hooks: {
+      beforeBackendSync: state => prepareModelStoreStateForBackend(
+        state,
+        isCoreStoresPersistenceWritable(),
+        modelCatalogPersistenceWritable,
+      ),
+      beforeFrontendSync: prepareModelStoreStateForFrontend,
+    },
     saveInterval: 500,
     saveStrategy: 'debounce',
   },
 })
 
 export function mergeModelCatalog(persistedModels: Model[], discoveredModels: Model[]) {
-  const discoveredById = new Map(discoveredModels.map(model => [model.id, model]))
-  const mergedModels = persistedModels.map((model) => {
-    const discoveredModel = discoveredById.get(model.id)
+  const persistedById = new Map(persistedModels.map(model => [model.id, model]))
 
-    if (!discoveredModel) return model
+  return discoveredModels.map((discoveredModel) => {
+    const model = persistedById.get(discoveredModel.id)
+
+    if (!model) return discoveredModel
 
     return {
       ...discoveredModel,
       ...model,
+      id: discoveredModel.id,
       path: discoveredModel.path,
     }
   })
-  const persistedIds = new Set(persistedModels.map(model => model.id))
-
-  return [
-    ...mergedModels,
-    ...discoveredModels.filter(model => !persistedIds.has(model.id)),
-  ]
 }
 
 async function discoverStoredCustomModels(customModelsPath: string) {
-  const entries = await readDir(customModelsPath).catch((error) => {
+  let entries
+
+  try {
+    await mkdir(customModelsPath, { recursive: true })
+    entries = await readDir(customModelsPath)
+  } catch (error) {
     logTrace('[model-persistence] custom model directory unavailable', { customModelsPath, error })
-    return []
-  })
+    return { models: [], succeeded: false }
+  }
   const discoveredModels: Model[] = []
+  let succeeded = true
 
   for (const entry of entries) {
     if (!entry.isDirectory || !entry.name) continue
 
     const modelPath = join(customModelsPath, entry.name)
-    const modelFile = await findStoredModelFile(modelPath)
+    const inspection = await inspectStoredModelDirectory(modelPath)
+
+    if (!inspection.succeeded) {
+      succeeded = false
+      logTrace('[model-persistence] custom model directory could not be inspected', { modelPath })
+      continue
+    }
+
+    const { modelFile } = inspection
 
     if (!modelFile) {
       logTrace('[model-persistence] skipped custom model directory without model JSON', { modelPath })
@@ -395,9 +477,10 @@ async function discoverStoredCustomModels(customModelsPath: string) {
   logInfo('[model-persistence] custom model directory scan completed', {
     customModelsPath,
     discoveredModelCount: discoveredModels.length,
+    succeeded,
   })
 
-  return discoveredModels
+  return { models: discoveredModels, succeeded }
 }
 
 async function fillModelMetadata(model: Model) {
@@ -441,10 +524,28 @@ async function readStoredCubismModelName(modelFile: string) {
 }
 
 async function findStoredModelFile(modelPath: string) {
-  const files = await readDir(modelPath).catch(() => [])
-  const modelFile = files.find(file => file.isFile && file.name.endsWith('.model3.json'))
+  return (await inspectStoredModelDirectory(modelPath)).modelFile
+}
 
-  return modelFile ? join(modelPath, modelFile.name) : undefined
+type StoredModelDirectoryReader = (
+  modelPath: string,
+) => Promise<Array<{ isFile: boolean, name: string }>>
+
+export async function inspectStoredModelDirectory(
+  modelPath: string,
+  reader: StoredModelDirectoryReader = readDir,
+) {
+  try {
+    const files = await reader(modelPath)
+    const modelFile = files.find(file => file.isFile && file.name.endsWith('.model3.json'))
+
+    return {
+      modelFile: modelFile ? join(modelPath, modelFile.name) : undefined,
+      succeeded: true,
+    }
+  } catch {
+    return { modelFile: undefined, succeeded: false }
+  }
 }
 
 async function inferStoredModelMode(modelPath: string): Promise<ModelMode> {
@@ -457,6 +558,28 @@ async function inferStoredModelMode(modelPath: string): Promise<ModelMode> {
 
   const fileNames = files.map(file => file.name.split('.')[0])
   return fileNames.includes('East') ? 'gamepad' : 'keyboard'
+}
+
+async function fillMissingModelFingerprints(models: Model[]) {
+  for (const model of models) {
+    if (model.fingerprint || model.isPreset) continue
+
+    model.fingerprint = await getStoredModelFingerprint(model).catch(() => undefined)
+  }
+}
+
+async function getStoredModelFingerprint(model: Model) {
+  const modelFile = await findStoredModelFile(model.path)
+  if (!modelFile) return undefined
+
+  const modelJSON = JSON5.parse(await readTextFile(modelFile))
+  const resources = collectCubismResourceReferences(modelFile, modelJSON)
+
+  return await createCubismFingerprint(model.mode, resources, async (path) => {
+    if (!await exists(path)) return undefined
+
+    return await readFile(path)
+  })
 }
 
 function normalizeDisplayName(value: unknown) {

--- a/src/utils/modelPersistence.test.ts
+++ b/src/utils/modelPersistence.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import { requestModelStoreSave } from './modelPersistence'
+
+test('awaits an explicit backend patch before saving the model store', async () => {
+  const calls: Array<{ operation: string, value?: unknown }> = []
+
+  await requestModelStoreSave({
+    currentModelId: 'new-model',
+    currentModel: { id: 'new-model', path: 'C:\\absolute\\path' },
+    modelReady: false,
+    models: [{ id: 'new-model', runtimeLease: { expiresAt: 1 } }],
+  }, {
+    adapter: {
+      patch: async (storeId, state) => {
+        calls.push({ operation: 'patch', value: { storeId, state } })
+      },
+      save: async (storeId) => {
+        calls.push({ operation: 'save', value: storeId })
+      },
+    },
+  })
+
+  assert.deepEqual(calls, [
+    {
+      operation: 'patch',
+      value: {
+        storeId: 'model',
+        state: {
+          schemaVersion: 2,
+          currentModelId: 'new-model',
+          models: [{ id: 'new-model' }],
+        },
+      },
+    },
+    { operation: 'save', value: 'model' },
+  ])
+})
+
+test('does not save or acknowledge persistence when the backend patch fails', async () => {
+  let saved = false
+
+  await assert.rejects(
+    requestModelStoreSave({ currentModelId: 'new-model' }, {
+      adapter: {
+        patch: async () => {
+          throw new Error('patch failed')
+        },
+        save: async () => {
+          saved = true
+        },
+      },
+    }),
+    /patch failed/,
+  )
+  assert.equal(saved, false)
+})

--- a/src/utils/modelPersistence.ts
+++ b/src/utils/modelPersistence.ts
@@ -1,10 +1,39 @@
 // SPDX-FileCopyrightText: 2026 InfinityXCat
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
-import { save } from '@tauri-store/pinia'
+import { invoke } from '@tauri-apps/api/core'
+import { saveNow } from '@tauri-store/pinia'
+import { nextTick } from 'vue'
+
+import { prepareModelStoreStateForBackend } from './modelStorePersistence'
 
 const MODEL_STORE_ID = 'model'
 
-export function requestModelStoreSave() {
-  return save(MODEL_STORE_ID)
+export interface ModelPersistenceAdapter {
+  patch: (storeId: string, state: Record<string, unknown>) => Promise<void>
+  save: (storeId: string) => Promise<void>
+}
+
+interface ModelPersistenceOptions {
+  adapter?: ModelPersistenceAdapter
+  persistModelCatalog?: boolean
+}
+
+const defaultAdapter: ModelPersistenceAdapter = {
+  patch: (storeId, state) => invoke('plugin:pinia|patch', { id: storeId, state }),
+  save: storeId => saveNow(storeId),
+}
+
+export async function requestModelStoreSave(
+  state: Record<string, unknown>,
+  options: ModelPersistenceOptions = {},
+) {
+  const adapter = options.adapter ?? defaultAdapter
+  await nextTick()
+  await adapter.patch(MODEL_STORE_ID, prepareModelStoreStateForBackend(
+    state,
+    true,
+    options.persistModelCatalog,
+  ) ?? {})
+  await adapter.save(MODEL_STORE_ID)
 }

--- a/src/utils/modelStorePersistence.test.ts
+++ b/src/utils/modelStorePersistence.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import {
+  MODEL_STORE_SCHEMA_VERSION,
+  prepareModelStoreStateForBackend,
+  prepareModelStoreStateForFrontend,
+  resolvePersistedModelSelection,
+} from './modelStorePersistence'
+
+const models = [
+  { id: 'preset-standard', fingerprint: 'preset' },
+  { id: 'custom-new', fingerprint: 'same-content' },
+]
+
+test('loads the legacy currentModel only for ID and fingerprint migration', () => {
+  const legacy = { id: 'custom-old', fingerprint: 'same-content', path: 'C:\\旧目录\\模型' }
+  const prepared = prepareModelStoreStateForFrontend({ currentModel: legacy, models })
+
+  assert.deepEqual(prepared.currentModel, legacy)
+  assert.deepEqual(prepared.models, models)
+})
+
+test('persists only the model whitelist and strips runtime leases', () => {
+  const persisted = prepareModelStoreStateForBackend({
+    schemaVersion: 1,
+    currentModelId: 'custom-new',
+    currentModelFingerprint: 'same-content',
+    currentModel: { id: 'custom-new', path: 'C:\\absolute\\path' },
+    models: [{ id: 'custom-new', path: 'C:\\installed', runtimeLease: { expiresAt: 1 } }],
+    shortcuts: { Tap: 'Space' },
+    behaviorNames: {},
+    behaviorGroups: {},
+    subModels: [],
+    modelReady: false,
+    currentMotions: [['Idle', []]],
+    currentExpressions: [],
+    supportKeys: { Space: [] },
+    pressedKeys: {},
+    activeKeys: {},
+  }, true)
+
+  assert.deepEqual(persisted, {
+    schemaVersion: MODEL_STORE_SCHEMA_VERSION,
+    currentModelId: 'custom-new',
+    currentModelFingerprint: 'same-content',
+    models: [{ id: 'custom-new', path: 'C:\\installed' }],
+    shortcuts: { Tap: 'Space' },
+    behaviorNames: {},
+    behaviorGroups: {},
+    subModels: [],
+  })
+})
+
+test('does not prepare model state for a read-only submodel window', () => {
+  assert.equal(prepareModelStoreStateForBackend({ currentModelId: 'custom-new' }, false), undefined)
+})
+
+test('prefers the stable persisted model ID', () => {
+  const selection = resolvePersistedModelSelection(models, 'custom-new', { id: 'preset-standard' })
+
+  assert.equal(selection.model?.id, 'custom-new')
+  assert.equal(selection.currentModelId, 'custom-new')
+  assert.equal(selection.selectionMigrated, false)
+})
+
+test('migrates a legacy model by ID and then by fingerprint', () => {
+  const byId = resolvePersistedModelSelection(models, undefined, { id: 'custom-new' })
+  const byFingerprint = resolvePersistedModelSelection(models, undefined, {
+    id: 'custom-old',
+    fingerprint: 'same-content',
+  })
+
+  assert.equal(byId.currentModelId, 'custom-new')
+  assert.equal(byFingerprint.model?.id, 'custom-new')
+  assert.equal(byFingerprint.currentModelId, 'custom-new')
+  assert.equal(byFingerprint.selectionMigrated, true)
+})
+
+test('uses a runtime fallback without overwriting a missing saved ID', () => {
+  const selection = resolvePersistedModelSelection(models, 'temporarily-missing')
+
+  assert.equal(selection.model?.id, 'preset-standard')
+  assert.equal(selection.currentModelId, 'temporarily-missing')
+  assert.equal(selection.usedRuntimeFallback, true)
+})
+
+test('does not overwrite a missing stable ID when its fingerprint matches another model', () => {
+  const selection = resolvePersistedModelSelection(models, 'missing-old-id', {
+    id: 'missing-old-id',
+    fingerprint: 'same-content',
+  })
+
+  assert.equal(selection.model?.id, 'preset-standard')
+  assert.equal(selection.currentModelId, 'missing-old-id')
+  assert.equal(selection.currentModelFingerprint, 'same-content')
+  assert.equal(selection.usedRuntimeFallback, true)
+})
+
+test('uses a fingerprint for an explicitly pending legacy migration', () => {
+  const selection = resolvePersistedModelSelection(models, 'missing-old-id', {
+    id: 'missing-old-id',
+    fingerprint: 'same-content',
+  }, true)
+
+  assert.equal(selection.model?.id, 'custom-new')
+  assert.equal(selection.currentModelId, 'custom-new')
+  assert.equal(selection.selectionMigrated, true)
+})
+
+test('preserves a missing legacy ID while migrating the schema', () => {
+  const selection = resolvePersistedModelSelection(models, undefined, { id: 'temporarily-missing' })
+
+  assert.equal(selection.model?.id, 'preset-standard')
+  assert.equal(selection.currentModelId, 'temporarily-missing')
+  assert.equal(selection.selectionMigrated, true)
+})
+
+test('keeps the persisted catalog untouched after a transient scan failure', () => {
+  const persisted = prepareModelStoreStateForBackend({
+    currentModelId: 'custom-new',
+    models: [{ id: 'custom-new', customName: 'Desk cat' }],
+    shortcuts: {},
+  }, true, false)
+
+  assert.deepEqual(persisted, {
+    schemaVersion: MODEL_STORE_SCHEMA_VERSION,
+    currentModelId: 'custom-new',
+    shortcuts: {},
+  })
+})

--- a/src/utils/modelStorePersistence.ts
+++ b/src/utils/modelStorePersistence.ts
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+export const MODEL_STORE_SCHEMA_VERSION = 2
+
+const PERSISTED_MODEL_STORE_KEYS = [
+  'schemaVersion',
+  'currentModelId',
+  'currentModelFingerprint',
+  'selectionMigrationPending',
+  'models',
+  'shortcuts',
+  'behaviorNames',
+  'behaviorGroups',
+  'subModels',
+] as const
+
+interface ModelSelectionCandidate {
+  id: string
+  fingerprint?: string
+}
+
+interface LegacyModelSelection extends ModelSelectionCandidate {}
+
+export function prepareModelStoreStateForFrontend(state: Record<string, unknown>) {
+  const prepared = pickPersistedModelStoreState(state)
+
+  if (isRecord(state.currentModel)) {
+    prepared.currentModel = state.currentModel
+  }
+
+  return prepared
+}
+
+export function prepareModelStoreStateForBackend(
+  state: Record<string, unknown>,
+  writable: boolean,
+  persistModelCatalog = true,
+) {
+  if (!writable) return undefined
+
+  const persisted = pickPersistedModelStoreState(state)
+
+  if (!persistModelCatalog) delete persisted.models
+
+  return persisted
+}
+
+export function pickPersistedModelStoreState(state: Record<string, unknown>) {
+  const persisted: Record<string, unknown> = {
+    schemaVersion: MODEL_STORE_SCHEMA_VERSION,
+  }
+
+  for (const key of PERSISTED_MODEL_STORE_KEYS) {
+    if (key === 'schemaVersion' || !(key in state)) continue
+
+    persisted[key] = key === 'models' && Array.isArray(state.models)
+      ? state.models.map(stripModelRuntimeState)
+      : state[key]
+  }
+
+  return persisted
+}
+
+export function resolvePersistedModelSelection<T extends ModelSelectionCandidate>(
+  models: T[],
+  currentModelId?: string,
+  legacyCurrentModel?: LegacyModelSelection,
+  allowFingerprintMigration = !normalizeModelId(currentModelId),
+) {
+  const persistedId = normalizeModelId(currentModelId)
+  const legacyId = normalizeModelId(legacyCurrentModel?.id)
+  const requestedId = persistedId ?? legacyId
+  let model = requestedId ? models.find(candidate => candidate.id === requestedId) : undefined
+
+  if (!model && allowFingerprintMigration && legacyCurrentModel?.fingerprint) {
+    model = models.find(candidate => candidate.fingerprint === legacyCurrentModel.fingerprint)
+  }
+
+  const matchedPersistedSelection = Boolean(model)
+  model ??= models[0]
+  const resolvedModelId = matchedPersistedSelection ? model?.id : requestedId ?? model?.id
+
+  return {
+    model,
+    currentModelId: resolvedModelId,
+    currentModelFingerprint: matchedPersistedSelection
+      ? model?.fingerprint
+      : legacyCurrentModel?.fingerprint,
+    selectionMigrated: Boolean(resolvedModelId && resolvedModelId !== persistedId),
+    usedRuntimeFallback: Boolean(requestedId && !matchedPersistedSelection && model),
+  }
+}
+
+function stripModelRuntimeState(value: unknown) {
+  if (!isRecord(value)) return value
+
+  const { runtimeLease: _, ...persistedModel } = value
+  return persistedModel
+}
+
+function normalizeModelId(value: unknown) {
+  if (typeof value !== 'string') return undefined
+
+  const id = value.trim()
+  return id || undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/utils/modelSwitch.test.ts
+++ b/src/utils/modelSwitch.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import { executeModelSwitchTransaction } from './modelSwitch'
+
+test('accepts a model switch only after loading, committing, and persisting', async () => {
+  const order: string[] = []
+  const result = await executeModelSwitchTransaction({
+    loadTarget: () => {
+      order.push('load')
+    },
+    commitSelection: () => {
+      order.push('commit')
+    },
+    persistSelection: () => {
+      order.push('persist')
+    },
+    rollbackSelection: () => {
+      order.push('rollback')
+    },
+    restorePrevious: () => {
+      order.push('restore')
+    },
+  })
+
+  assert.deepEqual(order, ['load', 'commit', 'persist'])
+  assert.deepEqual(result, { accepted: true })
+})
+
+test('rolls back without committing or saving when loading fails', async () => {
+  const order: string[] = []
+  let selectionCommitted: boolean | undefined
+  const result = await executeModelSwitchTransaction({
+    loadTarget: () => {
+      order.push('load')
+      throw new Error('model is invalid')
+    },
+    commitSelection: () => {
+      order.push('commit')
+    },
+    persistSelection: () => {
+      order.push('persist')
+    },
+    rollbackSelection: (committed) => {
+      selectionCommitted = committed
+      order.push('rollback')
+    },
+    restorePrevious: () => {
+      order.push('restore')
+    },
+  })
+
+  assert.deepEqual(order, ['load', 'rollback', 'restore'])
+  assert.equal(selectionCommitted, false)
+  assert.deepEqual(result, { accepted: false, reason: 'model is invalid' })
+})
+
+test('restores frontend and backend IDs when immediate persistence fails', async () => {
+  let currentModelId = 'old-model'
+  let backendModelId = 'old-model'
+  const order: string[] = []
+  const result = await executeModelSwitchTransaction({
+    loadTarget: () => {
+      order.push('load')
+    },
+    commitSelection: () => {
+      order.push('commit')
+      currentModelId = 'new-model'
+    },
+    persistSelection: () => {
+      order.push('persist-new')
+      backendModelId = currentModelId
+      throw new Error('disk full')
+    },
+    rollbackSelection: (committed) => {
+      assert.equal(committed, true)
+      order.push('rollback-local')
+      currentModelId = 'old-model'
+      order.push('rollback-backend')
+      backendModelId = currentModelId
+    },
+    restorePrevious: () => {
+      order.push('restore')
+    },
+  })
+
+  assert.equal(currentModelId, 'old-model')
+  assert.equal(backendModelId, 'old-model')
+  assert.deepEqual(order, [
+    'load',
+    'commit',
+    'persist-new',
+    'rollback-local',
+    'rollback-backend',
+    'restore',
+  ])
+  assert.deepEqual(result, { accepted: false, reason: 'disk full' })
+})

--- a/src/utils/modelSwitch.ts
+++ b/src/utils/modelSwitch.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+interface ModelSwitchTransactionOperations {
+  loadTarget: () => void | Promise<void>
+  commitSelection: () => void | Promise<void>
+  persistSelection: () => void | Promise<void>
+  rollbackSelection: (selectionCommitted: boolean) => void | Promise<void>
+  restorePrevious: () => void | Promise<void>
+}
+
+export async function executeModelSwitchTransaction(operations: ModelSwitchTransactionOperations) {
+  let selectionCommitted = false
+
+  try {
+    await operations.loadTarget()
+    await operations.commitSelection()
+    selectionCommitted = true
+    await operations.persistSelection()
+
+    return { accepted: true as const }
+  } catch (error) {
+    try {
+      await operations.rollbackSelection(selectionCommitted)
+    } catch {
+      // Preserve the original switching error while still restoring the renderer.
+    }
+
+    try {
+      await operations.restorePrevious()
+    } catch {
+      // The original switching error remains the actionable failure for the caller.
+    }
+
+    return {
+      accepted: false as const,
+      reason: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import { joinWithSeparator } from './path'
+
+test('joins Windows paths without escaping Unicode or shell metacharacters', () => {
+  assert.equal(
+    joinWithSeparator('\\', 'C:\\用户 目录\\猫咪#100%', '模型😀', '纹理.png'),
+    'C:\\用户 目录\\猫咪#100%\\模型😀\\纹理.png',
+  )
+})
+
+test('preserves Windows drive roots and normalizes mixed separators', () => {
+  assert.equal(joinWithSeparator('\\', 'C:\\'), 'C:\\')
+  assert.equal(joinWithSeparator('\\', 'C:/', '\\模型//资源\\', '/背景.png'), 'C:\\模型\\资源\\背景.png')
+})
+
+test('preserves UNC roots while collapsing duplicate separators', () => {
+  assert.equal(
+    joinWithSeparator('\\', '\\\\server\\共享//模型\\', '\\resources//声音.wav'),
+    '\\\\server\\共享\\模型\\resources\\声音.wav',
+  )
+})
+
+test('normalizes POSIX separators without treating backslashes as separators', () => {
+  assert.equal(joinWithSeparator('/', '/tmp//猫 #100%', '模型😀', 'a\\b.png'), '/tmp/猫 #100%/模型😀/a\\b.png')
+})

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -5,13 +5,35 @@
 import { sep } from '@tauri-apps/api/path'
 
 export function join(...paths: string[]) {
-  const joinPaths = paths.map((path, index) => {
-    if (index === 0) {
-      return path.replace(new RegExp(`${sep()}+$`), '')
+  return joinWithSeparator(sep(), ...paths)
+}
+
+export function joinWithSeparator(separator: string, ...paths: string[]) {
+  if (!paths.length) return ''
+
+  const windows = separator === '\\'
+  const normalize = (path: string) => {
+    if (!windows) return path.replace(/\/{2,}/g, '/')
+
+    const isUnc = /^[\\/]{2}/.test(path)
+    const normalized = path.replace(/[\\/]+/g, '\\')
+
+    return isUnc ? `\\${normalized}` : normalized
+  }
+  const normalizedPaths = paths.map(normalize)
+  let result = normalizedPaths.shift() ?? ''
+
+  for (const path of normalizedPaths) {
+    const segment = path.replace(windows ? /^\\+|\\+$/g : /^\/+|\/+$/g, '')
+
+    if (!segment) continue
+    if (!result) {
+      result = segment
+      continue
     }
 
-    return path.replace(new RegExp(`^${sep()}+|${sep()}+$`, 'g'), '')
-  })
+    result = `${result.replace(windows ? /\\+$/g : /\/+$/g, '')}${separator}${segment}`
+  }
 
-  return joinPaths.join(sep())
+  return result
 }

--- a/src/utils/persistence.test.ts
+++ b/src/utils/persistence.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import { persistStateWhenWritable } from './persistence'
+
+test('keeps core store updates in writable windows', () => {
+  const state = { currentModelId: 'model-id' }
+
+  assert.equal(persistStateWhenWritable(state, true), state)
+})
+
+test('drops core store updates in read-only submodel windows', () => {
+  assert.equal(persistStateWhenWritable({ currentModelId: 'runtime-fallback' }, false), undefined)
+})

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import { saveAllNow } from '@tauri-store/pinia'
+import { nextTick } from 'vue'
+
+let coreStoresWritable = true
+
+export function setCoreStoresPersistenceWritable(writable: boolean) {
+  coreStoresWritable = writable
+}
+
+export function isCoreStoresPersistenceWritable() {
+  return coreStoresWritable
+}
+
+export function persistStateWhenWritable<T>(state: T, writable = coreStoresWritable) {
+  return writable ? state : undefined
+}
+
+export async function saveAllPersistentStoresNow() {
+  await nextTick()
+  await saveAllNow()
+}


### PR DESCRIPTION
## Summary

- preserve Unicode, space, `#`, and `%` paths across model import, ZIP extraction, administrator relaunch, and portable packaging
- persist model selection by stable ID with legacy migration, runtime fallback, and an acknowledged load/save transaction
- prevent runtime and submodel-window state from overwriting persisted preferences, and flush stores before restart or exit

## Verification

- `pnpm test` (60/60 on the isolated PR commit)
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src --max-warnings 1` (one pre-existing UnoCSS ordering warning)
- `pnpm build:vite`
- `cargo test --workspace --all-targets` (16/16)
- `cargo check --workspace --all-targets`
- portable packaging through the direct Tauri CLI entry
- `git diff --check`