### PR TITLE
fix(release): rotate updater signing key

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -86,7 +86,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDUwMjgyOUNGRjkxODVGMUMKUldRY1h4ajV6eWtvVUcwVWo3WFZSNDc4OUtBR0ZGYmtiV1JBVjNHVXRmWFZCTXBDQStmbUMvSFUK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERDMjRBREVEQzk5RTU4NzAKUldSd1dKN0o3YTBrM00rWlhZV1BWd25RSVY3dXFjb2I2K3NmMXgzLzNUZkl2Q0hmMk85cUVKMVIK",
       "endpoints": [
         "https://github.com/CatStack-pixe/MochiPaw/releases/latest/download/latest-v2.json"
       ],


### PR DESCRIPTION
## Summary

- rotate the Tauri updater public key after the original GitHub Secret was corrupted by a UTF-8 BOM
- keep the private key and password exclusively in GitHub Actions secrets
- retain the encrypted offline private-key backup

## Verification

- local updater signing succeeds with the rotated key pair
- Tauri configuration parses successfully
- pnpm exec tauri info
- git diff --check