### PR TITLE
ci: add frontend Rust and portable checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CI: true
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.17.1
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Check TypeScript
+        run: pnpm exec tsc --noEmit
+
+      - name: Check lint
+        run: pnpm exec eslint src --max-warnings 1
+
+      - name: Build frontend
+        run: pnpm build:vite
+
+      - name: Check portable packaging script
+        run: node --check scripts/packagePortable.mjs
+
+  rust:
+    name: Rust (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            runner: ubuntu-22.04
+            inputd: true
+          - name: Windows
+            runner: windows-2022
+            inputd: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Linux dependencies
+        if: matrix.inputd
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libudev-dev
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-${{ matrix.name }}
+
+      - name: Run Rust tests
+        run: cargo test --workspace --all-targets --locked
+
+      - name: Check Rust workspace
+        run: cargo check --workspace --all-targets --locked
+
+      - name: Test Linux input service
+        if: matrix.inputd
+        run: cargo test -p mochi-paw --features inputd --bin mochi-paw-inputd --locked
+
+  portable-smoke:
+    name: Portable Unicode smoke
+    runs-on: windows-2022
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Package from a special-character path
+        shell: pwsh
+        run: ./scripts/testPortableUnicode.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.17.1
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Tauri icons
+        run: pnpm build:icon
+
       - name: Install Linux dependencies
         if: matrix.inputd
         run: |

--- a/scripts/testPortableUnicode.ps1
+++ b/scripts/testPortableUnicode.ps1
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 InfinityXCat
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$temporaryRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$chinese = -join ([char[]](0x4e2d, 0x6587))
+$space = -join ([char[]](0x7a7a, 0x683c))
+$model = -join ([char[]](0x6a21, 0x578b))
+$texture = -join ([char[]](0x7eb9, 0x7406))
+$image = -join ([char[]](0x8d34, 0x56fe))
+$extract = -join ([char[]](0x89e3, 0x538b))
+$result = -join ([char[]](0x7ed3, 0x679c))
+$testRoot = Join-Path $temporaryRoot "Mochi $chinese $space #100%-$([guid]::NewGuid().ToString('N'))"
+$testRoot = [IO.Path]::GetFullPath($testRoot)
+
+if (-not $testRoot.StartsWith($temporaryRoot, [StringComparison]::OrdinalIgnoreCase)) {
+  throw "Portable smoke directory is outside the system temporary directory: $testRoot"
+}
+
+function Assert-FileBytesEqual([string]$expectedPath, [string]$actualPath) {
+  $expected = [IO.File]::ReadAllBytes($expectedPath)
+  $actual = [IO.File]::ReadAllBytes($actualPath)
+
+  if ($expected.Length -ne $actual.Length) {
+    throw "File length differs: $actualPath"
+  }
+
+  for ($index = 0; $index -lt $expected.Length; $index += 1) {
+    if ($expected[$index] -ne $actual[$index]) {
+      throw "File content differs at byte ${index}: $actualPath"
+    }
+  }
+}
+
+try {
+  $scriptDirectory = Join-Path $testRoot 'scripts'
+  $tauriDirectory = Join-Path $testRoot 'src-tauri'
+  $assetDirectory = Join-Path $tauriDirectory 'assets'
+  $modelAssetDirectory = Join-Path $assetDirectory "models\$chinese $model #100%\$texture"
+  $cliDirectory = Join-Path $testRoot 'node_modules\@tauri-apps\cli'
+
+  New-Item -ItemType Directory -Path $scriptDirectory, $assetDirectory, $modelAssetDirectory, $cliDirectory -Force | Out-Null
+  Copy-Item -LiteralPath (Join-Path $repositoryRoot 'package.json') -Destination $testRoot
+  Copy-Item -LiteralPath (Join-Path $repositoryRoot 'scripts\packagePortable.mjs') -Destination $scriptDirectory
+  Copy-Item -LiteralPath (Join-Path $repositoryRoot 'src-tauri\tauri.conf.json') -Destination $tauriDirectory
+  Copy-Item -LiteralPath (Join-Path $repositoryRoot 'src-tauri\assets\tray.png') -Destination $assetDirectory
+
+  $fakeCli = @'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const args = process.argv.slice(2)
+const configIndex = args.indexOf('--config')
+const expectedConfigPath = resolve('target', 'portable-tauri.conf.json')
+const configPath = configIndex < 0 ? undefined : resolve(args[configIndex + 1])
+
+if (args[0] !== 'build' || args[1] !== '--no-bundle' || configPath !== expectedConfigPath) {
+  throw new Error(`Unexpected Tauri arguments: ${JSON.stringify(args)}`)
+}
+
+JSON.parse(readFileSync(configPath, 'utf8'))
+
+const releaseDirectory = resolve('target', 'release')
+mkdirSync(releaseDirectory, { recursive: true })
+writeFileSync(resolve(releaseDirectory, 'mochi-paw.exe'), Buffer.from([0x4d, 0x5a, 0x23, 0x25, 0x00, 0xff]))
+'@
+  $fakeCliPath = Join-Path $cliDirectory 'tauri.js'
+  [IO.File]::WriteAllText($fakeCliPath, $fakeCli, [Text.UTF8Encoding]::new($false))
+
+  $sourceAsset = Join-Path $modelAssetDirectory "$image %.bin"
+  [IO.File]::WriteAllBytes($sourceAsset, [byte[]](0x00, 0x01, 0x23, 0x25, 0x7f, 0xff))
+
+  Push-Location $testRoot
+  try {
+    & node 'scripts\packagePortable.mjs'
+    if ($LASTEXITCODE -ne 0) {
+      throw "Portable packaging failed with exit code $LASTEXITCODE"
+    }
+  } finally {
+    Pop-Location
+  }
+
+  $archive = Get-ChildItem -LiteralPath (Join-Path $testRoot 'target\release\bundle\portable') -Filter '*.zip' | Select-Object -First 1
+  if (-not $archive) {
+    throw 'Portable packaging did not create a ZIP archive.'
+  }
+
+  $extractedDirectory = Join-Path $testRoot "$extract $result #100%"
+  Expand-Archive -LiteralPath $archive.FullName -DestinationPath $extractedDirectory
+
+  $packagedRoot = Join-Path $extractedDirectory 'MochiPaw'
+  $sourceExecutable = Join-Path $testRoot 'target\release\mochi-paw.exe'
+  $packagedExecutable = Join-Path $packagedRoot 'MochiPaw.exe'
+  $packagedAsset = Join-Path $packagedRoot "assets\models\$chinese $model #100%\$texture\$image %.bin"
+
+  Assert-FileBytesEqual $sourceExecutable $packagedExecutable
+  Assert-FileBytesEqual $sourceAsset $packagedAsset
+} finally {
+  if (Test-Path -LiteralPath $testRoot) {
+    $cleanupPath = [IO.Path]::GetFullPath($testRoot)
+    if ($cleanupPath -eq $temporaryRoot -or -not $cleanupPath.StartsWith($temporaryRoot, [StringComparison]::OrdinalIgnoreCase)) {
+      throw "Refusing to remove unsafe portable smoke directory: $cleanupPath"
+    }
+
+    Remove-Item -LiteralPath $cleanupPath -Recurse -Force
+  }
+}


### PR DESCRIPTION
## Summary

- run frontend tests, TypeScript, lint, Vite build, and portable script syntax checks on pull requests and `master`
- run locked Rust tests/checks on Ubuntu 22.04 and Windows 2022, including Linux input-service tests
- exercise portable packaging from a Unicode, space, `#`, and `%` path and verify ZIP contents byte-for-byte

## CI behavior

- read-only repository permissions
- per-PR/ref concurrency with superseded runs cancelled
- frozen pnpm and Cargo lockfiles
- pnpm and Rust build caches
- explicit job timeouts

## Local verification

- `pnpm test` (60/60 on the isolated PR commit)
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src --max-warnings 1`
- `pnpm build:vite`
- `cargo test --workspace --all-targets --locked` (16/16)
- `cargo check --workspace --all-targets --locked`
- `powershell.exe -File scripts/testPortableUnicode.ps1`
- workflow YAML and PowerShell syntax parsing
- `git diff --check`