### PR TITLE
fix(release): pass locked flag to Cargo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,22 +22,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # tauri-action invokes pnpm directly; this separator belongs to Tauri's Cargo runner.
           - platform: macos-latest
             target: aarch64-apple-darwin
-            tauriArgs: --target aarch64-apple-darwin -- -- --locked
+            tauriArgs: --target aarch64-apple-darwin -- --locked
           - platform: macos-latest
             target: x86_64-apple-darwin
-            tauriArgs: --target x86_64-apple-darwin -- -- --locked
+            tauriArgs: --target x86_64-apple-darwin -- --locked
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
-            tauriArgs: --target x86_64-pc-windows-msvc --bundles msi,nsis -- -- --locked
+            tauriArgs: --target x86_64-pc-windows-msvc --bundles msi,nsis -- --locked
             portable: true
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            tauriArgs: --target x86_64-unknown-linux-gnu -- -- --locked
+            tauriArgs: --target x86_64-unknown-linux-gnu -- --locked
           - platform: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
-            tauriArgs: --target aarch64-unknown-linux-gnu -- -- --locked
+            tauriArgs: --target aarch64-unknown-linux-gnu -- --locked
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- pass a single Tauri runner separator through `tauri-action` so Cargo receives `--locked` as an option
- document the action-specific pnpm argument boundary

## Evidence

Release run 31309479255 invoked pnpm with `-- -- --locked`, which reached Cargo as `-- --locked` and failed with `unexpected argument '--locked'`.

## Verification

- `git diff --check`
- workflow diff limited to the five release matrix argument strings