### PR TITLE
feat(windows): add game compatibility mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.9-2"
+version = "1.1.10"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.9-2",
+  "version": "1.1.10",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "mochi-paw"
 default-run = "mochi-paw"
-version = "1.1.9-2"
+version = "1.1.10"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"

--- a/src-tauri/src/plugins/window/build.rs
+++ b/src-tauri/src/plugins/window/build.rs
@@ -5,6 +5,8 @@ const COMMANDS: &[&str] = &[
     "show_window",
     "hide_window",
     "set_always_on_top",
+    "set_pass_through",
+    "set_game_mode",
     "set_taskbar_visibility",
     "set_webview_memory_target",
 ];

--- a/src-tauri/src/plugins/window/permissions/default.toml
+++ b/src-tauri/src/plugins/window/permissions/default.toml
@@ -5,4 +5,4 @@
 
 [default]
 description = "Default permissions for the plugin"
-permissions = ["allow-show-window", "allow-hide-window", "allow-set-always-on-top", "allow-set-taskbar-visibility", "allow-set-webview-memory-target"]
+permissions = ["allow-show-window", "allow-hide-window", "allow-set-always-on-top", "allow-set-pass-through", "allow-set-game-mode", "allow-set-taskbar-visibility", "allow-set-webview-memory-target"]

--- a/src-tauri/src/plugins/window/src/commands/mod.rs
+++ b/src-tauri/src/plugins/window/src/commands/mod.rs
@@ -3,9 +3,57 @@
 
 use serde::Deserialize;
 use tauri::{AppHandle, Manager, async_runtime::spawn};
+#[cfg(not(target_os = "windows"))]
+use tauri::{Emitter, Runtime, command};
 
 pub static MAIN_WINDOW_LABEL: &str = "main";
 pub static PREFERENCE_WINDOW_LABEL: &str = "preference";
+pub static GAME_MODE_CHANGED_EVENT: &str = "game-mode-changed";
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GameModeConfig {
+    pub enabled: bool,
+    #[serde(default)]
+    pub processes: Vec<String>,
+    #[serde(default)]
+    pub always_on_top: bool,
+    #[serde(default)]
+    pub pass_through: bool,
+}
+
+#[cfg(not(target_os = "windows"))]
+#[command]
+pub async fn set_game_mode<R: Runtime>(
+    app_handle: AppHandle<R>,
+    _enabled: bool,
+    _processes: Vec<String>,
+    _always_on_top: bool,
+    _pass_through: bool,
+) -> Result<bool, String> {
+    for window in app_handle.webview_windows().into_values() {
+        if window.label() == MAIN_WINDOW_LABEL {
+            let _ = window.emit(GAME_MODE_CHANGED_EVENT, false);
+        }
+    }
+
+    Ok(false)
+}
+
+#[cfg(not(target_os = "windows"))]
+#[command]
+pub async fn set_pass_through<R: Runtime>(
+    _app_handle: AppHandle<R>,
+    window: tauri::WebviewWindow<R>,
+    pass_through: bool,
+) -> Result<(), String> {
+    window
+        .set_ignore_cursor_events(pass_through)
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn apply_current_game_mode<R: Runtime>(_window: &tauri::WebviewWindow<R>) {}
 
 #[derive(Clone, Copy, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -48,6 +96,6 @@ fn show_window_by_label(app_handle: &AppHandle, label: &str) {
     let app_handle = app_handle.clone();
 
     spawn(async move {
-        show_window(app_handle, window).await;
+        let _ = show_window(app_handle, window).await;
     });
 }

--- a/src-tauri/src/plugins/window/src/commands/windows.rs
+++ b/src-tauri/src/plugins/window/src/commands/windows.rs
@@ -2,31 +2,83 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
 use futures_channel::oneshot;
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
-use tauri::{AppHandle, Runtime, WebviewWindow, command, webview::PlatformWebview};
+use tauri::{
+    AppHandle, Emitter, Manager, Runtime, WebviewWindow, command, webview::PlatformWebview,
+};
 use webview2_com::Microsoft::Web::WebView2::Win32::{
     COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL, ICoreWebView2_19,
 };
-use windows::Win32::Foundation::HWND;
+use windows::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, GetLastError, HWND, SetLastError};
+use windows::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW, TH32CS_SNAPPROCESS,
+};
 use windows::Win32::UI::WindowsAndMessaging::{
-    HWND_NOTOPMOST, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SetWindowPos,
+    GWL_EXSTYLE, GetWindowLongPtrW, HWND_NOTOPMOST, HWND_TOPMOST, SW_SHOWNOACTIVATE,
+    SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SetWindowLongPtrW, SetWindowPos,
+    ShowWindow, WS_EX_NOACTIVATE, WS_EX_TRANSPARENT,
 };
 use windows::core::Interface;
 
-use super::WebviewMemoryTarget;
+use super::{GAME_MODE_CHANGED_EVENT, GameModeConfig, WebviewMemoryTarget};
 
-static TOPMOST_WINDOWS: OnceLock<Mutex<HashMap<isize, Arc<AtomicBool>>>> = OnceLock::new();
+const GAME_MODE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const GAME_MODE_STYLE_BITS: isize = WS_EX_NOACTIVATE.0 as isize;
+const MANAGED_EX_STYLE_BITS: isize = GAME_MODE_STYLE_BITS | WS_EX_TRANSPARENT.0 as isize;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct GameModeSettings {
+    enabled: bool,
+    processes: HashSet<String>,
+    always_on_top: bool,
+    pass_through: bool,
+}
+
+impl GameModeSettings {
+    fn from_config(config: GameModeConfig) -> Self {
+        Self {
+            enabled: config.enabled,
+            processes: normalize_processes(config.processes),
+            always_on_top: config.always_on_top,
+            pass_through: config.pass_through,
+        }
+    }
+}
+
+#[derive(Default)]
+struct GameModeState {
+    settings: Option<GameModeSettings>,
+    active: bool,
+    generation: u64,
+}
+
+static GAME_MODE_STATE: OnceLock<Arc<Mutex<GameModeState>>> = OnceLock::new();
+
+fn game_mode_state() -> &'static Arc<Mutex<GameModeState>> {
+    GAME_MODE_STATE.get_or_init(|| Arc::new(Mutex::new(GameModeState::default())))
+}
 
 #[command]
