### PR TITLE
feat(stats): add private typing insights for v1.1.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,14 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build-app:
+    timeout-minutes: 120
     permissions:
       contents: write
     strategy:
@@ -20,59 +24,59 @@ jobs:
         include:
           - platform: macos-latest
             target: aarch64-apple-darwin
-            tauriArgs: --target aarch64-apple-darwin
+            tauriArgs: --target aarch64-apple-darwin -- -- --locked
           - platform: macos-latest
             target: x86_64-apple-darwin
-            tauriArgs: --target x86_64-apple-darwin
+            tauriArgs: --target x86_64-apple-darwin -- -- --locked
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
-            tauriArgs: --target x86_64-pc-windows-msvc --bundles msi,nsis
+            tauriArgs: --target x86_64-pc-windows-msvc --bundles msi,nsis -- -- --locked
             portable: true
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            tauriArgs: --target x86_64-unknown-linux-gnu
+            tauriArgs: --target x86_64-unknown-linux-gnu -- -- --locked
           - platform: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
-            tauriArgs: --target aarch64-unknown-linux-gnu
+            tauriArgs: --target aarch64-unknown-linux-gnu -- -- --locked
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.17.1
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: 22
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 10
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
-      - name: Install rust target
-        run: rustup target add ${{ matrix.target }}
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       - name: Install Linux dependencies
         if: startsWith(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libudev-dev patchelf xdg-utils
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libudev-dev patchelf xdg-utils
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: target
-
-      - name: Setup node with pnpm cache
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
+          shared-key: release-${{ matrix.target }}
+          workspaces: . -> target
 
       - name: Install front-end dependencies
         run: |
           pnpm config set registry https://registry.npmjs.org
-          pnpm install --no-frozen-lockfile
+          pnpm install --frozen-lockfile
+
+      - name: Verify release version
+        run: pnpm exec tsx scripts/checkReleaseVersion.ts "${{ github.ref_name }}"
 
       - name: Generate Tauri icons
         if: startsWith(matrix.platform, 'ubuntu')
@@ -80,7 +84,7 @@ jobs:
 
       - name: Build Wayland input service
         if: startsWith(matrix.platform, 'ubuntu')
-        run: cargo build --manifest-path src-tauri/Cargo.toml --release --features inputd --bin mochi-paw-inputd
+        run: cargo build --manifest-path src-tauri/Cargo.toml --release --features inputd --bin mochi-paw-inputd --locked
 
       - name: Generate contributors manifest
         run: pnpm generate:contributors

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.8"
+version = "1.1.9"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/scripts/checkReleaseVersion.ts
+++ b/scripts/checkReleaseVersion.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import { name, version } from '../package.json'
+import { readCargoLockVersion, readCargoManifestVersion } from './releaseVersion'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const tag = process.argv[2]
+
+if (!tag) throw new Error('Usage: checkReleaseVersion.ts <tag>')
+
+const versions = {
+  package: version,
+  manifest: readCargoManifestVersion(
+    readFileSync(resolve(root, 'src-tauri', 'Cargo.toml'), 'utf8'),
+    name,
+  ),
+  lock: readCargoLockVersion(readFileSync(resolve(root, 'Cargo.lock'), 'utf8'), name),
+}
+const expectedTag = `v${version}`
+
+if (tag !== expectedTag) {
+  throw new Error(`Release tag ${tag} does not match package version ${expectedTag}.`)
+}
+
+for (const [source, sourceVersion] of Object.entries(versions)) {
+  if (sourceVersion !== version) {
+    throw new Error(`${source} version ${sourceVersion} does not match package version ${version}.`)
+  }
+}
+
+console.log(`Release version verified: ${tag}`)

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -7,6 +7,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { name, version } from '../package.json'
+import { replaceCargoLockVersion, replaceCargoManifestVersion } from './releaseVersion'
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -14,15 +15,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
   const tomlPath = resolve(__dirname, '..', 'src-tauri', 'Cargo.toml')
   const lockPath = resolve(__dirname, '..', 'Cargo.lock')
 
-  for (const path of [tomlPath, lockPath]) {
-    let content = readFileSync(path, 'utf-8')
+  const manifest = replaceCargoManifestVersion(readFileSync(tomlPath, 'utf-8'), name, version)
+  const lock = replaceCargoLockVersion(readFileSync(lockPath, 'utf-8'), name, version)
 
-    const regexp = new RegExp(
-      `(name\\s*=\\s*"${name}"\\s*version\\s*=\\s*)"(\\d+\\.\\d+\\.\\d+(-\\w+\\.\\d+)?)"`,
-    )
-
-    content = content.replace(regexp, `$1"${version}"`)
-
-    writeFileSync(path, content)
-  }
+  writeFileSync(tomlPath, manifest)
+  writeFileSync(lockPath, lock)
 })()

--- a/scripts/releaseVersion.test.ts
+++ b/scripts/releaseVersion.test.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import {
+  readCargoLockVersion,
+  readCargoManifestVersion,
+  replaceCargoLockVersion,
+  replaceCargoManifestVersion,
+} from './releaseVersion'
+
+test('updates a Cargo package version when default-run separates name and version', () => {
+  const manifest = `[package]
+name = "mochi-paw"
+default-run = "mochi-paw"
+version = "1.1.8"
+
+[lib]
+name = "mochi_paw_lib"
+`
+  const updated = replaceCargoManifestVersion(manifest, 'mochi-paw', '1.1.9')
+
+  assert.equal(readCargoManifestVersion(updated, 'mochi-paw'), '1.1.9')
+  assert.match(updated, /default-run = "mochi-paw"/)
+  assert.match(updated, /\[lib\]\nname = "mochi_paw_lib"/)
+})
+
+test('updates only the matching Cargo.lock package', () => {
+  const lock = `version = 4
+
+[[package]]
+name = "another-package"
+version = "1.1.8"
+
+[[package]]
+name = "mochi-paw"
+version = "1.1.8"
+dependencies = []
+`
+  const updated = replaceCargoLockVersion(lock, 'mochi-paw', '1.1.9')
+
+  assert.equal(readCargoLockVersion(updated, 'mochi-paw'), '1.1.9')
+  assert.match(updated, /name = "another-package"\nversion = "1\.1\.8"/)
+})
+
+test('fails instead of silently skipping a missing package', () => {
+  assert.throws(
+    () => replaceCargoManifestVersion('[package]\nname = "other"\nversion = "1.0.0"\n', 'mochi-paw', '1.1.9'),
+    /not mochi-paw/,
+  )
+  assert.throws(
+    () => replaceCargoLockVersion('version = 4\n', 'mochi-paw', '1.1.9'),
+    /found 0/,
+  )
+})

