### PR TITLE
chore(release): prepare v1.1.9-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.9-1"
+version = "1.1.9-2"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.9-1",
+  "version": "1.1.9-2",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "mochi-paw"
 default-run = "mochi-paw"
-version = "1.1.9-1"
+version = "1.1.9-2"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary
- advance the updater preview from `1.1.9-1` to `1.1.9-2`
- keep package.json, Cargo.toml, and Cargo.lock aligned with the prerelease version
- preserve v1.1.9 as the latest stable release

## Verification
- `pnpm exec tsx scripts/checkReleaseVersion.ts v1.1.9-2`
- `cargo metadata --no-deps --format-version 1 --locked`
- `pnpm test` (115 passed)
- `pnpm exec tsc --noEmit`
- `git diff --check`