### PR TITLE
fix(release): validate updater signing secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,37 @@ jobs:
       - name: Generate contributors manifest
         run: pnpm generate:contributors
 
+      - name: Validate updater signing secrets
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          node <<'NODE'
+          const requiredSecrets = [
+            'TAURI_SIGNING_PRIVATE_KEY',
+            'TAURI_SIGNING_PRIVATE_KEY_PASSWORD',
+          ];
+
+          for (const name of requiredSecrets) {
+            const value = process.env[name] ?? '';
+            if (!value) {
+              throw new Error(`${name} is empty`);
+            }
+            if (value.codePointAt(0) === 0xfeff) {
+              throw new Error(`${name} starts with a UTF-8 BOM`);
+            }
+          }
+
+          const decodedKey = Buffer.from(
+            process.env.TAURI_SIGNING_PRIVATE_KEY,
+            'base64',
+          ).toString('utf8');
+          if (!decodedKey.startsWith('untrusted comment: rsign encrypted secret key\n')) {
+            throw new Error('TAURI_SIGNING_PRIVATE_KEY is not a Tauri updater private key');
+          }
+          NODE
+
       - name: Build the app
         uses: tauri-apps/tauri-action@v1
         env:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -86,7 +86,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERDMjRBREVEQzk5RTU4NzAKUldSd1dKN0o3YTBrM00rWlhZV1BWd25RSVY3dXFjb2I2K3NmMXgzLzNUZkl2Q0hmMk85cUVKMVIK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDc4QkQzRUE3RTEyQTNBNEMKUldSTU9pcmhwejY5ZUlZODNQd3lhcnFwMWRHdys1Y2wyOU5rYUt3N0Q5cFNXeGVuTGdGK0NjMWIK",
       "endpoints": [
         "https://github.com/CatStack-pixe/MochiPaw/releases/latest/download/latest-v2.json"
       ],


### PR DESCRIPTION
## Summary

- rotate the updater signing key using GitHub CLI body arguments to preserve exact bytes
- add an early release-runner check for empty, BOM-prefixed, or malformed signing secrets
- keep the updater public key aligned with the encrypted v4 offline backup

## Verification

- local signing succeeds with the rotated key pair
- local signing-secret preflight succeeds
- workflow YAML parses and passes ESLint
- Tauri JSON parses
- git diff --check