### PR TITLE
chore(release): prepare v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.1.10-1"
+version = "1.2.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.1.10-1",
+  "version": "1.2.0",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "mochi-paw"
 default-run = "mochi-paw"
-version = "1.1.10-1"
+version = "1.2.0"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary

- Bump the application, Cargo manifest, and Cargo.lock versions from `1.1.10-1` to `1.2.0`.
- Prepare the stable `v1.2.0` release after merged PR #92.

## Verification

- `pnpm exec tsx scripts/checkReleaseVersion.ts v1.2.0`
- `git diff --check`

## Release Scope

The release notes cover all user-facing changes since `v1.1.10`, including PR #92 and the embedded Pomodoro timeline, shortcut controls, manual actions, updater notes, and related fixes.