-pub async fn show_window<R: Runtime>(_app_handle: AppHandle<R>, window: WebviewWindow<R>) {
+pub async fn show_window<R: Runtime>(
+    app_handle: AppHandle<R>,
+    window: WebviewWindow<R>,
+) -> Result<(), String> {
     let _ = set_webview_memory_target(window.clone(), WebviewMemoryTarget::Normal).await;
-    let _ = window.show();
-    let _ = window.unminimize();
-    let _ = window.set_focus();
+
+    if should_show_without_activation(is_game_mode_active(), is_game_mode_window(&window)) {
+        show_window_without_activation(&window)?;
+        apply_window_game_mode(&window, true, game_mode_settings())?;
+    } else {
+        window.show().map_err(|error| error.to_string())?;
+        window.unminimize().map_err(|error| error.to_string())?;
+        window.set_focus().map_err(|error| error.to_string())?;
+    }
+
+    let _ = app_handle;
+    Ok(())
 }
 
 #[command]
@@ -40,80 +92,87 @@ pub async fn set_always_on_top<R: Runtime>(
     _app_handle: AppHandle<R>,
     window: WebviewWindow<R>,
     always_on_top: bool,
-) {
-    let Ok(hwnd) = window.hwnd() else { return };
-    let raw_hwnd = hwnd.0 as isize;
-    let windows = TOPMOST_WINDOWS.get_or_init(|| Mutex::new(HashMap::new()));
+) -> Result<(), String> {
+    if is_game_mode_active() && is_game_mode_window(&window) {
+        update_game_mode_always_on_top(&window, always_on_top);
+        return Ok(());
+    }
 
-    if always_on_top {
-        let Ok(mut windows) = windows.lock() else {
-            return;
+    set_window_topmost(&window, always_on_top)?;
+    update_game_mode_always_on_top(&window, always_on_top);
+    Ok(())
+}
+
+#[command]
+pub async fn set_pass_through<R: Runtime>(
+    _app_handle: AppHandle<R>,
+    window: WebviewWindow<R>,
+    pass_through: bool,
+) -> Result<(), String> {
+    if is_game_mode_active() && is_game_mode_window(&window) {
+        update_game_mode_pass_through(&window, pass_through);
+    }
+
+    window
+        .set_ignore_cursor_events(pass_through)
+        .map_err(|error| error.to_string())?;
+
+    if is_game_mode_window(&window) {
+        let style_bits = if is_game_mode_active() {
+            GAME_MODE_STYLE_BITS
+        } else {
+            0
+        } | if pass_through {
+            WS_EX_TRANSPARENT.0 as isize
+        } else {
+            0
         };
 
-        if windows.contains_key(&raw_hwnd) {
-            return;
-        }
-
-        let running = Arc::new(AtomicBool::new(true));
-
-        windows.insert(raw_hwnd, Arc::clone(&running));
-
-        thread::spawn(move || {
-            let hwnd = HWND(raw_hwnd as *mut _);
-
-            while running.load(Ordering::SeqCst) {
-                let result = unsafe {
-                    SetWindowPos(
-                        hwnd,
-                        Some(HWND_TOPMOST),
-                        0,
-                        0,
-                        0,
-                        0,
-                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
-                    )
-                };
-
-                if result.is_err() {
-                    break;
-                }
-
-                thread::sleep(Duration::from_millis(16));
-            }
-
-            if let Some(windows) = TOPMOST_WINDOWS.get()
-                && let Ok(mut windows) = windows.lock()
-            {
-                let should_remove = windows
-                    .get(&raw_hwnd)
-                    .is_some_and(|current| Arc::ptr_eq(current, &running));
-
-                if should_remove {
-                    windows.remove(&raw_hwnd);
-                }
-            }
-        });
-    } else {
-        if let Ok(mut windows) = windows.lock() {
-            if let Some(running) = windows.remove(&raw_hwnd) {
-                running.store(false, Ordering::SeqCst);
-            }
-        }
-
-        let hwnd = HWND(raw_hwnd as *mut _);
-
-        unsafe {
-            let _ = SetWindowPos(
-                hwnd,
-                Some(HWND_NOTOPMOST),
-                0,
-                0,
-                0,
-                0,
-                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
-            );
-        }
+        update_managed_ex_style(
+            window.hwnd().map_err(|error| error.to_string())?,
+            style_bits,
+        )?;
     }
+
+    Ok(())
+}
+
+#[command]
+pub async fn set_game_mode<R: Runtime>(
+    app_handle: AppHandle<R>,
+    enabled: bool,
+    processes: Vec<String>,
+    always_on_top: bool,
+    pass_through: bool,
+) -> Result<bool, String> {
+    let settings = GameModeSettings::from_config(GameModeConfig {
+        enabled,
+        processes,
+        always_on_top,
+        pass_through,
+    });
+    let should_start_worker;
+    let active = settings.enabled
+        && !settings.processes.is_empty()
+        && configured_process_is_running(&settings.processes).unwrap_or(false);
+
+    {
+        let mut state = game_mode_state()
+            .lock()
+            .map_err(|_| "game mode state lock poisoned".to_owned())?;
+        should_start_worker = state.settings.is_none();
+        state.generation = state.generation.wrapping_add(1);
+        state.active = active;
+        state.settings = Some(settings.clone());
+    }
+
+    apply_game_mode(&app_handle, active, &settings)?;
+
+    if should_start_worker {
+        spawn_game_mode_worker(app_handle)?;
+    }
+
+    Ok(active)
 }
 
 #[command]
@@ -147,6 +206,270 @@ pub fn request_webview_memory_target<R: Runtime>(
     });
 }
 
+fn spawn_game_mode_worker<R: Runtime>(app_handle: AppHandle<R>) -> Result<(), String> {
+    thread::Builder::new()
+        .name("game-mode-detector".into())
+        .spawn(move || {
+            loop {
+                thread::sleep(GAME_MODE_POLL_INTERVAL);
+
+                let (settings, generation, was_active) = match game_mode_state().lock() {
+                    Ok(state) => (state.settings.clone(), state.generation, state.active),
+                    Err(_) => continue,
+                };
+
+                let Some(settings) = settings else {
+                    continue;
+                };
+                let active = settings.enabled
+                    && !settings.processes.is_empty()
+                    && configured_process_is_running(&settings.processes).unwrap_or(false);
+
+                if active == was_active {
+                    continue;
+                }
+
+                let state_is_current = match game_mode_state().lock() {
+                    Ok(mut state) if state.generation == generation => {
+                        state.active = active;
+                        true
+                    }
+                    _ => false,
+                };
+
+                if state_is_current {
+                    let _ = apply_game_mode(&app_handle, active, &settings);
+                }
+            }
+        })
+        .map(|_| ())
+        .map_err(|error| format!("failed to spawn game mode detector: {error}"))
+}
+
+fn is_game_mode_active() -> bool {
+    game_mode_state()
+        .lock()
+        .map(|state| state.active)
+        .unwrap_or(false)
+}
+
+fn game_mode_settings() -> Option<GameModeSettings> {
+    game_mode_state()
+        .lock()
+        .ok()
+        .and_then(|state| state.settings.clone())
+}
+
+pub fn apply_current_game_mode<R: Runtime>(window: &WebviewWindow<R>) {
+    if !is_game_mode_active() || !is_game_mode_window(window) {
+        return;
+    }
+
+    if apply_window_game_mode(window, true, game_mode_settings()).is_ok() {
+        let _ = window.emit(GAME_MODE_CHANGED_EVENT, true);
+    }
+}
+
+fn update_game_mode_always_on_top<R: Runtime>(window: &WebviewWindow<R>, always_on_top: bool) {
+    if window.label() != super::MAIN_WINDOW_LABEL {
+        return;
+    }
+
+    if let Ok(mut state) = game_mode_state().lock()
+        && let Some(settings) = state.settings.as_mut()
+    {
+        settings.always_on_top = always_on_top;
+    }
+}
+
+fn update_game_mode_pass_through<R: Runtime>(window: &WebviewWindow<R>, pass_through: bool) {
+    if window.label() != super::MAIN_WINDOW_LABEL {
+        return;
+    }
+
+    if let Ok(mut state) = game_mode_state().lock()
+        && let Some(settings) = state.settings.as_mut()
+    {
+        settings.pass_through = pass_through;
+    }
+}
+
+fn apply_game_mode<R: Runtime>(
+    app_handle: &AppHandle<R>,
+    active: bool,
+    settings: &GameModeSettings,
+) -> Result<(), String> {
+    for window in app_handle.webview_windows().into_values() {
+        if is_game_mode_window(&window) {
+            apply_window_game_mode(&window, active, Some(settings.clone()))?;
+            let _ = window.emit(GAME_MODE_CHANGED_EVENT, active);
+        }
+    }
+
+    Ok(())
+}
+
+fn is_game_mode_window<R: Runtime>(window: &WebviewWindow<R>) -> bool {
+    window.label() == super::MAIN_WINDOW_LABEL
+}
+
+fn should_show_without_activation(game_mode_active: bool, is_game_mode_window: bool) -> bool {
+    game_mode_active && is_game_mode_window
+}
+
+fn show_window_without_activation<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), String> {
+    let hwnd = window.hwnd().map_err(|error| error.to_string())?;
+
+    unsafe {
+        let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+    }
+
+    Ok(())
+}
+
+fn apply_window_game_mode<R: Runtime>(
+    window: &WebviewWindow<R>,
+    active: bool,
+    settings: Option<GameModeSettings>,
+) -> Result<(), String> {
+    let Some(settings) = settings else {
+        return Ok(());
+    };
+    let hwnd = window.hwnd().map_err(|error| error.to_string())?;
+    if active {
+        let managed_bits = GAME_MODE_STYLE_BITS
+            | if settings.pass_through {
+                WS_EX_TRANSPARENT.0 as isize
+            } else {
+                0
+            };
+        update_managed_ex_style(hwnd, managed_bits)?;
+        set_hwnd_topmost(hwnd, false)?;
+    } else {
+        let managed_bits = if settings.pass_through {
+            WS_EX_TRANSPARENT.0 as isize
+        } else {
+            0
+        };
+        update_managed_ex_style(hwnd, managed_bits)?;
+        set_hwnd_topmost(hwnd, settings.always_on_top)?;
+    }
+
+    window
+        .set_ignore_cursor_events(settings.pass_through)
+        .map_err(|error| error.to_string())?;
+
+    Ok(())
+}
+
+fn set_window_topmost<R: Runtime>(window: &WebviewWindow<R>, topmost: bool) -> Result<(), String> {
+    let hwnd = window.hwnd().map_err(|error| error.to_string())?;
+    set_hwnd_topmost(hwnd, topmost)
+}
+
+fn set_hwnd_topmost(hwnd: HWND, topmost: bool) -> Result<(), String> {
+    unsafe {
+        SetWindowPos(
+            hwnd,
+            Some(if topmost {
+                HWND_TOPMOST
+            } else {
+                HWND_NOTOPMOST
+            }),
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
+        )
+        .map_err(|error| error.to_string())
+    }
+}
+
+fn update_managed_ex_style(hwnd: HWND, managed_bits: isize) -> Result<isize, String> {
+    unsafe {
+        SetLastError(ERROR_SUCCESS);
+        let previous = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+        if previous == 0 && GetLastError() != ERROR_SUCCESS {
+            return Err(windows::core::Error::from_win32().to_string());
+        }
+        let updated = (previous & !MANAGED_EX_STYLE_BITS) | managed_bits;
+
+        if previous != updated {
+            SetLastError(ERROR_SUCCESS);
+            SetWindowLongPtrW(hwnd, GWL_EXSTYLE, updated);
+            if GetLastError() != ERROR_SUCCESS {
+                return Err(windows::core::Error::from_win32().to_string());
+            }
+            SetWindowPos(
+                hwnd,
+                None,
+                0,
+                0,
+                0,
+                0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_FRAMECHANGED,
+            )
+            .map_err(|error| error.to_string())?;
+        }
+
+        Ok(updated)
+    }
+}
+
+fn normalize_processes(processes: Vec<String>) -> HashSet<String> {
+    processes
+        .into_iter()
+        .map(|process| process.trim().to_ascii_lowercase())
+        .filter(|process| !process.is_empty())
+        .collect()
+}
+
+fn configured_process_is_running(processes: &HashSet<String>) -> Result<bool, String> {
+    let snapshot = unsafe {
+        CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0).map_err(|error| error.to_string())?
+    };
+    let result = unsafe { snapshot_contains_process(snapshot, processes) };
+    unsafe {
+        let _ = CloseHandle(snapshot);
+    }
+    result
+}
+
+unsafe fn snapshot_contains_process(
+    snapshot: windows::Win32::Foundation::HANDLE,
+    processes: &HashSet<String>,
+) -> Result<bool, String> {
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+    unsafe {
+        Process32FirstW(snapshot, &mut entry).map_err(|error| error.to_string())?;
+    }
+
+    loop {
+        let executable = process_entry_name(&entry);
+        if processes.contains(&executable) {
+            return Ok(true);
+        }
+        unsafe {
+            if Process32NextW(snapshot, &mut entry).is_err() {
+                return Ok(false);
+            }
+        }
+    }
+}
+
+fn process_entry_name(entry: &PROCESSENTRY32W) -> String {
+    let length = entry
+        .szExeFile
+        .iter()
+        .position(|character| *character == 0)
+        .unwrap_or(entry.szExeFile.len());
+    String::from_utf16_lossy(&entry.szExeFile[..length]).to_ascii_lowercase()
+}
+
 fn apply_webview_memory_target(webview: PlatformWebview, target: WebviewMemoryTarget) -> bool {
     let level = match target {
         WebviewMemoryTarget::Normal => COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL(0),
@@ -160,5 +483,56 @@ fn apply_webview_memory_target(webview: PlatformWebview, target: WebviewMemoryTa
             .and_then(|webview| webview.cast::<ICoreWebView2_19>())
             .and_then(|webview| webview.SetMemoryUsageTargetLevel(level))
             .is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        GameModeSettings, normalize_processes, process_entry_name, should_show_without_activation,
+    };
+    use crate::commands::GameModeConfig;
+    use windows::Win32::System::Diagnostics::ToolHelp::PROCESSENTRY32W;
+
+    #[test]
+    fn normalizes_processes_case_insensitively_and_ignores_blanks() {
+        let processes = normalize_processes(vec![
+            " VALORANT-Win64-Shipping.exe ".into(),
+            "valorant-win64-shipping.EXE".into(),
+            " ".into(),
+        ]);
+
+        assert_eq!(processes.len(), 1);
+        assert!(processes.contains("valorant-win64-shipping.exe"));
+    }
+
+    #[test]
+    fn converts_process_entry_name_to_lowercase() {
+        let mut entry = PROCESSENTRY32W::default();
+        let name: Vec<u16> = "VALORANT.exe\0".encode_utf16().collect();
+        entry.szExeFile[..name.len()].copy_from_slice(&name);
+
+        assert_eq!(process_entry_name(&entry), "valorant.exe");
+    }
+
+    #[test]
+    fn game_mode_settings_preserves_user_window_preferences() {
+        let settings = GameModeSettings::from_config(GameModeConfig {
+            enabled: true,
+            processes: vec!["VALORANT.exe".into()],
+            always_on_top: true,
+            pass_through: true,
+        });
+
+        assert!(settings.enabled);
+        assert!(settings.always_on_top);
+        assert!(settings.pass_through);
+    }
+
+    #[test]
+    fn only_the_active_main_window_uses_non_activating_show() {
+        assert!(should_show_without_activation(true, true));
+        assert!(!should_show_without_activation(false, true));
+        assert!(!should_show_without_activation(true, false));
     }
 }

--- a/src-tauri/src/plugins/window/src/lib.rs
+++ b/src-tauri/src/plugins/window/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
 use tauri::{
-    Runtime, generate_handler,
+    Manager, Runtime, generate_handler,
     plugin::{Builder, TauriPlugin},
 };
 
@@ -16,8 +16,15 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::show_window,
             commands::hide_window,
             commands::set_always_on_top,
+            commands::set_pass_through,
+            commands::set_game_mode,
             commands::set_taskbar_visibility,
             commands::set_webview_memory_target,
         ])
