### PR TITLE
chore(release): prepare v1.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "mochi-paw"
 default-run = "mochi-paw"
-version = "1.1.10"
+version = "1.1.11"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary

- bump the frontend and Rust package versions to 1.1.11
- keep the updater signing key and latest-v2 channel unchanged
- prepare the first automatic-update validation release after the 1.1.10 key migration

## Verification

- pnpm test (115 tests)
- pnpm exec tsc --noEmit
- cargo metadata --locked --no-deps --format-version 1
- git diff --check