--- a/scripts/releaseVersion.ts
+++ b/scripts/releaseVersion.ts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+function escapeRegularExpression(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function findTomlSection(content: string, header: string) {
+  const headerPattern = new RegExp(`^\\[${escapeRegularExpression(header)}\\]\\s*$`, 'm')
+  const match = headerPattern.exec(content)
+
+  if (!match) throw new Error(`Missing TOML section [${header}].`)
+
+  const start = match.index + match[0].length
+  const remaining = content.slice(start)
+  const nextSectionOffset = remaining.search(/^\s*\[/m)
+  const end = nextSectionOffset === -1 ? content.length : start + nextSectionOffset
+
+  return { end, start }
+}
+
+function readVersionFromBlock(block: string, context: string) {
+  const matches = [...block.matchAll(/^version\s*=\s*"([^"]+)"\s*$/gm)]
+
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one version in ${context}, found ${matches.length}.`)
+  }
+
+  return matches[0][1]
+}
+
+export function readCargoManifestVersion(content: string, packageName: string) {
+  const section = findTomlSection(content, 'package')
+  const block = content.slice(section.start, section.end)
+  const nameMatches = [...block.matchAll(/^name\s*=\s*"([^"]+)"\s*$/gm)]
+
+  if (nameMatches.length !== 1 || nameMatches[0][1] !== packageName) {
+    throw new Error(`Cargo manifest [package] is not ${packageName}.`)
+  }
+
+  return readVersionFromBlock(block, `Cargo manifest package ${packageName}`)
+}
+
+export function replaceCargoManifestVersion(content: string, packageName: string, version: string) {
+  const section = findTomlSection(content, 'package')
+  const block = content.slice(section.start, section.end)
+
+  readCargoManifestVersion(content, packageName)
+
+  const updatedBlock = block.replace(
+    /^(version\s*=\s*)"[^"]+"\s*$/m,
+    `$1"${version}"`,
+  )
+
+  return `${content.slice(0, section.start)}${updatedBlock}${content.slice(section.end)}`
+}
+
+function findCargoLockPackage(content: string, packageName: string) {
+  const blocks = content.split(/(?=^\[\[package\]\]\s*$)/m)
+  const matches = blocks.filter((block) => {
+    return new RegExp(`^name\\s*=\\s*"${escapeRegularExpression(packageName)}"\\s*$`, 'm').test(block)
+  })
+
+  if (matches.length !== 1) {
+    throw new Error(`Expected one Cargo.lock package named ${packageName}, found ${matches.length}.`)
+  }
+
+  return matches[0]
+}
+
+export function readCargoLockVersion(content: string, packageName: string) {
+  return readVersionFromBlock(
+    findCargoLockPackage(content, packageName),
+    `Cargo.lock package ${packageName}`,
+  )
+}
+
+export function replaceCargoLockVersion(content: string, packageName: string, version: string) {
+  const block = findCargoLockPackage(content, packageName)
+  const updatedBlock = block.replace(
+    /^(version\s*=\s*)"[^"]+"\s*$/m,
+    `$1"${version}"`,
+  )
+
+  return content.replace(block, updatedBlock)
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,8 @@
 
 [package]
 name = "mochi-paw"
-version = "1.1.8"
+default-run = "mochi-paw"
+version = "1.1.9"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"

--- a/src-tauri/src/bin/mochi-paw-inputd.rs
+++ b/src-tauri/src/bin/mochi-paw-inputd.rs
@@ -32,7 +32,7 @@ mod linux {
 
     const SOCKET_NAME: &str = "mochi-paw-inputd.sock";
 
-    #[derive(Serialize)]
+    #[derive(Debug, PartialEq, Serialize)]
     #[serde(tag = "kind", content = "value")]
     enum Message {
         Ready,
@@ -286,7 +286,7 @@ mod linux {
 
     fn key_event(key: &str, value: i32) -> Option<Message> {
         match value {
-            1 => Some(Message::KeyboardPress(key.into())),
+            1 | 2 => Some(Message::KeyboardPress(key.into())),
             0 => Some(Message::KeyboardRelease(key.into())),
             _ => None,
         }
@@ -338,6 +338,24 @@ mod linux {
             87 => Some("F11"),
             88 => Some("F12"),
             _ => None,
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{Message, key_event};
+
+        #[test]
+        fn normalizes_key_repeat_as_another_press() {
+            assert_eq!(
+                key_event("KeyA", 2),
+                Some(Message::KeyboardPress("KeyA".into()))
+            );
+        }
+
+        #[test]
+        fn ignores_invalid_key_values() {
+            assert_eq!(key_event("KeyA", 3), None);
         }
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,6 +28,11 @@ import { useCatStore } from './stores/cat'
 import { useGeneralStore } from './stores/general'
 import { useModelStore } from './stores/model'
 import { useShortcutStore } from './stores/shortcut.ts'
+import {
+  markTypingStatsPersistenceHydrated,
+  setTypingStatsPersistenceWritable,
+  useTypingStatsStore,
+} from './stores/typingStats'
 import { logError, logInfo, logStartupDiagnostics, logStep } from './utils/diagnostics'
 import { requestModelStoreSave } from './utils/modelPersistence'
 import { setCoreStoresPersistenceWritable } from './utils/persistence'
@@ -40,6 +45,7 @@ const modelStore = useModelStore()
 const catStore = useCatStore()
 const generalStore = useGeneralStore()
 const shortcutStore = useShortcutStore()
+const typingStatsStore = useTypingStatsStore()
 const appWindow = getCurrentWebviewWindow()
 const isSubModelWindow = appWindow.label.startsWith('sub-model-')
 setCoreStoresPersistenceWritable(!isSubModelWindow)
@@ -189,6 +195,10 @@ onMounted(async () => {
   await generalStore.init()
   logStep('app-init', 'start shortcut persistence', { windowLabel: appWindow.label })
   await shortcutStore.$tauri.start()
+  logStep('app-init', 'start typing stats persistence', { windowLabel: appWindow.label })
+  setTypingStatsPersistenceWritable(appWindow.label === WINDOW_LABEL.MAIN)
+  await typingStatsStore.$tauri.start()
+  markTypingStatsPersistenceHydrated()
   await restoreState()
   logStep('app-init', 'application state restored', { windowLabel: appWindow.label })
 

--- a/src/components/update-app/index.vue
+++ b/src/components/update-app/index.vue
@@ -19,7 +19,7 @@ import { useTauriListen } from '@/composables/useTauriListen'
 import { GITHUB_LINK, LISTEN_KEY, UPGRADE_LINK_ACCESS_KEY } from '@/constants'
 import { showWindow } from '@/plugins/window'
 import { useGeneralStore } from '@/stores/general'
-import { saveAllPersistentStoresNow } from '@/utils/persistence'
+import { runAfterSavingPersistentStores } from '@/utils/persistence'
 
 dayjs.extend(utc)
 
@@ -130,8 +130,7 @@ async function handleOk() {
       }
     })
 
-    await saveAllPersistentStoresNow()
-    await relaunch()
+    await runAfterSavingPersistentStores(relaunch)
   } catch (error) {
     message.error(String(error))
   } finally {

--- a/src/composables/useAppMenu.ts
+++ b/src/composables/useAppMenu.ts
@@ -15,7 +15,7 @@ import type { CatStore } from '@/stores/cat'
 import { WINDOW_LABEL } from '@/constants'
 import { showWindow } from '@/plugins/window'
 import { useCatStore } from '@/stores/cat'
-import { saveAllPersistentStoresNow } from '@/utils/persistence'
+import { runAfterSavingPersistentStores } from '@/utils/persistence'
 import { isMac } from '@/utils/platform'
 
 type AppMenuWindowSettings = Pick<CatStore['window'], 'passThrough' | 'scale' | 'opacity'>
@@ -129,12 +129,10 @@ export function useAppMenu(options: AppMenuOptions = {}) {
 
   const getExitMenu = async () => {
     const restartApp = async () => {
-      await saveAllPersistentStoresNow()
-      await relaunch()
+      await runAfterSavingPersistentStores(relaunch)
     }
     const quitApp = async () => {
-      await saveAllPersistentStoresNow()
-      await exit(0)
+      await runAfterSavingPersistentStores(() => exit(0))
     }
 
     return await Promise.all([

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -22,6 +22,8 @@ export const LISTEN_KEY = {
   SUB_MODEL_INPUT_FRAME: 'sub-model-input-frame',
   MODEL_SWITCH_REQUESTED: 'model-switch-requested',
   MODEL_SWITCH_APPLIED: 'model-switch-applied',
+  TYPING_STATS_OPERATION_REQUESTED: 'typing-stats-operation-requested',
+  TYPING_STATS_OPERATION_APPLIED: 'typing-stats-operation-applied',
 }
 
 export const INVOKE_KEY = {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -96,6 +96,35 @@
           "exitApp": "Exit App"
         }
       },
+      "typingStats": {
+        "title": "Typing Stats",
+        "labels": {
+          "overview": "Overview",
+          "today": "Key Presses Today",
+          "presses": "presses",
+          "last30Days": "Last 30 Days",
+          "trend": "Daily Activity",
+          "settings": "Settings",
+          "enabled": "Enable Typing Stats",
+          "history": "Stored History"
+        },
+        "status": {
+          "active": "Tracking",
+          "paused": "Paused"
+        },
+        "hints": {
+          "trendLabel": "Key press totals for the last 30 days",
+          "dayCount": "{date}: {count} presses",
+          "privacy": "Only the daily key press total is counted. Key names, typed content, and application sources are never saved.",
+          "clearHistory": "Permanently delete all saved daily totals.",
+          "clearConfirmation": "All typing statistics will be permanently deleted. This cannot be undone.",
+          "saveFailed": "Could not save the typing statistics change. Please try again."
+        },
+        "buttons": {
+          "clearHistory": "Clear All Statistics",
+          "confirmClear": "Clear Statistics"
+        }
+      },
       "model": {
         "title": "Model",
         "labels": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -90,6 +90,35 @@
           "exitApp": "Sair do App"
         }
       },
+      "typingStats": {
+        "title": "Digitação",
+        "labels": {
+          "overview": "Visão geral",
+          "today": "Teclas pressionadas hoje",
+          "presses": "pressionamentos",
+          "last30Days": "Últimos 30 dias",
+          "trend": "Atividade diária",
+          "settings": "Configurações",
+          "enabled": "Ativar estatísticas de digitação",
+          "history": "Histórico salvo"
+        },
+        "status": {
+          "active": "Registrando",
+          "paused": "Pausado"
+        },
+        "hints": {
+          "trendLabel": "Totais diários de teclas pressionadas nos últimos 30 dias",
+          "dayCount": "{date}: {count} pressionamentos",
+          "privacy": "Apenas o total diário de teclas pressionadas é contado. Nomes de teclas, conteúdo digitado e aplicativos de origem nunca são salvos.",
+          "clearHistory": "Exclui permanentemente todos os totais diários salvos.",
+          "clearConfirmation": "Todas as estatísticas de digitação serão excluídas permanentemente. Esta ação não pode ser desfeita.",
+          "saveFailed": "Não foi possível salvar a alteração nas estatísticas de digitação. Tente novamente."
+        },
+        "buttons": {
+          "clearHistory": "Limpar todas as estatísticas",
+          "confirmClear": "Limpar estatísticas"
+        }
+      },
       "model": {
         "title": "Modelo",
         "labels": {

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -90,6 +90,35 @@
           "exitApp": "Thoát ứng dụng"
         }
       },
+      "typingStats": {
+        "title": "Thống kê",
+        "labels": {
+          "overview": "Tổng quan",
+          "today": "Số lần nhấn phím hôm nay",
+          "presses": "lần nhấn",
+          "last30Days": "30 ngày gần đây",
+          "trend": "Xu hướng hằng ngày",
+          "settings": "Cài đặt",
+          "enabled": "Bật thống kê gõ phím",
+          "history": "Lịch sử đã lưu"
+        },
+        "status": {
+          "active": "Đang thống kê",
+          "paused": "Đã tạm dừng"
+        },
+        "hints": {
+          "trendLabel": "Tổng số lần nhấn phím mỗi ngày trong 30 ngày gần đây",
+          "dayCount": "{date}: {count} lần nhấn",
+          "privacy": "Chỉ tổng số lần nhấn phím mỗi ngày được thống kê. Tên phím, nội dung đã nhập và ứng dụng nguồn không bao giờ được lưu.",
+          "clearHistory": "Xóa vĩnh viễn tất cả số liệu hằng ngày đã lưu.",
+          "clearConfirmation": "Toàn bộ thống kê gõ phím sẽ bị xóa vĩnh viễn và không thể hoàn tác.",
+          "saveFailed": "Không thể lưu thay đổi thống kê gõ phím. Vui lòng thử lại."
+        },
+        "buttons": {
+          "clearHistory": "Xóa toàn bộ thống kê",
+          "confirmClear": "Xác nhận xóa"
+        }
+      },
       "model": {
         "title": "Mô hình",
         "labels": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -96,6 +96,35 @@
           "exitApp": "退出应用"
         }
       },
+      "typingStats": {
+        "title": "打字统计",
+        "labels": {
+          "overview": "概览",
+          "today": "今日按键数",
+          "presses": "次按键",
+          "last30Days": "最近 30 天",
+          "trend": "每日趋势",
+          "settings": "设置",
+          "enabled": "启用打字统计",
+          "history": "已保存的历史记录"
+        },
+        "status": {
+          "active": "统计中",
+          "paused": "已暂停"
+        },
+        "hints": {
+          "trendLabel": "最近 30 天的每日按键总数",
+          "dayCount": "{date}：{count} 次按键",
+          "privacy": "仅统计每日按键总数，不保存按键名称、输入内容或应用来源。",
+          "clearHistory": "永久删除所有已保存的每日统计。",
+          "clearConfirmation": "全部打字统计将被永久删除，且无法撤销。",
+          "saveFailed": "无法保存打字统计更改，请重试。"
+        },
+        "buttons": {
+          "clearHistory": "清空全部统计",
+          "confirmClear": "确认清空"
+        }
+      },
       "model": {
         "title": "模型管理",
         "labels": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -90,6 +90,35 @@
           "exitApp": "退出應用"
         }
       },
+      "typingStats": {
+        "title": "打字統計",
+        "labels": {
+          "overview": "概覽",
+          "today": "今日按鍵數",
+          "presses": "次按鍵",
+          "last30Days": "最近 30 天",
+          "trend": "每日趨勢",
+          "settings": "設定",
+          "enabled": "啟用打字統計",
+          "history": "已儲存的歷史記錄"
+        },
+        "status": {
+          "active": "統計中",
+          "paused": "已暫停"
+        },
+        "hints": {
+          "trendLabel": "最近 30 天的每日按鍵總數",
+          "dayCount": "{date}：{count} 次按鍵",
+          "privacy": "僅統計每日按鍵總數，不儲存按鍵名稱、輸入內容或應用程式來源。",
+          "clearHistory": "永久刪除所有已儲存的每日統計。",
+          "clearConfirmation": "全部打字統計將被永久刪除，且無法復原。",
+          "saveFailed": "無法儲存打字統計變更，請再試一次。"
+        },
+        "buttons": {
+          "clearHistory": "清除全部統計",
+          "confirmClear": "確認清除"
+        }
+      },
       "model": {
         "title": "模型管理",
         "labels": {

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -17,7 +17,9 @@ import { computed, nextTick, onMounted, onUnmounted, ref, toRaw, watch } from 'v
 import { useRoute } from 'vue-router'
 
 import type { Model, ModelMotionInfo, ModelSwitchAcknowledgement, ModelSwitchRequest, SubModelInstance } from '@/stores/model'
-import type { SubModelInputFrame } from '@/utils/subModelRuntime'
+import type { DeviceInputEvent, SubModelInputFrame } from '@/utils/subModelRuntime'
+import type { TypingStatsState } from '@/utils/typingStatsPersistence'
+import type { TypingStatsOperationAcknowledgement, TypingStatsOperationRequest } from '@/utils/typingStatsRequest'
 
 import { useAppMenu } from '@/composables/useAppMenu'
 import { useDevice } from '@/composables/useDevice'
@@ -29,6 +31,11 @@ import { hideWindow, setAlwaysOnTop, setTaskbarVisibility, showWindow } from '@/
 import { useCatStore } from '@/stores/cat'
 import { useGeneralStore } from '@/stores/general.ts'
 import { useModelStore } from '@/stores/model'
+import {
+  isCountableTypingEvent,
+  useTypingStatsStore,
+  waitForTypingStatsPersistenceHydration,
+} from '@/stores/typingStats'
 import { logDebug, logError, logInfo, logStep, logTrace, logWarn } from '@/utils/diagnostics'
 import { isImage } from '@/utils/is'
 import live2d from '@/utils/live2d'
@@ -39,6 +46,8 @@ import { isWindows } from '@/utils/platform'
 import { ensureRuntimeLease, reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
 import { clearObject } from '@/utils/shared'
 import { SubModelInputCoordinator } from '@/utils/subModelRuntime'
+import { TypingStatsOperationCoordinator } from '@/utils/typingStatsCoordinator'
+import { executeTypingStatsMutationTransaction, requestTypingStatsStoreSave } from '@/utils/typingStatsPersistence'
 
 const appWindow = getCurrentWebviewWindow()
 const route = useRoute()
@@ -47,6 +56,8 @@ const isSubModel = Boolean(subModelId)
 const modelStore = useModelStore()
 const catStore = useCatStore()
 const generalStore = useGeneralStore()
+const typingStatsStore = useTypingStatsStore()
+const typingStatsCoordinator = new TypingStatsOperationCoordinator<TimestampedTypingInput>()
 const inputCoordinator = isSubModel
   ? undefined
   : new SubModelInputCoordinator(() => modelStore.subModels.filter(instance => instance.visible))
@@ -103,7 +114,10 @@ const { startListening, handleInputEvent: handleDeviceInputEvent } = useDevice({
   listeners: listenerSettings,
   enableWindowHover: !isSubModel,
   listen: !isSubModel,
-  onInputEvent: event => inputCoordinator?.enqueueDevice(event),
+  onInputEvent: (event) => {
+    recordTypingStatsInput(event)
+    inputCoordinator?.enqueueDevice(event)
+  },
 })
 const { getBaseMenu, getExitMenu } = useAppMenu({
   windowSettings,
@@ -142,6 +156,21 @@ const modelLoadTrigger = ref(0)
 
 const SCALE_DRAG_SENSITIVITY = 0.12
 const SHORTCUT_RESIZE_INTERVAL = 33
+
+interface TimestampedTypingInput {
+  event: DeviceInputEvent
+  now: Date
+}
+
+function applyTypingInput(input: TimestampedTypingInput) {
+  typingStatsStore.recordInput(input.event, input.now)
+}
+
+function recordTypingStatsInput(event: DeviceInputEvent) {
+  if (!isCountableTypingEvent(event)) return
+
+  typingStatsCoordinator.record({ event, now: new Date() }, applyTypingInput)
+}
 
 function reportCurrentSubModelWindowChange() {
   const instance = subModel.value
@@ -291,10 +320,104 @@ useTauriListen<ModelSwitchRequest>(LISTEN_KEY.MODEL_SWITCH_REQUESTED, async ({ p
   }
 })
 
-onMounted(() => {
-  if (!isSubModel) startListening()
+function getTypingStatsState(): TypingStatsState {
+  return {
+    dailyCounts: { ...typingStatsStore.dailyCounts },
+    enabled: typingStatsStore.enabled,
+  }
+}
 
-  if (!isSubModel) return
+function applyTypingStatsState(state: TypingStatsState) {
+  typingStatsStore.dailyCounts = { ...state.dailyCounts }
+  typingStatsStore.enabled = state.enabled
+}
+
+function acknowledgeTypingStatsOperation(acknowledgement: TypingStatsOperationAcknowledgement) {
+  void emit(LISTEN_KEY.TYPING_STATS_OPERATION_APPLIED, acknowledgement)
+    .catch(error => logError('[typing-stats] failed to send acknowledgement', {
+      ...acknowledgement,
+      error,
+    }))
+}
+
+async function applyTypingStatsOperation(request: TypingStatsOperationRequest) {
+  await waitForTypingStatsPersistenceHydration()
+
+  const { operation } = request
+  let result: Pick<TypingStatsOperationAcknowledgement, 'accepted' | 'reason'>
+
+  if (operation.kind === 'resume') {
+    try {
+      const replayedInputCount = typingStatsCoordinator.resumeInputs(operation.pauseId, applyTypingInput)
+
+      if (replayedInputCount > 0) {
+        await requestTypingStatsStoreSave(getTypingStatsState())
+      }
+      result = { accepted: true }
+    } catch (error) {
+      result = {
+        accepted: false,
+        reason: error instanceof Error ? error.message : String(error),
+      }
+    }
+  } else if (operation.kind === 'flush') {
+    typingStatsCoordinator.pauseInputs(operation.pauseId)
+
+    try {
+      await requestTypingStatsStoreSave(getTypingStatsState())
+      result = { accepted: true }
+    } catch (error) {
+      typingStatsCoordinator.resumeInputs(operation.pauseId, applyTypingInput)
+      result = {
+        accepted: false,
+        reason: error instanceof Error ? error.message : String(error),
+      }
+    }
+  } else {
+    result = await executeTypingStatsMutationTransaction({
+      snapshot: getTypingStatsState,
+      apply: () => {
+        if (operation.kind === 'set-enabled') {
+          typingStatsStore.enabled = operation.enabled
+        } else {
+          typingStatsStore.clearHistory()
+        }
+      },
+      persist: () => requestTypingStatsStoreSave(getTypingStatsState()),
+      restore: async (snapshot) => {
+        applyTypingStatsState(snapshot)
+        await requestTypingStatsStoreSave(snapshot)
+      },
+    })
+  }
+
+  acknowledgeTypingStatsOperation({
+    requestId: request.requestId,
+    state: getTypingStatsState(),
+    ...result,
+  })
+}
+
+useTauriListen<TypingStatsOperationRequest>(LISTEN_KEY.TYPING_STATS_OPERATION_REQUESTED, ({ payload }) => {
+  if (isSubModel) return
+
+  void typingStatsCoordinator.run(() => applyTypingStatsOperation(payload))
+    .catch((error) => {
+      acknowledgeTypingStatsOperation({
+        accepted: false,
+        reason: error instanceof Error ? error.message : String(error),
+        requestId: payload.requestId,
+        state: getTypingStatsState(),
+      })
+    })
+})
+
+onMounted(async () => {
+  if (!isSubModel) {
+    await waitForTypingStatsPersistenceHydration()
+    startListening()
+    return
+  }
 
   appWindow.onMoved(({ payload }) => {
     const instance = subModel.value

--- a/src/pages/preference/components/general/components/windows-permissions/index.vue
+++ b/src/pages/preference/components/general/components/windows-permissions/index.vue
@@ -12,7 +12,7 @@ import { useI18n } from 'vue-i18n'
 import ProListItem from '@/components/pro-list-item/index.vue'
 import ProList from '@/components/pro-list/index.vue'
 import { isRunningAsAdministrator, relaunchAsAdministrator } from '@/plugins/adminStatus'
-import { saveAllPersistentStoresNow } from '@/utils/persistence'
+import { runAfterSavingPersistentStores } from '@/utils/persistence'
 
 const authorized = ref(true)
 const restarting = ref(false)
@@ -41,8 +41,7 @@ async function showAdministratorGuide() {
   try {
     restarting.value = true
 
-    await saveAllPersistentStoresNow()
-    await relaunchAsAdministrator()
+    await runAfterSavingPersistentStores(relaunchAsAdministrator)
   } catch (error) {
     console.error(error)
     await message(t('pages.preference.general.hints.administratorRelaunchFailed'), {

--- a/src/pages/preference/components/typing-stats/index.vue
+++ b/src/pages/preference/components/typing-stats/index.vue
@@ -1,0 +1,280 @@
+<!-- SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ -->
+
+<script setup lang="ts">
+import { Button, message, Modal, Switch, Tag } from 'antdv-next'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import ProListItem from '@/components/pro-list-item/index.vue'
+import ProList from '@/components/pro-list/index.vue'
+import { useGeneralStore } from '@/stores/general'
+import { useTypingStatsStore } from '@/stores/typingStats'
+import { logError } from '@/utils/diagnostics'
+import { requestTypingStatsOperation } from '@/utils/typingStatsRequest'
+
+const typingStatsStore = useTypingStatsStore()
+const generalStore = useGeneralStore()
+const { t } = useI18n()
+
+const maxCount = computed(() => {
+  return Math.max(1, ...typingStatsStore.recent30Days.map(item => item.count))
+})
+const hasHistory = computed(() => Object.keys(typingStatsStore.dailyCounts).length > 0)
+const pendingEnabled = ref<boolean>()
+const mutationPending = ref(false)
+const trackingEnabled = computed({
+  get: () => pendingEnabled.value ?? typingStatsStore.enabled,
+  set: requestEnabledChange,
+})
+let midnightTimer: ReturnType<typeof setTimeout> | undefined
+
+watch(() => typingStatsStore.enabled, (value) => {
+  if (value === pendingEnabled.value) pendingEnabled.value = undefined
+})
+
+function formatCount(count: number) {
+  return new Intl.NumberFormat(generalStore.appearance.language).format(count)
+}
+
+function formatDate(dateKey: string) {
+  const [year, month, day] = dateKey.split('-').map(Number)
+
+  return new Intl.DateTimeFormat(generalStore.appearance.language, {
+    day: 'numeric',
+    month: 'short',
+  }).format(new Date(year, month - 1, day, 12))
+}
+
+function barHeight(count: number) {
+  if (count === 0) return '2px'
+
+  return `${Math.max(4, (count / maxCount.value) * 100)}%`
+}
+
+function showDateLabel(index: number, length: number) {
+  return (index % 6 === 0 && index < 24) || index === length - 1
+}
+
+function dateGridColumn(index: number, length: number) {
+  if (index === length - 1) return `${length - 5} / ${length + 1}`
+
+  return `${index + 1} / span 6`
+}
+
+function scheduleMidnightRefresh() {
+  const now = new Date()
+  const nextMidnight = new Date(now)
+
+  typingStatsStore.refreshCurrentDate(now)
+  nextMidnight.setHours(24, 0, 0, 0)
+  midnightTimer = setTimeout(scheduleMidnightRefresh, nextMidnight.getTime() - now.getTime() + 100)
+}
+
+function requestEnabledChange(enabled: boolean) {
+  if (mutationPending.value) return
+
+  pendingEnabled.value = enabled
+  mutationPending.value = true
+
+  void requestTypingStatsOperation({ kind: 'set-enabled', enabled })
+    .then((acknowledgement) => {
+      if (!acknowledgement.accepted) {
+        throw new Error(acknowledgement.reason ?? 'The main window rejected the tracking change.')
+      }
+
+      if (acknowledgement.state) {
+        typingStatsStore.$patch(acknowledgement.state)
+      }
+    })
+    .catch((error) => {
+      logError('[typing-stats] failed to change tracking state', { enabled, error })
+      message.error(t('pages.preference.typingStats.hints.saveFailed'))
+    })
+    .finally(() => {
+      pendingEnabled.value = undefined
+      mutationPending.value = false
+    })
+}
+
+async function requestClearHistory() {
+  if (mutationPending.value) return
+
+  mutationPending.value = true
+
+  try {
+    const acknowledgement = await requestTypingStatsOperation({ kind: 'clear-history' })
+
+    if (!acknowledgement.accepted) {
+      throw new Error(acknowledgement.reason ?? 'The main window rejected clearing typing history.')
+    }
+
+    if (acknowledgement.state) {
+      typingStatsStore.$patch(acknowledgement.state)
+    }
+  } catch (error) {
+    logError('[typing-stats] failed to request history clearing', { error })
+    message.error(t('pages.preference.typingStats.hints.saveFailed'))
+    throw error
+  } finally {
+    mutationPending.value = false
+  }
+}
+
+function confirmClearHistory() {
+  Modal.confirm({
+    content: t('pages.preference.typingStats.hints.clearConfirmation'),
+    okText: t('pages.preference.typingStats.buttons.confirmClear'),
+    okType: 'danger',
+    onOk: requestClearHistory,
+    title: t('pages.preference.typingStats.buttons.clearHistory'),
+  })
+}
+
+onMounted(scheduleMidnightRefresh)
+
+onUnmounted(() => {
+  if (midnightTimer) clearTimeout(midnightTimer)
+})
+</script>
+
+<template>
+  <ProList :title="t('pages.preference.typingStats.labels.overview')">
+    <ProListItem
+      :title="t('pages.preference.typingStats.labels.today')"
+      vertical
+    >
+      <div class="flex items-end justify-between gap-4">
+        <div class="min-w-0 flex items-baseline gap-2">
+          <strong class="break-all text-9 font-semibold leading-none">
+            {{ formatCount(typingStatsStore.todayCount) }}
+          </strong>
+          <span class="color-text-tertiary">
+            {{ t('pages.preference.typingStats.labels.presses') }}
+          </span>
+        </div>
+
+        <Tag :color="typingStatsStore.enabled ? 'success' : 'default'">
+          {{ t(`pages.preference.typingStats.status.${typingStatsStore.enabled ? 'active' : 'paused'}`) }}
+        </Tag>
+      </div>
+    </ProListItem>
+  </ProList>
+
+  <ProList :title="t('pages.preference.typingStats.labels.last30Days')">
+    <ProListItem
+      :title="t('pages.preference.typingStats.labels.trend')"
+      vertical
+    >
+      <div
+        :aria-label="t('pages.preference.typingStats.hints.trendLabel')"
+        class="typing-trend"
+        role="img"
+      >
+        <template
+          v-for="(item, index) in typingStatsStore.recent30Days"
+          :key="item.date"
+        >
+          <div
+            class="typing-trend-track"
+            :style="{ gridColumn: index + 1 }"
+            :title="t('pages.preference.typingStats.hints.dayCount', { count: formatCount(item.count), date: formatDate(item.date) })"
+          >
+            <div
+              class="typing-trend-bar"
+              :class="{ 'typing-trend-bar-empty': item.count === 0 }"
+              :style="{ height: barHeight(item.count) }"
+            />
+          </div>
+
+          <span
+            v-if="showDateLabel(index, typingStatsStore.recent30Days.length)"
+            class="typing-trend-date"
+            :class="{ 'typing-trend-date-last': index === typingStatsStore.recent30Days.length - 1 }"
+            :style="{ gridColumn: dateGridColumn(index, typingStatsStore.recent30Days.length) }"
+          >
+            {{ formatDate(item.date) }}
+          </span>
+        </template>
+      </div>
+    </ProListItem>
+  </ProList>
+
+  <ProList :title="t('pages.preference.typingStats.labels.settings')">
+    <ProListItem
+      :description="t('pages.preference.typingStats.hints.privacy')"
+      :title="t('pages.preference.typingStats.labels.enabled')"
+    >
+      <Switch
+        v-model:checked="trackingEnabled"
+        :loading="mutationPending"
+      />
+    </ProListItem>
+
+    <ProListItem
+      :description="t('pages.preference.typingStats.hints.clearHistory')"
+      :title="t('pages.preference.typingStats.labels.history')"
+    >
+      <Button
+        danger
+        :disabled="!hasHistory || mutationPending"
+        :loading="mutationPending"
+        @click="confirmClearHistory"
+      >
+        <template #icon>
+          <i class="i-lucide:trash-2" />
+        </template>
+        {{ t('pages.preference.typingStats.buttons.clearHistory') }}
+      </Button>
+    </ProListItem>
+  </ProList>
+</template>
+
+<style scoped>
+.typing-trend {
+  display: grid;
+  grid-template-columns: repeat(30, minmax(6px, 1fr));
+  grid-template-rows: 156px 24px;
+  gap: 4px;
+  width: 100%;
+  height: 184px;
+}
+
+.typing-trend-track {
+  grid-row: 1;
+  display: flex;
+  align-items: flex-end;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--ant-color-fill-quaternary);
+  border-radius: 3px 3px 0 0;
+}
+
+.typing-trend-bar {
+  width: 100%;
+  min-height: 2px;
+  background: var(--ant-color-primary);
+  border-radius: 3px 3px 0 0;
+  transition: height 180ms ease;
+}
+
+.typing-trend-bar-empty {
+  background: var(--ant-color-fill-secondary);
+}
+
+.typing-trend-date {
+  grid-row: 2;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ant-color-text-tertiary);
+  font-size: 11px;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.typing-trend-date-last {
+  text-align: right;
+}
+</style>

--- a/src/pages/preference/index.vue
+++ b/src/pages/preference/index.vue
@@ -22,6 +22,7 @@ import General from './components/general/index.vue'
 import Model from './components/model/index.vue'
 import Shortcut from './components/shortcut/index.vue'
 import SubModel from './components/sub-model/index.vue'
+import TypingStats from './components/typing-stats/index.vue'
 
 useTray()
 const appStore = useAppStore()
@@ -47,6 +48,12 @@ const menus = computed(() => [
     label: t('pages.preference.general.title'),
     icon: 'i-solar:settings-minimalistic-bold',
     component: General,
+  },
+  {
+    key: 'typing-stats',
+    label: t('pages.preference.typingStats.title'),
+    icon: 'i-solar:chart-2-bold',
+    component: TypingStats,
   },
   {
     key: 'model',
@@ -115,7 +122,7 @@ const menus = computed(() => [
             :class="item.icon"
           />
 
-          <span>{{ item.label }}</span>
+          <span class="break-words text-center leading-tight">{{ item.label }}</span>
         </div>
       </div>
     </div>

--- a/src/stores/typingStats.test.ts
+++ b/src/stores/typingStats.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+
+import type { DeviceInputEvent } from '@/utils/subModelRuntime'
+
+import {
+  buildRecentDailyCounts,
+  getLocalDateKey,
+  isCountableTypingEvent,
+  useTypingStatsStore,
+} from './typingStats'
+
+function keyboardPress(value: string): DeviceInputEvent {
+  return { kind: 'KeyboardPress', value }
+}
+
+function createStore() {
+  setActivePinia(createPinia())
+  return useTypingStatsStore()
+}
+
+test('ignores modifiers, unknown keys, and empty keyboard presses', () => {
+  for (const key of [
+    '',
+    '   ',
+    'ShiftLeft',
+    'ControlRight',
+    'AltGr',
+    'MetaLeft',
+    'Fn',
+    'Function',
+    'Unknown(123)',
+    'RawKey(456)',
+    'Unidentified',
+  ]) {
+    assert.equal(isCountableTypingEvent(keyboardPress(key)), false, key)
+  }
+})
+
+test('counts text and non-modifier control keys', () => {
+  for (const key of ['KeyA', 'Return', 'Backspace', 'UpArrow', 'F1', 'CapsLock']) {
+    assert.equal(isCountableTypingEvent(keyboardPress(key)), true, key)
+  }
+})
+
+test('ignores keyboard releases and mouse events', () => {
+  assert.equal(isCountableTypingEvent({ kind: 'KeyboardRelease', value: 'KeyA' }), false)
+  assert.equal(isCountableTypingEvent({ kind: 'MousePress', value: 'Left' }), false)
+  assert.equal(isCountableTypingEvent({ kind: 'MouseMove', value: { x: 1, y: 2 } }), false)
+})
+
+test('records each repeated press and pauses while disabled', () => {
+  const store = createStore()
+  const now = new Date(2026, 0, 31, 23, 59)
+
+  assert.equal(store.recordInput(keyboardPress('KeyA'), now), true)
+  assert.equal(store.recordInput(keyboardPress('KeyA'), now), true)
+  assert.equal(store.todayCount, 2)
+
+  store.enabled = false
+
+  assert.equal(store.recordInput(keyboardPress('KeyA'), now), false)
+  assert.equal(store.todayCount, 2)
+})
+
+test('archives presses using the local date across midnight', () => {
+  const store = createStore()
+  const beforeMidnight = new Date(2026, 0, 31, 23, 59, 59)
+  const afterMidnight = new Date(2026, 1, 1, 0, 0, 1)
+
+  store.recordInput(keyboardPress('Return'), beforeMidnight)
+  store.recordInput(keyboardPress('Backspace'), afterMidnight)
+
+  assert.deepEqual(store.dailyCounts, {
+    '2026-01-31': 1,
+    '2026-02-01': 1,
+  })
+  assert.equal(store.todayCount, 1)
+})
+
+test('builds an ordered recent series and fills missing dates with zero', () => {
+  const series = buildRecentDailyCounts({
+    '2026-02-01': 4,
+    '2026-02-03': 7,
+  }, new Date(2026, 1, 3, 18), 4)
+
+  assert.deepEqual(series, [
+    { count: 0, date: '2026-01-31' },
+    { count: 4, date: '2026-02-01' },
+    { count: 0, date: '2026-02-02' },
+    { count: 7, date: '2026-02-03' },
+  ])
+})
+
+test('exposes 30 recent days and refreshes the current day without input', () => {
+  const store = createStore()
+
+  store.dailyCounts = {
+    '2026-04-10': 3,
+    '2026-04-11': 8,
+  }
+  store.refreshCurrentDate(new Date(2026, 3, 10, 23, 59))
+
+  assert.equal(store.recent30Days.length, 30)
+  assert.equal(store.todayCount, 3)
+
+  store.refreshCurrentDate(new Date(2026, 3, 11, 0, 0))
+
+  assert.equal(store.todayCount, 8)
+  assert.equal(store.recent30Days.at(-1)?.date, '2026-04-11')
+})
+
+test('clears history without changing the enabled preference', () => {
+  const store = createStore()
+
+  store.enabled = false
+  store.dailyCounts = { '2026-01-01': 12 }
+  store.clearHistory()
+
+  assert.deepEqual(store.dailyCounts, {})
+  assert.equal(store.enabled, false)
+})
+
+test('initializes new users with privacy-preserving defaults', () => {
+  const store = createStore()
+
+  store.$patch({})
+
+  assert.deepEqual(store.$state, {
+    dailyCounts: {},
+    enabled: true,
+  })
+  assert.equal(getLocalDateKey(new Date(2026, 0, 2)), '2026-01-02')
+
+  store.recordInput(keyboardPress('KeySecret'), new Date(2026, 0, 2, 12))
+
+  assert.deepEqual(store.$state, {
+    dailyCounts: { '2026-01-02': 1 },
+    enabled: true,
+  })
+  assert.equal(JSON.stringify(store.$state).includes('KeySecret'), false)
+})

--- a/src/stores/typingStats.ts
+++ b/src/stores/typingStats.ts
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+import type { DeviceInputEvent } from '@/utils/subModelRuntime'
+
+export interface DailyTypingCount {
+  count: number
+  date: string
+}
+
+const RECENT_DAY_COUNT = 30
+const MODIFIER_KEY_PATTERN = /^(?:Shift|Control|Alt|Meta)/
+const UNKNOWN_KEY_PATTERN = /^(?:Unknown|Unidentified|RawKey)/i
+let persistenceWritable = true
+let persistenceHydrated = false
+let resolvePersistenceHydrated!: () => void
+const persistenceHydratedPromise = new Promise<void>((resolve) => {
+  resolvePersistenceHydrated = resolve
+})
+
+export function setTypingStatsPersistenceWritable(writable: boolean) {
+  persistenceWritable = writable
+}
+
+export function markTypingStatsPersistenceHydrated() {
+  if (persistenceHydrated) return
+
+  persistenceHydrated = true
+  resolvePersistenceHydrated()
+}
+
+export function waitForTypingStatsPersistenceHydration() {
+  return persistenceHydratedPromise
+}
+
+export function getLocalDateKey(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}-${month}-${day}`
+}
+
+export function isCountableTypingEvent(event: DeviceInputEvent) {
+  if (event.kind !== 'KeyboardPress') return false
+
+  const key = event.value.trim()
+
+  if (!key || MODIFIER_KEY_PATTERN.test(key) || UNKNOWN_KEY_PATTERN.test(key)) return false
+
+  return key !== 'Fn' && key !== 'Function'
+}
+
+function getDailyCount(dailyCounts: Record<string, number>, dateKey: string) {
+  const count = dailyCounts[dateKey]
+
+  if (!Number.isFinite(count) || count < 0) return 0
+
+  return Math.trunc(count)
+}
+
+export function buildRecentDailyCounts(
+  dailyCounts: Record<string, number>,
+  now: Date,
+  dayCount = RECENT_DAY_COUNT,
+): DailyTypingCount[] {
+  const count = Math.max(0, Math.trunc(dayCount))
+  const anchor = new Date(now)
+
+  anchor.setHours(12, 0, 0, 0)
+
+  return Array.from({ length: count }, (_, index) => {
+    const date = new Date(anchor)
+
+    date.setDate(anchor.getDate() - (count - index - 1))
+
+    const dateKey = getLocalDateKey(date)
+
+    return {
+      count: getDailyCount(dailyCounts, dateKey),
+      date: dateKey,
+    }
+  })
+}
+
+export const useTypingStatsStore = defineStore('typingStats', () => {
+  const enabled = ref(true)
+  const dailyCounts = ref<Record<string, number>>({})
+  const currentDateKey = ref(getLocalDateKey(new Date()))
+
+  const todayCount = computed(() => getDailyCount(dailyCounts.value, currentDateKey.value))
+  const recent30Days = computed(() => {
+    const [year, month, day] = currentDateKey.value.split('-').map(Number)
+
+    return buildRecentDailyCounts(dailyCounts.value, new Date(year, month - 1, day, 12))
+  })
+
+  function refreshCurrentDate(now = new Date()) {
+    currentDateKey.value = getLocalDateKey(now)
+  }
+
+  function recordInput(event: DeviceInputEvent, now = new Date()) {
+    if (!enabled.value || !isCountableTypingEvent(event)) return false
+
+    const dateKey = getLocalDateKey(now)
+    const count = getDailyCount(dailyCounts.value, dateKey)
+
+    currentDateKey.value = dateKey
+    dailyCounts.value[dateKey] = count + 1
+
+    return true
+  }
+
+  function clearHistory() {
+    dailyCounts.value = {}
+  }
+
+  return {
+    clearHistory,
+    dailyCounts,
+    enabled,
+    recent30Days,
+    recordInput,
+    refreshCurrentDate,
+    todayCount,
+  }
+}, {
+  tauri: {
+    filterKeys: ['enabled', 'dailyCounts'],
+    filterKeysStrategy: 'pick',
+    hooks: {
+      beforeBackendSync: state => persistenceWritable ? state : null,
+    },
+    saveInterval: 1000,
+    saveStrategy: 'throttle',
+    syncInterval: 1000,
+    syncStrategy: 'throttle',
+  },
+})

--- a/src/utils/persistence.test.ts
+++ b/src/utils/persistence.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict'
 // eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
 import test from 'node:test'
 
-import { persistStateWhenWritable } from './persistence'
+import {
+  persistStateWhenWritable,
+  runAfterSavingPersistentStores,
+  saveAllPersistentStoresNow,
+} from './persistence'
 
 test('keeps core store updates in writable windows', () => {
   const state = { currentModelId: 'model-id' }
@@ -12,4 +16,114 @@ test('keeps core store updates in writable windows', () => {
 
 test('drops core store updates in read-only submodel windows', () => {
   assert.equal(persistStateWhenWritable({ currentModelId: 'runtime-fallback' }, false), undefined)
+})
+
+test('flushes main-window typing statistics before saving all stores', async () => {
+  const order: string[] = []
+
+  await saveAllPersistentStoresNow({
+    flushTypingStats: async () => {
+      order.push('flush-typing-stats')
+    },
+    resumeTypingStats: async () => {},
+    saveAll: async () => {
+      order.push('save-all')
+    },
+  })
+
+  assert.deepEqual(order, ['flush-typing-stats', 'save-all'])
+})
+
+test('does not save stale backend state when typing statistics cannot flush', async () => {
+  let saved = false
+  let resumed = false
+
+  await assert.rejects(
+    saveAllPersistentStoresNow({
+      flushTypingStats: async () => {
+        throw new Error('main window unavailable')
+      },
+      resumeTypingStats: async () => {
+        resumed = true
+      },
+      saveAll: async () => {
+        saved = true
+      },
+    }),
+    /main window unavailable/,
+  )
+  assert.equal(saved, false)
+  assert.equal(resumed, true)
+})
+
+test('resumes buffered typing input when the final save fails', async () => {
+  const order: string[] = []
+
+  await assert.rejects(
+    saveAllPersistentStoresNow({
+      flushTypingStats: async () => {
+        order.push('flush-typing-stats')
+      },
+      resumeTypingStats: async () => {
+        order.push('resume-typing-stats')
+      },
+      saveAll: async () => {
+        order.push('save-all')
+        throw new Error('save failed')
+      },
+    }),
+    /save failed/,
+  )
+
+  assert.deepEqual(order, ['flush-typing-stats', 'save-all', 'resume-typing-stats'])
+})
+
+test('resumes buffered typing input when the process action fails', async () => {
+  const order: string[] = []
+
+  await assert.rejects(
+    runAfterSavingPersistentStores(
+      async () => {
+        order.push('relaunch')
+        throw new Error('relaunch failed')
+      },
+      {
+        flushTypingStats: async () => {
+          order.push('flush-typing-stats')
+        },
+        resumeTypingStats: async () => {
+          order.push('resume-typing-stats')
+        },
+        saveAll: async () => {
+          order.push('save-all')
+        },
+      },
+    ),
+    /relaunch failed/,
+  )
+
+  assert.deepEqual(order, ['flush-typing-stats', 'save-all', 'relaunch', 'resume-typing-stats'])
+})
+
+test('keeps typing input paused when the process action succeeds', async () => {
+  const order: string[] = []
+
+  await runAfterSavingPersistentStores(
+    async () => {
+      order.push('exit')
+    },
+    {
+      flushTypingStats: async () => {
+        order.push('flush-typing-stats')
+      },
+      resumeTypingStats: async () => {
+        order.push('resume-typing-stats')
+      },
+      saveAll: async () => {
+        order.push('save-all')
+      },
+    },
+  )
+
+  assert.deepEqual(order, ['flush-typing-stats', 'save-all', 'exit'])
 })

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -2,9 +2,31 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
 import { saveAllNow } from '@tauri-store/pinia'
+import { nanoid } from 'nanoid'
 import { nextTick } from 'vue'
 
+import { requestTypingStatsOperation } from './typingStatsRequest'
+
 let coreStoresWritable = true
+let terminalActionInProgress = false
+
+export interface PersistentStoresSaveAdapter {
+  flushTypingStats: (pauseId: string) => Promise<void>
+  resumeTypingStats: (pauseId: string) => Promise<void>
+  saveAll: () => Promise<void>
+}
+
+const defaultSaveAdapter: PersistentStoresSaveAdapter = {
+  flushTypingStats: pauseId => flushTypingStatsPersistenceNow(pauseId),
+  resumeTypingStats: async (pauseId) => {
+    const acknowledgement = await requestTypingStatsOperation({ kind: 'resume', pauseId })
+
+    if (!acknowledgement.accepted) {
+      throw new Error(acknowledgement.reason ?? 'The main window could not resume typing statistics.')
+    }
+  },
+  saveAll: saveAllNow,
+}
 
 export function setCoreStoresPersistenceWritable(writable: boolean) {
   coreStoresWritable = writable
@@ -18,7 +40,59 @@ export function persistStateWhenWritable<T>(state: T, writable = coreStoresWrita
   return writable ? state : undefined
 }
 
-export async function saveAllPersistentStoresNow() {
-  await nextTick()
-  await saveAllNow()
+export async function flushTypingStatsPersistenceNow(pauseId: string) {
+  const acknowledgement = await requestTypingStatsOperation({ kind: 'flush', pauseId })
+
+  if (!acknowledgement.accepted) {
+    throw new Error(acknowledgement.reason ?? 'The main window could not flush typing statistics.')
+  }
+}
+
+export async function saveAllPersistentStoresNow(
+  adapter = defaultSaveAdapter,
+  pauseId = nanoid(),
+) {
+  try {
+    await adapter.flushTypingStats(pauseId)
+    await nextTick()
+    await adapter.saveAll()
+  } catch (error) {
+    try {
+      await adapter.resumeTypingStats(pauseId)
+    } catch {
+      // Preserve the original save error; the main window may already be unavailable.
+    }
+
+    throw error
+  }
+}
+
+export async function runAfterSavingPersistentStores(
+  action: () => Promise<void>,
+  adapter = defaultSaveAdapter,
+) {
+  if (terminalActionInProgress) {
+    throw new Error('Another application exit or restart is already in progress.')
+  }
+
+  terminalActionInProgress = true
+  const pauseId = nanoid()
+
+  try {
+    await saveAllPersistentStoresNow(adapter, pauseId)
+
+    try {
+      await action()
+    } catch (error) {
+      try {
+        await adapter.resumeTypingStats(pauseId)
+      } catch {
+        // Preserve the process action error; the main window may already be unavailable.
+      }
+
+      throw error
+    }
+  } finally {
+    terminalActionInProgress = false
+  }
 }

--- a/src/utils/typingStatsCoordinator.test.ts
+++ b/src/utils/typingStatsCoordinator.test.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import { TypingStatsOperationCoordinator } from './typingStatsCoordinator'
+
+test('serializes inputs before and after an asynchronous operation', async () => {
+  const coordinator = new TypingStatsOperationCoordinator<string>()
+  const order: string[] = []
+  let markOperationStarted!: () => void
+  let finishOperation!: () => void
+  const operationStarted = new Promise<void>((resolve) => {
+    markOperationStarted = resolve
+  })
+  const operationGate = new Promise<void>((resolve) => {
+    finishOperation = resolve
+  })
+
+  coordinator.record('before', input => order.push(input))
+  const operation = coordinator.run(async () => {
+    order.push('operation-start')
+    markOperationStarted()
+    await operationGate
+    order.push('operation-end')
+  })
+  coordinator.record('after', input => order.push(input))
+
+  await operationStarted
+  assert.deepEqual(order, ['before', 'operation-start'])
+
+  finishOperation()
+  await operation
+  await coordinator.run(() => undefined)
+
+  assert.deepEqual(order, ['before', 'operation-start', 'operation-end', 'after'])
+})
+
+test('buffers paused inputs and replays them in order after a failed exit', async () => {
+  const coordinator = new TypingStatsOperationCoordinator<string>()
+  const recorded: string[] = []
+
+  await coordinator.run(() => coordinator.pauseInputs('exit-1'))
+  coordinator.record('KeyA', input => recorded.push(input))
+  coordinator.record('KeyB', input => recorded.push(input))
+
+  const replayed = await coordinator.run(() => coordinator.resumeInputs('exit-1', input => recorded.push(input)))
+
+  assert.equal(replayed, 2)
+  assert.deepEqual(recorded, ['KeyA', 'KeyB'])
+})
+
+test('keeps input paused until every window releases its pause token', async () => {
+  const coordinator = new TypingStatsOperationCoordinator<string>()
+  const recorded: string[] = []
+
+  await coordinator.run(() => {
+    coordinator.pauseInputs('main-exit')
+    coordinator.pauseInputs('preference-restart')
+  })
+  coordinator.record('KeyA', input => recorded.push(input))
+
+  const firstReplay = await coordinator.run(() => (
+    coordinator.resumeInputs('main-exit', input => recorded.push(input))
+  ))
+  assert.equal(firstReplay, 0)
+  assert.equal(recorded.length, 0)
+
+  const finalReplay = await coordinator.run(() => (
+    coordinator.resumeInputs('preference-restart', input => recorded.push(input))
+  ))
+  assert.equal(finalReplay, 1)
+  assert.deepEqual(recorded, ['KeyA'])
+})

--- a/src/utils/typingStatsCoordinator.ts
+++ b/src/utils/typingStatsCoordinator.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+export class TypingStatsOperationCoordinator<TInput> {
+  private inputPauseTokens = new Set<string>()
+  private pausedInputs: TInput[] = []
+  private queue = Promise.resolve()
+
+  run<TResult>(operation: () => TResult | Promise<TResult>) {
+    const result = this.queue
+      .catch(() => undefined)
+      .then(operation)
+
+    this.queue = result.then(() => undefined, () => undefined)
+
+    return result
+  }
+
+  record(input: TInput, apply: (input: TInput) => void) {
+    void this.run(() => {
+      if (this.inputPauseTokens.size > 0) {
+        this.pausedInputs.push(input)
+        return
+      }
+
+      apply(input)
+    })
+  }
+
+  pauseInputs(token: string) {
+    this.inputPauseTokens.add(token)
+  }
+
+  resumeInputs(token: string, apply: (input: TInput) => void) {
+    this.inputPauseTokens.delete(token)
+
+    if (this.inputPauseTokens.size > 0) return 0
+
+    const inputs = this.pausedInputs.splice(0)
+
+    for (const input of inputs) apply(input)
+
+    return inputs.length
+  }
+}

--- a/src/utils/typingStatsPersistence.test.ts
+++ b/src/utils/typingStatsPersistence.test.ts
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import {
+  executeTypingStatsMutationTransaction,
+  requestTypingStatsStoreSave,
+} from './typingStatsPersistence'
+
+test('patches the typing stats store before saving it', async () => {
+  const calls: string[] = []
+
+  await requestTypingStatsStoreSave({
+    dailyCounts: { '2026-08-09': 12 },
+    enabled: true,
+  }, {
+    adapter: {
+      patch: async (storeId) => {
+        calls.push(`patch:${storeId}`)
+      },
+      save: async (storeId) => {
+        calls.push(`save:${storeId}`)
+      },
+    },
+  })
+
+  assert.deepEqual(calls, ['patch:typingStats', 'save:typingStats'])
+})
+
+test('persists only enabled and a shallow copy of daily counts', async () => {
+  const dailyCounts = { '2026-08-09': 12 }
+  let patchedState: Record<string, unknown> | undefined
+
+  await requestTypingStatsStoreSave({
+    dailyCounts,
+    enabled: false,
+    runtimeOnly: 'discarded',
+  }, {
+    adapter: {
+      patch: async (_storeId, state) => {
+        patchedState = state
+      },
+      save: async () => {},
+    },
+  })
+
+  assert.deepEqual(patchedState, {
+    dailyCounts: { '2026-08-09': 12 },
+    enabled: false,
+  })
+  assert.notEqual(patchedState?.dailyCounts, dailyCounts)
+
+  dailyCounts['2026-08-09'] = 13
+  assert.deepEqual(patchedState?.dailyCounts, { '2026-08-09': 12 })
+})
+
+test('does not save when the explicit backend patch fails', async () => {
+  let saved = false
+
+  await assert.rejects(
+    requestTypingStatsStoreSave({ dailyCounts: {}, enabled: true }, {
+      adapter: {
+        patch: async () => {
+          throw new Error('patch failed')
+        },
+        save: async () => {
+          saved = true
+        },
+      },
+    }),
+    /patch failed/,
+  )
+  assert.equal(saved, false)
+})
+
+test('restores the snapshot when persistence fails after a mutation', async () => {
+  const order: string[] = []
+  let state: { dailyCounts: Record<string, number>, enabled: boolean } = {
+    dailyCounts: { '2026-08-09': 12 },
+    enabled: true,
+  }
+
+  const result = await executeTypingStatsMutationTransaction({
+    snapshot: () => {
+      order.push('snapshot')
+      return { dailyCounts: { ...state.dailyCounts }, enabled: state.enabled }
+    },
+    apply: () => {
+      order.push('apply')
+      state.dailyCounts = {}
+    },
+    persist: () => {
+      order.push('persist')
+      throw new Error('disk full')
+    },
+    restore: (snapshot) => {
+      order.push('restore')
+      state = snapshot
+    },
+  })
+
+  assert.deepEqual(order, ['snapshot', 'apply', 'persist', 'restore'])
+  assert.deepEqual(state, { dailyCounts: { '2026-08-09': 12 }, enabled: true })
+  assert.deepEqual(result, { accepted: false, reason: 'disk full' })
+})

--- a/src/utils/typingStatsPersistence.ts
+++ b/src/utils/typingStatsPersistence.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import { invoke } from '@tauri-apps/api/core'
+import { saveNow } from '@tauri-store/pinia'
+import { nextTick } from 'vue'
+
+const TYPING_STATS_STORE_ID = 'typingStats'
+
+export interface TypingStatsPersistenceAdapter {
+  patch: (storeId: string, state: Record<string, unknown>) => Promise<void>
+  save: (storeId: string) => Promise<void>
+}
+
+export interface TypingStatsState extends Record<string, unknown> {
+  dailyCounts: Record<string, number>
+  enabled: boolean
+}
+
+interface TypingStatsPersistenceOptions {
+  adapter?: TypingStatsPersistenceAdapter
+}
+
+interface TypingStatsMutationTransactionOperations<TSnapshot> {
+  apply: () => void | Promise<void>
+  persist: () => void | Promise<void>
+  restore: (snapshot: TSnapshot) => void | Promise<void>
+  snapshot: () => TSnapshot | Promise<TSnapshot>
+}
+
+const defaultAdapter: TypingStatsPersistenceAdapter = {
+  patch: (storeId, state) => invoke('plugin:pinia|patch', { id: storeId, state }),
+  save: storeId => saveNow(storeId),
+}
+
+export async function requestTypingStatsStoreSave(
+  state: TypingStatsState,
+  options: TypingStatsPersistenceOptions = {},
+) {
+  const adapter = options.adapter ?? defaultAdapter
+  const persistentState = {
+    dailyCounts: { ...state.dailyCounts },
+    enabled: state.enabled,
+  }
+
+  await nextTick()
+  await adapter.patch(TYPING_STATS_STORE_ID, persistentState)
+  await adapter.save(TYPING_STATS_STORE_ID)
+}
+
+export async function executeTypingStatsMutationTransaction<TSnapshot>(
+  operations: TypingStatsMutationTransactionOperations<TSnapshot>,
+) {
+  let snapshot: TSnapshot | undefined
+  let snapshotCreated = false
+
+  try {
+    snapshot = await operations.snapshot()
+    snapshotCreated = true
+    await operations.apply()
+    await operations.persist()
+
+    return { accepted: true as const }
+  } catch (error) {
+    if (snapshotCreated) {
+      try {
+        await operations.restore(snapshot as TSnapshot)
+      } catch {
+        // Preserve the original mutation or persistence error for the caller.
+      }
+    }
+
+    return {
+      accepted: false as const,
+      reason: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/src/utils/typingStatsRequest.test.ts
+++ b/src/utils/typingStatsRequest.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import type {
+  TypingStatsOperationAcknowledgement,
+  TypingStatsOperationRequest,
+  TypingStatsRequestAdapter,
+} from './typingStatsRequest'
+
+import { PromiseTimeoutError } from './promise'
+import { requestTypingStatsOperation } from './typingStatsRequest'
+
+test('registers the acknowledgement listener before emitting and returns the accepted result', async () => {
+  const order: string[] = []
+  let acknowledge: ((acknowledgement: TypingStatsOperationAcknowledgement) => void) | undefined
+  const adapter: TypingStatsRequestAdapter = {
+    listen: async (callback) => {
+      order.push('listen')
+      acknowledge = callback
+
+      return () => {
+        order.push('unlisten')
+      }
+    },
+    emit: async (request) => {
+      order.push('emit')
+      assert(acknowledge)
+      acknowledge({
+        accepted: true,
+        requestId: request.requestId,
+        state: { dailyCounts: { '2026-08-09': 4 }, enabled: true },
+      })
+    },
+  }
+
+  const result = await requestTypingStatsOperation({ kind: 'set-enabled', enabled: true }, { adapter })
+
+  assert.deepEqual(order, ['listen', 'emit', 'unlisten'])
+  assert.equal(result.accepted, true)
+  assert.deepEqual(result.state, { dailyCounts: { '2026-08-09': 4 }, enabled: true })
+})
+
+test('ignores acknowledgements for a different request ID', async () => {
+  let acknowledge: ((acknowledgement: TypingStatsOperationAcknowledgement) => void) | undefined
+  let emittedRequest: TypingStatsOperationRequest | undefined
+  const adapter: TypingStatsRequestAdapter = {
+    listen: async (callback) => {
+      acknowledge = callback
+      return () => undefined
+    },
+    emit: async (request) => {
+      emittedRequest = request
+      assert(acknowledge)
+      acknowledge({ accepted: false, reason: 'stale', requestId: 'another-request' })
+      acknowledge({ accepted: true, requestId: request.requestId })
+    },
+  }
+
+  const result = await requestTypingStatsOperation({ kind: 'clear-history' }, { adapter })
+
+  assert.equal(result.accepted, true)
+  assert.equal(result.requestId, emittedRequest?.requestId)
+})
+
+test('unlistens when emitting fails', async () => {
+  let unlistenCount = 0
+  const adapter: TypingStatsRequestAdapter = {
+    listen: async () => () => {
+      unlistenCount += 1
+    },
+    emit: async () => {
+      throw new Error('emit failed')
+    },
+  }
+
+  await assert.rejects(
+    requestTypingStatsOperation({ kind: 'flush', pauseId: 'exit-1' }, { adapter }),
+    /emit failed/,
+  )
+  assert.equal(unlistenCount, 1)
+})
+
+test('unlistens when acknowledgement times out', async () => {
+  let unlistenCount = 0
+  const adapter: TypingStatsRequestAdapter = {
+    listen: async () => () => {
+      unlistenCount += 1
+    },
+    emit: async () => undefined,
+  }
+
+  await assert.rejects(
+    requestTypingStatsOperation({ kind: 'flush', pauseId: 'exit-1' }, { adapter, timeoutMs: 5 }),
+    (error: unknown) => {
+      assert(error instanceof PromiseTimeoutError)
+      return true
+    },
+  )
+  assert.equal(unlistenCount, 1)
+})

--- a/src/utils/typingStatsRequest.ts
+++ b/src/utils/typingStatsRequest.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+import { emitTo, listen } from '@tauri-apps/api/event'
+import { nanoid } from 'nanoid'
+
+import { LISTEN_KEY, WINDOW_LABEL } from '@/constants'
+
+import type { TypingStatsState } from './typingStatsPersistence'
+
+import { withTimeout } from './promise'
+
+const DEFAULT_TIMEOUT_MS = 15_000
+
+export type TypingStatsOperation
+  = | { kind: 'set-enabled', enabled: boolean }
+    | { kind: 'clear-history' }
+    | { kind: 'flush', pauseId: string }
+    | { kind: 'resume', pauseId: string }
+
+export interface TypingStatsOperationRequest {
+  operation: TypingStatsOperation
+  requestId: string
+}
+
+export interface TypingStatsOperationAcknowledgement {
+  accepted: boolean
+  reason?: string
+  requestId: string
+  state?: TypingStatsState
+}
+
+export interface TypingStatsRequestAdapter {
+  emit: (request: TypingStatsOperationRequest) => Promise<void>
+  listen: (
+    callback: (acknowledgement: TypingStatsOperationAcknowledgement) => void,
+  ) => Promise<() => void | Promise<void>>
+}
+
+interface TypingStatsRequestOptions {
+  adapter?: TypingStatsRequestAdapter
+  timeoutMs?: number
+}
+
+const defaultAdapter: TypingStatsRequestAdapter = {
+  emit: request => emitTo(
+    WINDOW_LABEL.MAIN,
+    LISTEN_KEY.TYPING_STATS_OPERATION_REQUESTED,
+    request,
+  ),
+  listen: callback => listen<TypingStatsOperationAcknowledgement>(
+    LISTEN_KEY.TYPING_STATS_OPERATION_APPLIED,
+    ({ payload }) => callback(payload),
+  ),
+}
+
+export async function requestTypingStatsOperation(
+  operation: TypingStatsOperation,
+  options: TypingStatsRequestOptions = {},
+) {
+  const adapter = options.adapter ?? defaultAdapter
+  const request: TypingStatsOperationRequest = {
+    operation,
+    requestId: nanoid(),
+  }
+  let resolveAcknowledgement!: (acknowledgement: TypingStatsOperationAcknowledgement) => void
+  const acknowledgement = new Promise<TypingStatsOperationAcknowledgement>((resolve) => {
+    resolveAcknowledgement = resolve
+  })
+  const unlisten = await adapter.listen((payload) => {
+    if (payload.requestId !== request.requestId) return
+
+    resolveAcknowledgement(payload)
+  })
+
+  try {
+    return await withTimeout((async () => {
+      await adapter.emit(request)
+      return await acknowledgement
+    })(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS, 'Typing statistics operation timed out.')
+  } finally {
+    await unlisten()
+  }
+}


### PR DESCRIPTION
## Summary

- add privacy-preserving local typing statistics with daily totals, a 30-day activity view, controls, and localized copy
- serialize statistics persistence through the main window so clear, settings, and final counts survive restart and failure paths
- count Linux evdev repeat events as presses and harden reproducible tag builds with strict version checks
- prepare package and Rust metadata for v1.1.9

## Verification

- `pnpm test` (88 tests)
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src --max-warnings 1`
- `pnpm build:vite`
- `cargo test --workspace --all-targets --locked`
- `cargo check --workspace --all-targets --locked`
- `pnpm exec tsx scripts/checkReleaseVersion.ts v1.1.9`
- `pnpm tauri build --no-bundle -- -- --locked`
- `git diff --check`

Closes #17