+        .on_webview_ready(|webview| {
+            if let Some(window) = webview.app_handle().get_webview_window(webview.label()) {
+                commands::apply_current_game_mode(&window);
+            }
+        })
         .build()
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -22,6 +22,7 @@ export const LISTEN_KEY = {
   MODEL_SWITCH_APPLIED: 'model-switch-applied',
   TYPING_STATS_OPERATION_REQUESTED: 'typing-stats-operation-requested',
   TYPING_STATS_OPERATION_APPLIED: 'typing-stats-operation-applied',
+  GAME_MODE_CHANGED: 'game-mode-changed',
 }
 
 export const INVOKE_KEY = {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -18,6 +18,8 @@
           "windowSettings": "Window Settings",
           "passThrough": "Cat Lock",
           "alwaysOnTop": "Always on Top",
+          "gameMode": "Game Mode",
+          "gameProcesses": "Target process names",
           "returnToScreen": "Return to Screen",
           "windowSize": "Window Size",
           "windowRadius": "Window Radius",
@@ -39,6 +41,7 @@
           "typingExpression": "When enabled, typing randomly triggers a motion or expression from the selected group after a random delay within this range.",
           "passThrough": "When enabled, cat window interaction is locked and mouse input passes to apps underneath.",
           "alwaysOnTop": "When enabled, the window stays above all other windows.",
+          "gameMode": "On Windows, keeps the pet from activating or repeatedly forcing itself above configured game processes. True exclusive fullscreen may hide the pet.",
           "returnToScreen": "Moves the pet window to the visible area of the screen containing the pointer.",
           "windowSize": "Use the slider for quick resizing, or enter a percentage for precise control.",
           "autoReleaseDelay": "On Windows, some system keys cannot capture release events and will auto-release after timeout.",
@@ -251,14 +254,16 @@
           "togglePreferences": "Toggle Preferences",
           "mirrorMode": "Mirror Mode",
           "passThrough": "Cat Lock",
-          "alwaysOnTop": "Always on Top"
+          "alwaysOnTop": "Always on Top",
+          "gameMode": "Toggle Game Mode"
         },
         "hints": {
           "toggleCat": "Toggle the visibility of the cat window.",
           "togglePreferences": "Toggle the visibility of the preferences window.",
           "mirrorMode": "Toggle the cat's mirror mode.",
           "passThrough": "Toggle whether cat window interaction is locked.",
-          "alwaysOnTop": "Toggle whether the cat window stays on top."
+          "alwaysOnTop": "Toggle whether the cat window stays on top.",
+          "gameMode": "Toggle Windows game compatibility mode."
         }
       },
       "about": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -18,6 +18,8 @@
           "windowSettings": "Configurações da Janela",
           "passThrough": "Bloqueio do Gato",
           "alwaysOnTop": "Sempre no Topo",
