### PR TITLE
fix(windows): restore hover pass-through

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.10"
+version = "1.1.10-1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.10",
+  "version": "1.1.10-1",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "mochi-paw"
 default-run = "mochi-paw"
-version = "1.1.10"
+version = "1.1.10-1"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"

--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -13,6 +13,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import type { ModelRuntimeOptions } from '@/composables/useModel'
 import type { DeviceInputEvent } from '@/utils/subModelRuntime'
 
+import { setPassThrough } from '@/plugins/window'
 import { useAppStore } from '@/stores/app'
 import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
@@ -64,6 +65,12 @@ export function useDevice(options: UseDeviceOptions = {}) {
   let cursorSmoothingFrame = 0
   let lastCursorSmoothingAt = 0
   let relativeMouseFrame = 0
+
+  const updateMainWindowPassThrough = (passThrough: boolean) => {
+    if (isWindows) return setPassThrough(passThrough)
+
+    return appWindow.setIgnoreCursorEvents(passThrough)
+  }
 
   const reportRuntimeUsed = () => {
     const now = Date.now()
@@ -244,12 +251,12 @@ export function useDevice(options: UseDeviceOptions = {}) {
         timer = setTimeout(() => {
           document.body.style.setProperty('opacity', '0')
 
-          appWindow.setIgnoreCursorEvents(true)
+          void updateMainWindowPassThrough(true)
         }, catStore.window.hideOnHoverDelay * 1000)
       } else {
         document.body.style.setProperty('opacity', 'unset')
 
-        appWindow.setIgnoreCursorEvents(catStore.window.passThrough)
+        void updateMainWindowPassThrough(catStore.window.passThrough)
       }
 
       wasInWindow = isInWindow


### PR DESCRIPTION
## Summary

- route Windows hover-hide pass-through updates through the custom window command
- restore the persisted Cat Lock state after leaving the pet window
- prepare the `1.1.10-1` prerelease version across package and Cargo metadata

## Verification

- `pnpm test` (115/115)
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm build:vite`
- `pnpm exec eslint src --max-warnings 1`
- `cargo test --workspace --all-targets --locked` (38/38)
- `cargo check --workspace --all-targets --locked`
- custom-window plugin tests and Windows target check
- `pnpm exec tsx scripts/checkReleaseVersion.ts v1.1.10-1`
- `git diff --check`

## Manual verification

- Windows Cat Lock and hide-on-hover interaction remains to be exercised with the packaged prerelease.
- This prerelease sorts below stable `1.1.10`, so it is intended for manual installation and testing.