### PR TITLE
fix(store): recover corrupted persistent state

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,9 @@ use tauri_plugin_custom_window::{
     show_preference_window,
 };
 use utils::fs_extra::{copy_dir, extract_zip};
+use utils::persistence_recovery::{
+    PersistenceRecoveryState, init as persistence_recovery_init, take_persistence_recovery_report,
+};
 
 const MODEL_STORE_SCHEMA_VERSION: u64 = 2;
 
@@ -113,6 +116,10 @@ pub fn run() {
 
             setup::default(&app_handle, main_window.clone(), preference_window.clone());
 
+            if app.state::<PersistenceRecoveryState>().requires_attention() {
+                show_preference_window(app_handle);
+            }
+
             Ok(())
         })
         .invoke_handler(generate_handler![
@@ -125,7 +132,8 @@ pub fn run() {
             set_gamepad_listener_enabled,
             runtime_installation_identity,
             prepare_dedicated_runtime,
-            record_dedicated_runtime_event
+            record_dedicated_runtime_event,
+            take_persistence_recovery_report
         ])
         .plugin(tauri_plugin_admin_status::init())
         .plugin(tauri_plugin_custom_window::init())
@@ -149,6 +157,7 @@ pub fn run() {
                 .filter(|metadata| !metadata.target().contains("gilrs"))
                 .build(),
         )
+        .plugin(persistence_recovery_init())
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,
             None,

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -3,3 +3,4 @@
 // SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
 
 pub mod fs_extra;
+pub mod persistence_recovery;

--- a/src-tauri/src/utils/persistence_recovery.rs
+++ b/src-tauri/src/utils/persistence_recovery.rs
@@ -1,0 +1,407 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: MIT AND PolyForm-Noncommercial-1.0.0
+
+use serde::Serialize;
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    sync::Mutex,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tauri::{Manager, Runtime, plugin::TauriPlugin};
+use tauri_plugin_custom_window::PREFERENCE_WINDOW_LABEL;
+use tauri_plugin_pinia::ManagerExt as _;
+
+const STORE_IDS: [&str; 6] = ["app", "cat", "general", "model", "shortcut", "typingStats"];
+
+#[cfg(debug_assertions)]
+const STORE_FILE_EXTENSION: &str = "dev.json";
+#[cfg(not(debug_assertions))]
+const STORE_FILE_EXTENSION: &str = "json";
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoveredPersistenceStore {
+    pub store_id: String,
+    pub backup_path: PathBuf,
+    pub reason: String,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistenceRecoveryFailure {
+    pub store_id: String,
+    pub path: PathBuf,
+    pub reason: String,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistenceRecoveryReport {
+    pub recovered: Vec<RecoveredPersistenceStore>,
+    pub failures: Vec<PersistenceRecoveryFailure>,
+}
+
+impl PersistenceRecoveryReport {
+    fn is_empty(&self) -> bool {
+        self.recovered.is_empty() && self.failures.is_empty()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct PersistenceRecoveryState {
+    report: Mutex<Option<PersistenceRecoveryReport>>,
+    requires_attention: bool,
+}
+
+impl PersistenceRecoveryState {
+    pub fn new(report: Option<PersistenceRecoveryReport>) -> Self {
+        Self {
+            requires_attention: report.is_some(),
+            report: Mutex::new(report),
+        }
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+
+    fn take_for_window(&self, window_label: &str) -> Option<PersistenceRecoveryReport> {
+        if window_label != PREFERENCE_WINDOW_LABEL {
+            return None;
+        }
+
+        self.report.lock().ok()?.take()
+    }
+}
+
+#[tauri::command]
+pub fn take_persistence_recovery_report(
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, PersistenceRecoveryState>,
+) -> Option<PersistenceRecoveryReport> {
+    state.take_for_window(window.label())
+}
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    tauri::plugin::Builder::new("persistence-recovery")
+        .setup(|app, _api| {
+            let store_directory = app.pinia().path();
+            let recovery_report = recover_persistence_stores(&store_directory);
+
+            if let Some(report) = &recovery_report {
+                for recovered in &report.recovered {
+                    tauri_plugin_log::log::warn!(
+                        "recovered corrupted persistence store: store_id={}, backup_path={}, reason={}",
+                        recovered.store_id,
+                        recovered.backup_path.display(),
+                        recovered.reason
+                    );
+                }
+                for failure in &report.failures {
+                    tauri_plugin_log::log::error!(
+                        "failed to recover corrupted persistence store: store_id={}, path={}, reason={}",
+                        failure.store_id,
+                        failure.path.display(),
+                        failure.reason
+                    );
+                }
+            }
+
+            app.manage(PersistenceRecoveryState::new(recovery_report));
+            Ok(())
+        })
+        .build()
+}
+
+pub fn recover_persistence_stores(store_directory: &Path) -> Option<PersistenceRecoveryReport> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let mut rename = |from: &Path, to: &Path| fs::rename(from, to);
+    let report = recover_persistence_stores_with(store_directory, timestamp, &mut rename);
+
+    (!report.is_empty()).then_some(report)
+}
+
+fn recover_persistence_stores_with<F>(
+    store_directory: &Path,
+    timestamp: u128,
+    rename: &mut F,
+) -> PersistenceRecoveryReport
+where
+    F: FnMut(&Path, &Path) -> io::Result<()>,
+{
+    let mut report = PersistenceRecoveryReport::default();
+
+    for store_id in STORE_IDS {
+        let path = store_path(store_directory, store_id);
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                report.failures.push(PersistenceRecoveryFailure {
+                    store_id: store_id.to_string(),
+                    path,
+                    reason: format!("failed to read persisted store: {error}"),
+                });
+                continue;
+            }
+        };
+
+        let reason = match serde_json::from_slice::<tauri_plugin_pinia::StoreState>(&bytes) {
+            Ok(_) => continue,
+            Err(error) => error.to_string(),
+        };
+        let backup_path = match unique_backup_path(store_directory, store_id, timestamp) {
+            Ok(path) => path,
+            Err(error) => {
+                report.failures.push(PersistenceRecoveryFailure {
+                    store_id: store_id.to_string(),
+                    path,
+                    reason: format!(
+                        "persisted store is invalid ({reason}); failed to select a backup path: {error}"
+                    ),
+                });
+                continue;
+            }
+        };
+
+        match rename(&path, &backup_path) {
+            Ok(()) => report.recovered.push(RecoveredPersistenceStore {
+                store_id: store_id.to_string(),
+                backup_path,
+                reason,
+            }),
+            Err(error) => report.failures.push(PersistenceRecoveryFailure {
+                store_id: store_id.to_string(),
+                path,
+                reason: format!(
+                    "persisted store is invalid ({reason}); failed to create backup: {error}"
+                ),
+            }),
+        }
+    }
+
+    report
+}
+
+fn store_path(store_directory: &Path, store_id: &str) -> PathBuf {
+    store_directory.join(format!("{store_id}.{STORE_FILE_EXTENSION}"))
+}
+
+fn unique_backup_path(
+    store_directory: &Path,
+    store_id: &str,
+    timestamp: u128,
+) -> io::Result<PathBuf> {
+    for collision_index in 0_u64.. {
+        let collision_suffix = match collision_index {
+            0 => String::new(),
+            index => format!("-{index}"),
+        };
+        let candidate = store_directory.join(format!(
+            "{store_id}.corrupt-{timestamp}{collision_suffix}.json"
+        ));
+
+        match fs::symlink_metadata(&candidate) {
+            Ok(_) => continue,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(candidate),
+            Err(error) => return Err(error),
+        }
+    }
+
+    unreachable!("the backup collision counter is exhaustive")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        PersistenceRecoveryReport, PersistenceRecoveryState, recover_persistence_stores,
+        recover_persistence_stores_with, store_path,
+    };
+    use std::{
+        fs, io,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use tauri_plugin_custom_window::PREFERENCE_WINDOW_LABEL;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(name: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should follow UNIX epoch")
+                .as_nanos();
+            let path = std::env::temp_dir()
+                .join(format!("mochi-paw-{name}-{}-{unique}", std::process::id()));
+            fs::create_dir_all(&path).expect("test directory should be created");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn run_with_timestamp(store_directory: &Path, timestamp: u128) -> PersistenceRecoveryReport {
+        recover_persistence_stores_with(store_directory, timestamp, &mut |from, to| {
+            fs::rename(from, to)
+        })
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn uses_the_active_debug_store_filename() {
+        assert_eq!(
+            store_path(Path::new("pinia"), "model"),
+            Path::new("pinia").join("model.dev.json")
+        );
+    }
+
+    #[test]
+    fn ignores_missing_and_valid_store_files() {
+        let root = TestDirectory::new("valid-stores");
+        let valid_path = store_path(root.path(), "model");
+        let valid_contents = br#"{"currentModelId":"preset-gamepad","models":[]}"#;
+        fs::write(&valid_path, valid_contents).unwrap();
+
+        let report = recover_persistence_stores(root.path());
+
+        assert!(report.is_none());
+        assert_eq!(fs::read(valid_path).unwrap(), valid_contents);
+        assert_eq!(fs::read_dir(root.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn recovers_empty_malformed_and_non_object_stores_without_changing_bytes() {
+        let root = TestDirectory::new("\u{6301}\u{4e45}\u{5316} \u{7a7a}\u{683c}#100% \u{1f431}");
+        let cases = [
+            ("app", Vec::new()),
+            ("cat", b"{\"truncated\":".to_vec()),
+            ("general", b"[]".to_vec()),
+        ];
+
+        for (store_id, contents) in &cases {
+            fs::write(store_path(root.path(), store_id), contents).unwrap();
+        }
+
+        let report = run_with_timestamp(root.path(), 1_234);
+
+        assert_eq!(report.recovered.len(), cases.len());
+        assert!(report.failures.is_empty());
+        for (store_id, contents) in cases {
+            assert!(!store_path(root.path(), store_id).exists());
+            let recovered = report
+                .recovered
+                .iter()
+                .find(|recovered| recovered.store_id == store_id)
+                .unwrap();
+            assert_eq!(fs::read(&recovered.backup_path).unwrap(), contents);
+            assert!(recovered.backup_path.starts_with(root.path()));
+            assert!(recovered.reason.contains("line 1 column"));
+        }
+    }
+
+    #[test]
+    fn uses_a_unique_backup_name_without_overwriting_a_collision() {
+        let root = TestDirectory::new("backup-collision");
+        let invalid_path = store_path(root.path(), "model");
+        let existing_backup = root.path().join("model.corrupt-42.json");
+        fs::write(&invalid_path, b"invalid").unwrap();
+        fs::write(&existing_backup, b"existing backup").unwrap();
+
+        let report = run_with_timestamp(root.path(), 42);
+
+        assert_eq!(report.recovered.len(), 1);
+        assert_eq!(
+            report.recovered[0].backup_path,
+            root.path().join("model.corrupt-42-1.json")
+        );
+        assert_eq!(fs::read(existing_backup).unwrap(), b"existing backup");
+        assert_eq!(
+            fs::read(&report.recovered[0].backup_path).unwrap(),
+            b"invalid"
+        );
+    }
+
+    #[test]
+    fn reports_rename_failures_and_leaves_the_original_file_untouched() {
+        let root = TestDirectory::new("rename-failure");
+        let invalid_path = store_path(root.path(), "shortcut");
+        let original_contents = b"not JSON";
+        fs::write(&invalid_path, original_contents).unwrap();
+        let mut failing_rename = |_from: &Path, _to: &Path| {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "test denied rename",
+            ))
+        };
+
+        let report = recover_persistence_stores_with(root.path(), 99, &mut failing_rename);
+
+        assert!(report.recovered.is_empty());
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].store_id, "shortcut");
+        assert_eq!(report.failures[0].path, invalid_path);
+        assert!(report.failures[0].reason.contains("test denied rename"));
+        assert_eq!(fs::read(invalid_path).unwrap(), original_contents);
+    }
+
+    #[test]
+    fn reports_store_read_failures() {
+        let root = TestDirectory::new("read-failure");
+        let unreadable_path = store_path(root.path(), "app");
+        fs::create_dir(&unreadable_path).unwrap();
+
+        let report = run_with_timestamp(root.path(), 100);
+
+        assert!(report.recovered.is_empty());
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].store_id, "app");
+        assert_eq!(report.failures[0].path, unreadable_path);
+        assert!(report.failures[0].reason.contains("failed to read"));
+    }
+
+    #[test]
+    fn only_the_preference_window_consumes_a_recovery_report_once() {
+        let state = PersistenceRecoveryState::new(Some(PersistenceRecoveryReport::default()));
+
+        assert!(state.requires_attention());
+        assert!(state.take_for_window("main").is_none());
+        assert!(state.requires_attention());
+        assert!(state.take_for_window(PREFERENCE_WINDOW_LABEL).is_some());
+        assert!(state.requires_attention());
+        assert!(state.take_for_window(PREFERENCE_WINDOW_LABEL).is_none());
+        let empty_state = PersistenceRecoveryState::new(None);
+        assert!(!empty_state.requires_attention());
+        assert!(
+            empty_state
+                .take_for_window(PREFERENCE_WINDOW_LABEL)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn serializes_the_recovery_report_with_camel_case_fields() {
+        let root = TestDirectory::new("serialized-report");
+        fs::write(store_path(root.path(), "cat"), b"invalid").unwrap();
+        let report = run_with_timestamp(root.path(), 101);
+
+        let value = serde_json::to_value(report).unwrap();
+
+        assert_eq!(value["recovered"][0]["storeId"], "cat");
+        assert!(value["recovered"][0].get("backupPath").is_some());
+        assert!(value["recovered"][0].get("backup_path").is_none());
+        assert!(value["failures"].is_array());
+    }
+}

--- a/src/components/persistence-recovery-alert/index.vue
+++ b/src/components/persistence-recovery-alert/index.vue
@@ -1,0 +1,148 @@
+<!-- SPDX-FileCopyrightText: 2026 InfinityXCat
+  SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ -->
+
+<script setup lang="ts">
+import { invoke } from '@tauri-apps/api/core'
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
+import { Alert, Button, Flex, Modal } from 'antdv-next'
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { PersistenceRecoveryReport, PersistenceStoreId } from '@/utils/persistenceRecovery'
+
+import { WINDOW_LABEL } from '@/constants'
+import { logError, logInfo } from '@/utils/diagnostics'
+import {
+  formatPersistenceRecoveryReport,
+  normalizePersistenceRecoveryReport,
+} from '@/utils/persistenceRecovery'
+
+const { t } = useI18n()
+const open = ref(false)
+const report = ref<PersistenceRecoveryReport | null>(null)
+
+const storeNames = computed<Partial<Record<PersistenceStoreId, string>>>(() => ({
+  app: t('components.persistenceRecovery.stores.app'),
+  cat: t('components.persistenceRecovery.stores.cat'),
+  general: t('components.persistenceRecovery.stores.general'),
+  model: t('components.persistenceRecovery.stores.model'),
+  shortcut: t('components.persistenceRecovery.stores.shortcut'),
+  typingStats: t('components.persistenceRecovery.stores.typingStats'),
+}))
+
+const viewModel = computed(() => report.value
+  ? formatPersistenceRecoveryReport(report.value, storeNames.value)
+  : null)
+const hasRecovered = computed(() => Boolean(viewModel.value?.recovered.length))
+const hasFailures = computed(() => Boolean(viewModel.value?.failures.length))
+const alertType = computed(() => {
+  if (!hasFailures.value) return 'success'
+  return hasRecovered.value ? 'warning' : 'error'
+})
+const summary = computed(() => {
+  if (!hasFailures.value) return t('components.persistenceRecovery.successSummary')
+  if (hasRecovered.value) return t('components.persistenceRecovery.mixedSummary')
+  return t('components.persistenceRecovery.failureSummary')
+})
+
+onMounted(async () => {
+  if (getCurrentWebviewWindow().label !== WINDOW_LABEL.PREFERENCE) return
+
+  try {
+    const result = normalizePersistenceRecoveryReport(
+      await invoke<unknown>('take_persistence_recovery_report'),
+    )
+
+    if (!result) return
+
+    report.value = result
+    open.value = true
+    logInfo('[persistence-recovery] showing recovery report', {
+      recoveredStoreIds: result.recovered.map(item => item.storeId),
+      failedStoreIds: result.failures.map(item => item.storeId),
+    })
+  } catch (error) {
+    logError('[persistence-recovery] failed to take recovery report', { error })
+  }
+})
+</script>
+
+<template>
+  <Modal
+    v-if="viewModel"
+    v-model:open="open"
+    centered
+    :closable="false"
+    :keyboard="false"
+    :mask-closable="false"
+    :title="hasFailures ? t('components.persistenceRecovery.failureTitle') : t('components.persistenceRecovery.title')"
+    :width="680"
+  >
+    <Flex
+      gap="middle"
+      vertical
+    >
+      <Alert
+        :message="summary"
+        show-icon
+        :type="alertType"
+      />
+
+      <p class="m-0 color-text-secondary text-sm">
+        {{ t('components.persistenceRecovery.consequence') }}
+      </p>
+
+      <section v-if="viewModel.recovered.length">
+        <h3 class="mb-1 font-semibold">
+          {{ t('components.persistenceRecovery.recoveredTitle') }}
+        </h3>
+
+        <div
+          v-for="item in viewModel.recovered"
+          :key="`recovered-${item.storeId}-${item.path}`"
+          class="border-t border-[--ant-color-border-secondary] py-3 first:border-t-0"
+        >
+          <strong>{{ item.storeName }}</strong>
+          <div class="mt-1 color-text-secondary">
+            {{ t('components.persistenceRecovery.backupLocation') }}
+          </div>
+          <code class="block whitespace-pre-wrap break-all">{{ item.path }}</code>
+          <div class="mt-1 break-words color-text-tertiary text-sm">
+            {{ t('components.persistenceRecovery.technicalReason') }}: {{ item.reason }}
+          </div>
+        </div>
+      </section>
+
+      <section v-if="viewModel.failures.length">
+        <h3 class="mb-1 font-semibold color-error">
+          {{ t('components.persistenceRecovery.failedTitle') }}
+        </h3>
+
+        <div
+          v-for="item in viewModel.failures"
+          :key="`failed-${item.storeId}-${item.path}`"
+          class="border-t border-[--ant-color-border-secondary] py-3 first:border-t-0"
+        >
+          <strong>{{ item.storeName }}</strong>
+          <div class="mt-1 color-text-secondary">
+            {{ t('components.persistenceRecovery.fileLocation') }}
+          </div>
+          <code class="block whitespace-pre-wrap break-all">{{ item.path }}</code>
+          <div class="mt-1 break-words color-text-tertiary text-sm">
+            {{ t('components.persistenceRecovery.technicalReason') }}: {{ item.reason }}
+          </div>
+        </div>
+      </section>
+    </Flex>
+
+    <template #footer>
+      <Button
+        type="primary"
+        @click="open = false"
+      >
+        {{ t('components.persistenceRecovery.acknowledge') }}
+      </Button>
+    </template>
+  </Modal>
+</template>

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -325,6 +325,28 @@
     }
   },
   "components": {
+    "persistenceRecovery": {
+      "title": "Settings Recovery Completed",
+      "failureTitle": "Settings Recovery Needs Attention",
+      "successSummary": "MochiPaw found unreadable settings files. The original files were backed up and the affected settings were reset so the app could continue.",
+      "mixedSummary": "Some unreadable settings were backed up and reset, but MochiPaw could not safely back up every affected file.",
+      "failureSummary": "MochiPaw found unreadable settings but could not safely back them up. The original files were left unchanged.",
+      "consequence": "Depending on the affected settings, reset data may include custom model names, behaviors, submodel setup, or typing statistics; installed model folders remain available for rediscovery.",
+      "recoveredTitle": "Backed Up and Reset",
+      "failedTitle": "Could Not Back Up",
+      "backupLocation": "Backup location",
+      "fileLocation": "Affected file",
+      "technicalReason": "Details",
+      "acknowledge": "OK",
+      "stores": {
+        "app": "Application state",
+        "cat": "Cat settings",
+        "general": "General settings",
+        "model": "Model settings",
+        "shortcut": "Shortcuts",
+        "typingStats": "Typing statistics"
+      }
+    },
     "shortcut": {
       "labels": {
         "shortcutRegistrationFailed": "Shortcut unavailable"

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -319,6 +319,28 @@
     }
   },
   "components": {
+    "persistenceRecovery": {
+      "title": "Recuperação de configurações concluída",
+      "failureTitle": "A recuperação de configurações requer atenção",
+      "successSummary": "O MochiPaw encontrou arquivos de configuração ilegíveis. Os arquivos originais foram copiados e as configurações afetadas foram redefinidas para que o aplicativo pudesse continuar.",
+      "mixedSummary": "Algumas configurações ilegíveis foram copiadas e redefinidas, mas o MochiPaw não conseguiu criar cópias seguras de todos os arquivos afetados.",
+      "failureSummary": "O MochiPaw encontrou configurações ilegíveis, mas não conseguiu criar cópias seguras. Os arquivos originais não foram alterados.",
+      "consequence": "Dependendo das configurações afetadas, os dados redefinidos podem incluir nomes de modelos personalizados, comportamentos, configuração de submodelos ou estatísticas de digitação; as pastas de modelos instalados continuam disponíveis para nova detecção.",
+      "recoveredTitle": "Copiado e redefinido",
+      "failedTitle": "Não foi possível criar a cópia",
+      "backupLocation": "Local da cópia",
+      "fileLocation": "Arquivo afetado",
+      "technicalReason": "Detalhes",
+      "acknowledge": "OK",
+      "stores": {
+        "app": "Estado do aplicativo",
+        "cat": "Configurações do gato",
+        "general": "Configurações gerais",
+        "model": "Configurações do modelo",
+        "shortcut": "Atalhos",
+        "typingStats": "Estatísticas de digitação"
+      }
+    },
     "shortcut": {
       "labels": {
         "shortcutRegistrationFailed": "Atalho indisponível"

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -319,6 +319,28 @@
     }
   },
   "components": {
+    "persistenceRecovery": {
+      "title": "Đã khôi phục cài đặt",
+      "failureTitle": "Cần xử lý việc khôi phục cài đặt",
+      "successSummary": "MochiPaw phát hiện các tệp cài đặt không thể đọc được. Các tệp gốc đã được sao lưu và cài đặt bị ảnh hưởng đã được đặt lại để ứng dụng có thể tiếp tục chạy.",
+      "mixedSummary": "Một số cài đặt không thể đọc đã được sao lưu và đặt lại, nhưng MochiPaw không thể sao lưu an toàn tất cả các tệp bị ảnh hưởng.",
+      "failureSummary": "MochiPaw phát hiện cài đặt không thể đọc nhưng không thể sao lưu an toàn. Các tệp gốc vẫn được giữ nguyên.",
+      "consequence": "Tùy theo cài đặt bị ảnh hưởng, dữ liệu đặt lại có thể gồm tên mô hình tùy chỉnh, hành vi, thiết lập mô hình phụ hoặc thống kê gõ phím; các thư mục mô hình đã cài đặt vẫn có thể được phát hiện lại.",
+      "recoveredTitle": "Đã sao lưu và đặt lại",
+      "failedTitle": "Không thể sao lưu",
+      "backupLocation": "Vị trí sao lưu",
+      "fileLocation": "Tệp bị ảnh hưởng",
+      "technicalReason": "Chi tiết",
+      "acknowledge": "OK",
+      "stores": {
+        "app": "Trạng thái ứng dụng",
+        "cat": "Cài đặt mèo",
+        "general": "Cài đặt chung",
+        "model": "Cài đặt mô hình",
+        "shortcut": "Phím tắt",
+        "typingStats": "Thống kê gõ phím"
+      }
+    },
     "shortcut": {
       "labels": {
         "shortcutRegistrationFailed": "Phím tắt không khả dụng"

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -325,6 +325,28 @@
     }
   },
   "components": {
+    "persistenceRecovery": {
+      "title": "设置恢复完成",
+      "failureTitle": "设置恢复需要处理",
+      "successSummary": "MochiPaw 检测到无法读取的设置文件。原文件已备份，受影响的设置已重置，应用可以继续运行。",
+      "mixedSummary": "部分无法读取的设置已备份并重置，但 MochiPaw 未能安全备份所有受影响的文件。",
+      "failureSummary": "MochiPaw 检测到无法读取的设置，但未能安全备份。原文件保持不变。",
+      "consequence": "根据受影响的设置，重置内容可能包括自定义模型名称、行为、子模型配置或打字统计；已安装的模型目录仍可重新发现。",
+      "recoveredTitle": "已备份并重置",
+      "failedTitle": "无法备份",
+      "backupLocation": "备份位置",
+      "fileLocation": "受影响的文件",
+      "technicalReason": "详细信息",
+      "acknowledge": "确定",
+      "stores": {
+        "app": "应用状态",
+        "cat": "猫咪设置",
+        "general": "通用设置",
+        "model": "模型设置",
+        "shortcut": "快捷键",
+        "typingStats": "打字统计"
+      }
+    },
     "shortcut": {
       "labels": {
         "shortcutRegistrationFailed": "快捷键不可用"

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -319,6 +319,28 @@
     }
   },
   "components": {
+    "persistenceRecovery": {
+      "title": "設定復原完成",
+      "failureTitle": "設定復原需要處理",
+      "successSummary": "MochiPaw 偵測到無法讀取的設定檔。原始檔案已備份，受影響的設定已重設，應用程式可以繼續執行。",
+      "mixedSummary": "部分無法讀取的設定已備份並重設，但 MochiPaw 無法安全備份所有受影響的檔案。",
+      "failureSummary": "MochiPaw 偵測到無法讀取的設定，但無法安全備份。原始檔案維持不變。",
+      "consequence": "視受影響的設定而定，重設內容可能包括自訂模型名稱、行為、子模型設定或打字統計；已安裝的模型目錄仍可重新偵測。",
+      "recoveredTitle": "已備份並重設",
+      "failedTitle": "無法備份",
+      "backupLocation": "備份位置",
+      "fileLocation": "受影響的檔案",
+      "technicalReason": "詳細資訊",
+      "acknowledge": "確定",
+      "stores": {
+        "app": "應用程式狀態",
+        "cat": "貓咪設定",
+        "general": "一般設定",
+        "model": "模型設定",
+        "shortcut": "快速鍵",
+        "typingStats": "打字統計"
+      }
+    },
     "shortcut": {
       "labels": {
         "shortcutRegistrationFailed": "快速鍵無法使用"

--- a/src/pages/preference/index.vue
+++ b/src/pages/preference/index.vue
@@ -9,6 +9,7 @@ import { Flex, Spin } from 'antdv-next'
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import PersistenceRecoveryAlert from '@/components/persistence-recovery-alert/index.vue'
 import UpdateApp from '@/components/update-app/index.vue'
 import { useTray } from '@/composables/useTray'
 import { useAppStore } from '@/stores/app'
@@ -138,6 +139,7 @@ const menus = computed(() => [
     </div>
   </Flex>
 
+  <PersistenceRecoveryAlert />
   <UpdateApp />
 </template>
 

--- a/src/utils/persistenceRecovery.test.ts
+++ b/src/utils/persistenceRecovery.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import { formatPersistenceRecoveryReport, normalizePersistenceRecoveryReport } from './persistenceRecovery'
+
+test('normalizes recovered stores and backup failures from the backend payload', () => {
+  const report = normalizePersistenceRecoveryReport({
+    recovered: [{
+      storeId: 'model',
+      backupPath: 'C:\\用户 数据\\pinia\\model.corrupt-1.json',
+      reason: 'expected value at line 1 column 1',
+    }],
+    failures: [{
+      storeId: 'general',
+      path: 'C:\\用户 数据\\pinia\\general.json',
+      reason: 'access denied',
+    }],
+  })
+
+  assert.deepEqual(report, {
+    recovered: [{
+      storeId: 'model',
+      backupPath: 'C:\\用户 数据\\pinia\\model.corrupt-1.json',
+      reason: 'expected value at line 1 column 1',
+    }],
+    failures: [{
+      storeId: 'general',
+      path: 'C:\\用户 数据\\pinia\\general.json',
+      reason: 'access denied',
+    }],
+  })
+})
+
+test('ignores malformed entries and empty reports', () => {
+  assert.equal(normalizePersistenceRecoveryReport(null), null)
+  assert.equal(normalizePersistenceRecoveryReport({ recovered: [], failures: [] }), null)
+  assert.equal(normalizePersistenceRecoveryReport({
+    recovered: [{ storeId: 'model', backupPath: '', reason: 'invalid' }],
+    failures: [{ storeId: 'cat', path: 'C:\\cat.json' }],
+  }), null)
+})
+
+test('formats localized known stores and safely falls back to an unknown store ID', () => {
+  const viewModel = formatPersistenceRecoveryReport({
+    recovered: [{ storeId: 'model', backupPath: 'model.backup', reason: 'invalid JSON' }],
+    failures: [{ storeId: 'futureStore', path: 'future.json', reason: 'locked' }],
+  }, {
+    model: 'Model settings',
+  })
+
+  assert.deepEqual(viewModel, {
+    recovered: [{
+      storeId: 'model',
+      storeName: 'Model settings',
+      path: 'model.backup',
+      reason: 'invalid JSON',
+    }],
+    failures: [{
+      storeId: 'futureStore',
+      storeName: 'futureStore',
+      path: 'future.json',
+      reason: 'locked',
+    }],
+  })
+})

--- a/src/utils/persistenceRecovery.ts
+++ b/src/utils/persistenceRecovery.ts
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+export const PERSISTENCE_STORE_IDS = [
+  'app',
+  'cat',
+  'general',
+  'model',
+  'shortcut',
+  'typingStats',
+] as const
+
+export type PersistenceStoreId = typeof PERSISTENCE_STORE_IDS[number]
+
+export interface RecoveredPersistenceStore {
+  storeId: string
+  backupPath: string
+  reason: string
+}
+
+export interface FailedPersistenceStoreRecovery {
+  storeId: string
+  path: string
+  reason: string
+}
+
+export interface PersistenceRecoveryReport {
+  recovered: RecoveredPersistenceStore[]
+  failures: FailedPersistenceStoreRecovery[]
+}
+
+export interface PersistenceRecoveryDisplayEntry {
+  storeId: string
+  storeName: string
+  path: string
+  reason: string
+}
+
+export interface PersistenceRecoveryViewModel {
+  recovered: PersistenceRecoveryDisplayEntry[]
+  failures: PersistenceRecoveryDisplayEntry[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function normalizeRecoveredEntry(value: unknown): RecoveredPersistenceStore | undefined {
+  if (!isRecord(value)
+    || !isNonEmptyString(value.storeId)
+    || !isNonEmptyString(value.backupPath)
+    || !isNonEmptyString(value.reason)) {
+    return undefined
+  }
+
+  return {
+    storeId: value.storeId,
+    backupPath: value.backupPath,
+    reason: value.reason,
+  }
+}
+
+function normalizeFailedEntry(value: unknown): FailedPersistenceStoreRecovery | undefined {
+  if (!isRecord(value)
+    || !isNonEmptyString(value.storeId)
+    || !isNonEmptyString(value.path)
+    || !isNonEmptyString(value.reason)) {
+    return undefined
+  }
+
+  return {
+    storeId: value.storeId,
+    path: value.path,
+    reason: value.reason,
+  }
+}
+
+export function normalizePersistenceRecoveryReport(value: unknown): PersistenceRecoveryReport | null {
+  if (!isRecord(value)) return null
+
+  const recovered = Array.isArray(value.recovered)
+    ? value.recovered.map(normalizeRecoveredEntry).filter(item => item !== undefined)
+    : []
+  const failures = Array.isArray(value.failures)
+    ? value.failures.map(normalizeFailedEntry).filter(item => item !== undefined)
+    : []
+
+  if (recovered.length === 0 && failures.length === 0) return null
+
+  return { recovered, failures }
+}
+
+export function formatPersistenceRecoveryReport(
+  report: PersistenceRecoveryReport,
+  storeNames: Partial<Record<PersistenceStoreId, string>>,
+): PersistenceRecoveryViewModel {
+  const getStoreName = (storeId: string) => storeNames[storeId as PersistenceStoreId] ?? storeId
+
+  return {
+    recovered: report.recovered.map(item => ({
+      storeId: item.storeId,
+      storeName: getStoreName(item.storeId),
+      path: item.backupPath,
+      reason: item.reason,
+    })),
+    failures: report.failures.map(item => ({
+      storeId: item.storeId,
+      storeName: getStoreName(item.storeId),
+      path: item.path,
+      reason: item.reason,
+    })),
+  }
+}


### PR DESCRIPTION
## Summary
- recover empty or malformed Pinia store files before frontend hydration
- preserve corrupt bytes in timestamped backups and report recovery failures without overwriting originals
- show a one-time localized recovery report in the preference window

## Testing
- `pnpm test` (91 tests)
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src --max-warnings 1`
- `pnpm build:vite`
- `cargo test --workspace --all-targets --locked`
- `cargo check --workspace --all-targets --locked`
- targeted `rustfmt --check`
- locale JSON parsing
- `git diff --check`