+          "gameMode": "Modo de Jogo",
+          "gameProcesses": "Nomes dos processos-alvo",
           "returnToScreen": "Trazer para a Tela",
           "windowSize": "Tamanho da Janela",
           "windowRadius": "Raio da Janela",
@@ -39,6 +41,7 @@
           "typingExpression": "Quando ativado, a digita??o aciona aleatoriamente um movimento ou express?o do grupo selecionado ap?s um atraso neste intervalo.",
           "passThrough": "Quando ativado, a interação com a janela do gato fica bloqueada e o mouse passa para os aplicativos abaixo.",
           "alwaysOnTop": "Quando ativado, a janela sempre ficará acima de outros aplicativos.",
+          "gameMode": "No Windows, impede que o pet ative a janela ou force repetidamente sua posição acima dos processos de jogo configurados. Tela cheia exclusiva pode ocultar o pet.",
           "returnToScreen": "Move a janela do pet para a area visivel da tela onde esta o ponteiro.",
           "windowSize": "Use o controle deslizante para ajustar rapidamente ou digite uma porcentagem para controle preciso.",
           "autoReleaseDelay": "Devido ao Windows não capturar eventos de liberação de certas teclas de nível do sistema, elas serão automaticamente tratadas como liberadas após um tempo limite.",
@@ -245,14 +248,16 @@
           "togglePreferences": "Abrir Preferências",
           "mirrorMode": "Modo Espelho",
           "passThrough": "Bloqueio do Gato",
-          "alwaysOnTop": "Sempre no Topo"
+          "alwaysOnTop": "Sempre no Topo",
+          "gameMode": "Alternar Modo de Jogo"
         },
         "hints": {
           "toggleCat": "Alternar a visibilidade da janela do gato.",
           "togglePreferences": "Alternar a visibilidade da janela de preferências.",
           "mirrorMode": "Alternar o modo espelho do gato.",
           "passThrough": "Alternar se a interação com a janela do gato fica bloqueada.",
-          "alwaysOnTop": "Alternar se a janela do gato permanece no topo."
+          "alwaysOnTop": "Alternar se a janela do gato permanece no topo.",
+          "gameMode": "Alternar o modo de compatibilidade de jogos do Windows."
         }
       },
       "about": {

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -18,6 +18,8 @@
           "windowSettings": "Cài đặt Cửa sổ",
           "passThrough": "Khóa mèo",
           "alwaysOnTop": "Luôn trên cùng",
+          "gameMode": "Chế độ trò chơi",
+          "gameProcesses": "Tên tiến trình mục tiêu",
           "returnToScreen": "Đưa về màn hình",
           "windowSize": "Kích thước",
           "windowRadius": "Độ bo tròn cửa sổ",
@@ -39,6 +41,7 @@
           "typingExpression": "Khi b?t, vi?c g? s? k?ch ho?t ng?u nhi?n m?t chuy?n ??ng ho?c bi?u c?m trong nh?m ?? ch?n sau kho?ng tr? n?y.",
           "passThrough": "Bật để khóa tương tác với cửa sổ mèo và chuyển thao tác chuột xuống ứng dụng bên dưới.",
           "alwaysOnTop": "Bật để cửa sổ luôn nằm trên ứng dụng khác.",
+          "gameMode": "Trên Windows, thú cưng không kích hoạt cửa sổ hoặc liên tục tranh thứ tự hiển thị với các tiến trình trò chơi đã cấu hình. Toàn màn hình độc quyền có thể ẩn thú cưng.",
           "returnToScreen": "Di chuyển cửa sổ thú cưng đến vùng hiển thị của màn hình có con trỏ.",
           "windowSize": "Dùng thanh trượt để chỉnh nhanh hoặc nhập phần trăm để đặt chính xác.",
           "autoReleaseDelay": "Do Windows không bắt được sự kiện nhả của một số phím hệ thống, các phím đó sẽ được tự động xem như đã nhả sau khi hết thời gian chờ.",
@@ -245,14 +248,16 @@
           "togglePreferences": "Mở Tùy chỉnh",
           "mirrorMode": "Chế độ gương",
           "passThrough": "Khóa mèo",
-          "alwaysOnTop": "Luôn trên cùng"
+          "alwaysOnTop": "Luôn trên cùng",
+          "gameMode": "Chuyển chế độ trò chơi"
         },
         "hints": {
           "toggleCat": "Bật/Tắt cửa sổ mèo.",
           "togglePreferences": "Bật/Tắt cửa sổ tùy chỉnh.",
           "mirrorMode": "Bật/Tắt chế độ gương.",
           "passThrough": "Bật/Tắt khóa tương tác với cửa sổ mèo.",
-          "alwaysOnTop": "Bật/Tắt luôn giữ cửa sổ mèo trên cùng."
+          "alwaysOnTop": "Bật/Tắt luôn giữ cửa sổ mèo trên cùng.",
+          "gameMode": "Chuyển chế độ tương thích trò chơi Windows."
         }
       },
       "about": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -18,6 +18,8 @@
           "windowSettings": "窗口设置",
           "passThrough": "猫咪锁定",
           "alwaysOnTop": "窗口置顶",
+          "gameMode": "游戏模式",
+          "gameProcesses": "目标进程名称",
           "returnToScreen": "回到屏幕内",
           "windowSize": "窗口尺寸",
           "windowRadius": "窗口圆角",
@@ -39,6 +41,7 @@
           "typingExpression": "启用后，打字时会在设置的随机延迟范围内，从选中的组里随机触发动作或表情。",
           "passThrough": "启用后，锁定猫咪窗口交互，鼠标操作会穿透到下方应用。",
           "alwaysOnTop": "启用后，窗口始终显示在其他应用程序上方。",
+          "gameMode": "Windows 下，桌宠不会激活窗口或持续争抢已配置游戏进程的窗口层级。真正独占全屏时桌宠可能不可见。",
           "returnToScreen": "将猫猫窗口移动到当前鼠标所在屏幕的可见区域。",
           "windowSize": "使用滑动条快速调整窗口大小，也可以输入百分比精确设置。",
           "autoReleaseDelay": "由于 Windows 下部分系统级按键无法捕获释放事件，超时后将自动视为已释放。",
@@ -251,14 +254,16 @@
           "togglePreferences": "打开偏好设置",
           "mirrorMode": "镜像模式",
           "passThrough": "猫咪锁定",
-          "alwaysOnTop": "窗口置顶"
+          "alwaysOnTop": "窗口置顶",
+          "gameMode": "切换游戏模式"
         },
         "hints": {
           "toggleCat": "切换猫咪窗口的显示与隐藏。",
           "togglePreferences": "切换偏好设置窗口的显示与隐藏。",
           "mirrorMode": "切换猫咪的镜像模式。",
           "passThrough": "切换是否锁定猫咪窗口交互。",
-          "alwaysOnTop": "切换猫咪窗口是否置顶。"
+          "alwaysOnTop": "切换猫咪窗口是否置顶。",
+          "gameMode": "切换 Windows 游戏兼容模式。"
         }
       },
       "about": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -18,6 +18,8 @@
           "windowSettings": "視窗設定",
           "passThrough": "貓咪鎖定",
           "alwaysOnTop": "視窗置頂",
+          "gameMode": "遊戲模式",
+          "gameProcesses": "目標處理程序名稱",
           "returnToScreen": "移回螢幕內",
           "windowSize": "視窗尺寸",
           "windowRadius": "視窗圓角",
@@ -39,6 +41,7 @@
           "typingExpression": "啟用後，打字時會在設定的隨機延遲範圍內，從選中的組裡隨機觸發動作或表情。",
           "passThrough": "啟用後，鎖定貓咪視窗互動，滑鼠操作會穿透到下方應用程式。",
           "alwaysOnTop": "啟用後，視窗始終顯示在其他應用程式上方。",
+          "gameMode": "在 Windows 上，桌寵不會啟用視窗或持續爭奪已設定遊戲處理程序的視窗層級。真正獨占全螢幕時桌寵可能不可見。",
           "returnToScreen": "將貓咪視窗移到目前滑鼠所在螢幕的可見區域。",
           "windowSize": "使用滑動條快速調整視窗大小，也可以輸入百分比精確設定。",
           "autoReleaseDelay": "由於 Windows 下部份系統級按鍵無法擷取釋放事件，超時後將自動視為已釋放。",
@@ -245,14 +248,16 @@
           "togglePreferences": "開啟偏好設定",
           "mirrorMode": "鏡像模式",
           "passThrough": "貓咪鎖定",
-          "alwaysOnTop": "視窗置頂"
+          "alwaysOnTop": "視窗置頂",
+          "gameMode": "切換遊戲模式"
         },
         "hints": {
           "toggleCat": "切換貓咪視窗的顯示與隱藏。",
           "togglePreferences": "切換偏好設定視窗的顯示與隱藏。",
           "mirrorMode": "切換貓咪的鏡像模式。",
           "passThrough": "切換是否鎖定貓咪視窗互動。",
-          "alwaysOnTop": "切換貓咪視窗是否置頂。"
+          "alwaysOnTop": "切換貓咪視窗是否置頂。",
+          "gameMode": "切換 Windows 遊戲相容模式。"
         }
       },
       "about": {

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -27,7 +27,7 @@ import { useGamepad } from '@/composables/useGamepad'
 import { useModel } from '@/composables/useModel'
 import { useTauriListen } from '@/composables/useTauriListen'
 import { LISTEN_KEY, WINDOW_LABEL } from '@/constants'
-import { hideWindow, setAlwaysOnTop, setTaskbarVisibility, showWindow } from '@/plugins/window'
+import { hideWindow, setAlwaysOnTop, setGameMode, setPassThrough, setTaskbarVisibility, showWindow } from '@/plugins/window'
 import { useCatStore } from '@/stores/cat'
 import { useGeneralStore } from '@/stores/general.ts'
 import { useModelStore } from '@/stores/model'
@@ -127,6 +127,7 @@ const { getBaseMenu, getExitMenu } = useAppMenu({
 })
 const backgroundImagePath = ref<string>()
 const live2dCanvas = ref<HTMLCanvasElement | null>(null)
+const gameModeActive = ref(false)
 const { stickActive, handleInputEvent: handleGamepadInputEvent } = useGamepad({
   currentModel: activeModel,
   mouseMirror: computed(() => appearanceSettings.value.mouseMirror),
@@ -670,10 +671,27 @@ if (!isSubModel) {
 }
 
 watch(() => windowSettings.value.passThrough, (value) => {
-  appWindow.setIgnoreCursorEvents(value)
+  if (isWindows && !isSubModel) {
+    setPassThrough(value)
+  } else {
+    appWindow.setIgnoreCursorEvents(value)
+  }
 }, { immediate: true })
 
 watch(() => windowSettings.value.alwaysOnTop, setAlwaysOnTop, { immediate: true })
+
+if (!isSubModel) {
+  watch([
+    () => catStore.window.gameMode.enabled,
+    () => catStore.window.gameMode.processes,
+    () => catStore.window.alwaysOnTop,
+    () => catStore.window.passThrough,
+  ], ([enabled, processes, alwaysOnTop, passThrough]) => {
+    void setGameMode({ enabled, processes, alwaysOnTop, passThrough }).then((active) => {
+      gameModeActive.value = active
+    })
+  }, { deep: true, immediate: true })
+}
 
 if (!isSubModel) {
   watch(() => generalStore.app.taskbarVisible, setTaskbarVisibility, { immediate: true })
@@ -681,7 +699,13 @@ if (!isSubModel) {
 
 watch(() => catStore.model.motionSound, live2d.setMotionSoundEnabled, { immediate: true })
 
-watch(() => appearanceSettings.value.maxFPS, fps => live2d.setMaxFPS(fps), { immediate: true })
+watch([() => appearanceSettings.value.maxFPS, gameModeActive], ([fps, active]) => {
+  live2d.setMaxFPS(active ? Math.min(fps, 30) : fps)
+}, { immediate: true })
+
+useTauriListen<boolean>(LISTEN_KEY.GAME_MODE_CHANGED, ({ payload }) => {
+  if (!isSubModel) gameModeActive.value = payload
+})
 
 useTauriListen<{
   id: string

--- a/src/pages/preference/components/cat/index.vue
+++ b/src/pages/preference/components/cat/index.vue
@@ -171,6 +171,28 @@ const typingBehaviorGroupOptions = computed(() => {
     </ProListItem>
 
     <ProListItem
+      v-if="isWindows"
+      :description="$t('pages.preference.cat.hints.gameMode')"
+      :title="$t('pages.preference.cat.labels.gameMode')"
+      vertical
+    >
+      <Flex
+        align="center"
+        class="gap-3"
+      >
+        <Switch v-model:checked="catStore.window.gameMode.enabled" />
+
+        <Select
+          v-model:value="catStore.window.gameMode.processes"
+          class="min-w-70 flex-1"
+          mode="tags"
+          :placeholder="$t('pages.preference.cat.labels.gameProcesses')"
+          :token-separators="[',', ';']"
+        />
+      </Flex>
+    </ProListItem>
+
+    <ProListItem
       :description="hideOnHoverSupported ? $t('pages.preference.cat.hints.hideOnHover') : $t('pages.preference.cat.hints.hideOnHoverWayland')"
       :title="$t('pages.preference.cat.labels.hideOnHover')"
     >

--- a/src/pages/preference/components/shortcut/index.vue
+++ b/src/pages/preference/components/shortcut/index.vue
@@ -16,7 +16,7 @@ import { useCatStore } from '@/stores/cat'
 import { useShortcutStore } from '@/stores/shortcut.ts'
 
 const shortcutStore = useShortcutStore()
-const { visibleCat, visiblePreference, mirrorMode, penetrable, alwaysOnTop } = storeToRefs(shortcutStore)
+const { visibleCat, visiblePreference, mirrorMode, penetrable, alwaysOnTop, gameMode } = storeToRefs(shortcutStore)
 const catStore = useCatStore()
 
 useKeyPress(visibleCat, () => {
@@ -37,6 +37,10 @@ useKeyPress(penetrable, () => {
 
 useKeyPress(alwaysOnTop, () => {
   catStore.window.alwaysOnTop = !catStore.window.alwaysOnTop
+})
+
+useKeyPress(gameMode, () => {
+  catStore.window.gameMode.enabled = !catStore.window.gameMode.enabled
 })
 </script>
 
@@ -75,6 +79,13 @@ useKeyPress(alwaysOnTop, () => {
       :title="$t('pages.preference.shortcut.labels.alwaysOnTop')"
     >
       <Shortcut v-model="shortcutStore.alwaysOnTop" />
+    </ProListItem>
+
+    <ProListItem
+      :description="$t('pages.preference.shortcut.hints.gameMode')"
+      :title="$t('pages.preference.shortcut.labels.gameMode')"
+    >
+      <Shortcut v-model="shortcutStore.gameMode" />
     </ProListItem>
   </ProList>
 </template>

--- a/src/plugins/window.ts
+++ b/src/plugins/window.ts
@@ -14,12 +14,21 @@ import { LISTEN_KEY } from '../constants'
 export type WindowLabel = typeof WINDOW_LABEL[keyof typeof WINDOW_LABEL]
 export type WebviewMemoryTarget = 'normal' | 'low'
 
+export interface GameModeOptions extends Record<string, unknown> {
+  enabled: boolean
+  processes: string[]
+  alwaysOnTop: boolean
+  passThrough: boolean
+}
+
 const COMMAND = {
   SHOW_WINDOW: 'plugin:custom-window|show_window',
   HIDE_WINDOW: 'plugin:custom-window|hide_window',
   SET_ALWAYS_ON_TOP: 'plugin:custom-window|set_always_on_top',
+  SET_PASS_THROUGH: 'plugin:custom-window|set_pass_through',
   SET_TASKBAR_VISIBILITY: 'plugin:custom-window|set_taskbar_visibility',
   SET_WEBVIEW_MEMORY_TARGET: 'plugin:custom-window|set_webview_memory_target',
+  SET_GAME_MODE: 'plugin:custom-window|set_game_mode',
 }
 
 function formatWindowError(error: unknown) {
@@ -56,6 +65,19 @@ export function hideWindow(label?: WindowLabel) {
 
 export function setAlwaysOnTop(alwaysOnTop: boolean) {
   return invoke(COMMAND.SET_ALWAYS_ON_TOP, { alwaysOnTop }).catch(catchWindowError('always-on-top'))
+}
+
+export function setPassThrough(passThrough: boolean) {
+  return invoke(COMMAND.SET_PASS_THROUGH, { passThrough }).catch(catchWindowError('pass-through'))
+}
+
+export async function setGameMode(options: GameModeOptions): Promise<boolean> {
+  try {
+    return await invoke<boolean>(COMMAND.SET_GAME_MODE, options)
+  } catch (reason) {
+    catchWindowError('game-mode')(reason)
+    return false
+  }
 }
 
 export async function toggleWindowVisible(label?: WindowLabel) {

--- a/src/stores/cat.ts
+++ b/src/stores/cat.ts
@@ -25,6 +25,10 @@ export interface CatStore {
     visible: boolean
     passThrough: boolean
     alwaysOnTop: boolean
+    gameMode: {
+      enabled: boolean
+      processes: string[]
+    }
     scale: number
     opacity: number
     radius: number
@@ -75,6 +79,10 @@ export const useCatStore = defineStore('cat', () => {
     visible: true,
     passThrough: false,
     alwaysOnTop: false,
+    gameMode: {
+      enabled: false,
+      processes: ['VALORANT-Win64-Shipping.exe', 'VALORANT.exe'],
+    },
     scale: 100,
     opacity: 100,
     radius: 0,
@@ -83,6 +91,13 @@ export const useCatStore = defineStore('cat', () => {
   })
 
   const init = () => {
+    if (!window.gameMode || !Array.isArray(window.gameMode.processes)) {
+      window.gameMode = {
+        enabled: false,
+        processes: ['VALORANT-Win64-Shipping.exe', 'VALORANT.exe'],
+      }
+    }
+
     if (migrated.value) return
 
     model.mirror = mirrorMode.value

--- a/src/stores/shortcut.ts
+++ b/src/stores/shortcut.ts
@@ -5,7 +5,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
-export type HotKey = 'visibleCat' | 'mirrorMode' | 'penetrable' | 'alwaysOnTop'
+export type HotKey = 'visibleCat' | 'mirrorMode' | 'penetrable' | 'alwaysOnTop' | 'gameMode'
 
 export const useShortcutStore = defineStore('shortcut', () => {
   const visibleCat = ref('')
@@ -13,6 +13,7 @@ export const useShortcutStore = defineStore('shortcut', () => {
   const mirrorMode = ref('')
   const penetrable = ref('')
   const alwaysOnTop = ref('')
+  const gameMode = ref('Ctrl+Shift+G')
 
   return {
     visibleCat,
@@ -20,5 +21,6 @@ export const useShortcutStore = defineStore('shortcut', () => {
     mirrorMode,
     penetrable,
     alwaysOnTop,
+    gameMode,
   }
 })


### PR DESCRIPTION
## Summary

- Add Windows Game Mode with configurable target process names and a default Valorant process list.
- Preserve the pet window's focus behavior by using non-activating Win32 display while Game Mode is active.
- Coordinate TOPMOST, mouse passthrough, game-mode events, shortcut handling, localized preferences, and a 30 FPS active-mode cap.
- Update package, Cargo manifest, and lockfile versions to `1.1.10`.

## Verification

- `pnpm test` (115 passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src --max-warnings 1` (one pre-existing UnoCSS ordering warning)
- `pnpm build:vite`
- `cargo test --workspace --all-targets --locked`
- `cargo check --workspace --all-targets --locked`
- `cargo test --manifest-path src-tauri/src/plugins/window/Cargo.toml --locked`
- `cargo check --manifest-path src-tauri/src/plugins/window/Cargo.toml --locked`
- `pnpm exec tsx scripts/checkReleaseVersion.ts v1.1.10`
- `git diff --check`

## Release Note

This PR is intended to become the `v1.1.10` release. The final release description will reference this PR's actual number after merge.