### PR TITLE
fix(submodel): prevent stale window lifecycle operations

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -469,4 +469,4 @@
 - Prevented hidden preference updates from scheduling redundant synchronization, made hidden-window cleanup and destruction idempotent, and added lifecycle generations so newer show/hide/destroy requests cancel stale opens while a submodel is waiting for runtime readiness.
 - Added `SubModelWindowLifecycle` regression coverage for stale generation invalidation, cancellation notification, and listener disposal.
 - Verification passed: `pnpm test` (169/169), `pnpm exec tsc --noEmit --pretty false`, focused ESLint, full ESLint with only the pre-existing UnoCSS ordering warning, `pnpm build:vite`, and `git diff --check`.
-- PR delivery is pending; the requested PR must be labeled and reviewed but left unmerged.
+- PR #102 was created from `fix/submodel-window-lifecycle`, labeled `bug` and `performance`, and received a findings-first audit with no blocking or actionable findings. The PR remains open and unmerged by request.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -462,3 +462,11 @@
 - Windows Raw Input 修复已实现并通过自动化验证。Windows 在光标可见时继续使用绝对坐标以保留桌面跟随和悬停行为，在游戏隐藏光标时切换到 Raw Input 相对位移；键盘和鼠标按键仍由 `rdev` 提供。
 - 尚需在真实交互环境完成桌面、窗口化/无边框游戏、普通权限游戏和管理员权限游戏的手动验收，并确认 Cat Lock、鼠标穿透、Game Mode 和鼠标灵敏度无回归。
 - 本次只创建本地提交，不推送、不创建 PR，不执行 label、远程 review 或 squash merge。
+
+## Submodel Window Lifecycle Fix (2026-08-26)
+
+- Investigated `C:\Users\LEGION\Downloads\MochiPaw.log`; the run showed repeated hide, destroy, hidden-sync, and stale-open operations for one submodel instance while Live2D remained loaded at about 58 FPS.
+- Prevented hidden preference updates from scheduling redundant synchronization, made hidden-window cleanup and destruction idempotent, and added lifecycle generations so newer show/hide/destroy requests cancel stale opens while a submodel is waiting for runtime readiness.
+- Added `SubModelWindowLifecycle` regression coverage for stale generation invalidation, cancellation notification, and listener disposal.
+- Verification passed: `pnpm test` (169/169), `pnpm exec tsc --noEmit --pretty false`, focused ESLint, full ESLint with only the pre-existing UnoCSS ordering warning, `pnpm build:vite`, and `git diff --check`.
+- PR delivery is pending; the requested PR must be labeled and reviewed but left unmerged.

--- a/src/pages/preference/components/model/components/sub-model-manager/index.vue
+++ b/src/pages/preference/components/model/components/sub-model-manager/index.vue
@@ -108,7 +108,11 @@ function toggleExpanded(instanceId: string) {
 }
 
 async function notifyInstance(instance: SubModelInstance) {
+  if (!instance.visible) return
+
   await nextTick()
+
+  if (!instance.visible) return
 
   await syncSubModelWindow(instance)
 }

--- a/src/utils/subModelWindow.ts
+++ b/src/utils/subModelWindow.ts
@@ -11,12 +11,17 @@ import type { SubModelInstance } from '@/stores/model'
 import { LISTEN_KEY } from '@/constants'
 import { logError, logInfo, logStep, logTrace, logWarn } from '@/utils/diagnostics'
 
+import { SubModelWindowLifecycle } from './subModelWindowLifecycle'
+
 const SUB_MODEL_WINDOW_PREFIX = 'sub-model-'
 const DEFAULT_SIZE = 300
 const WINDOW_READY_TIMEOUT = 10_000
 let windowOpenQueue = Promise.resolve()
 const runtimeStates = new Map<string, SubModelInteractionState>()
 const lifecycleQueues = new Map<string, Promise<unknown>>()
+const lifecycle = new SubModelWindowLifecycle()
+const destroyedWindowLabels = new Set<string>()
+const destroyingWindowTasks = new Map<string, Promise<boolean>>()
 
 export interface SubModelInteractionState {
   modelReady: boolean
@@ -101,8 +106,10 @@ export function getSubModelWindowLabel(instanceId: string) {
 }
 
 export async function openSubModelWindow(instance: SubModelInstance) {
+  const generation = lifecycle.begin(instance.id)
+
   return enqueueWindowOperation(instance.id, () => {
-    const task = windowOpenQueue.then(() => openSubModelWindowNow(instance))
+    const task = windowOpenQueue.then(() => openSubModelWindowNow(instance, generation))
 
     windowOpenQueue = task.then(() => undefined, () => undefined)
 
@@ -110,12 +117,22 @@ export async function openSubModelWindow(instance: SubModelInstance) {
   })
 }
 
-async function openSubModelWindowNow(instance: SubModelInstance) {
+async function openSubModelWindowNow(instance: SubModelInstance, generation: number) {
   const label = getSubModelWindowLabel(instance.id)
 
   if (!instance.visible) {
+    runtimeStates.delete(instance.id)
     logStep('sub-model-window', 'skipped hidden window open', getInstanceContext(instance))
     await destroySubModelWindowNow(instance.id)
+    return
+  }
+
+  if (!lifecycle.isCurrent(instance.id, generation)) {
+    runtimeStates.delete(instance.id)
+    logTrace('[sub-model-window] skipped stale window open', {
+      ...getInstanceContext(instance),
+      generation,
+    })
     return
   }
 
@@ -126,7 +143,13 @@ async function openSubModelWindowNow(instance: SubModelInstance) {
     generation: previousGeneration + 1,
   })
   logStep('sub-model-window', 'begin open', getInstanceContext(instance))
+  destroyedWindowLabels.delete(label)
   const existingWindow = await getWindowSafely(instance.id)
+
+  if (!lifecycle.isCurrent(instance.id, generation) || !instance.visible) {
+    if (existingWindow) await destroyWindowSafely(existingWindow, 'open-cancelled')
+    return
+  }
 
   if (existingWindow) {
     logWarn('[sub-model-window] replacing existing window to restore runtime handshake', {
@@ -135,10 +158,18 @@ async function openSubModelWindowNow(instance: SubModelInstance) {
     await destroyWindowSafely(existingWindow, 'replace-existing')
   }
 
-  const runtimeReady = await listenForSubModelRuntimeReady(instance.id)
+  if (!lifecycle.isCurrent(instance.id, generation) || !instance.visible) {
+    runtimeStates.delete(instance.id)
+    return
+  }
+
+  const cancellation = lifecycle.onChange(instance.id, generation)
+  let runtimeReady: Awaited<ReturnType<typeof listenForSubModelRuntimeReady>> | undefined
   let window: WebviewWindow | undefined
 
   try {
+    runtimeReady = await listenForSubModelRuntimeReady(instance.id)
+    destroyedWindowLabels.delete(label)
     window = new WebviewWindow(label, {
       url: `index.html/#/sub-model?instance=${encodeURIComponent(instance.id)}`,
       title: 'MochiPaw',
@@ -154,17 +185,40 @@ async function openSubModelWindowNow(instance: SubModelInstance) {
       visible: false,
     })
 
-    await Promise.all([waitForWindowCreation(window), runtimeReady.ready])
+    const cancelled = await Promise.race([
+      Promise.all([waitForWindowCreation(window), runtimeReady.ready]).then(() => false),
+      cancellation.promise.then(() => true),
+    ])
+    if (cancelled || !lifecycle.isCurrent(instance.id, generation) || !instance.visible) {
+      await destroyWindowSafely(window, 'open-cancelled')
+      return
+    }
+
     await makeWindowNonInteractive(window, 'runtime-mounted')
 
-    if (!instance.visible) {
-      await destroyWindowSafely(window, 'hidden-during-open')
+    if (!lifecycle.isCurrent(instance.id, generation) || !instance.visible) {
+      await destroyWindowSafely(window, 'open-cancelled')
       return
     }
 
     await syncSubModelWindowNow(instance, window)
+    if (!lifecycle.isCurrent(instance.id, generation) || !instance.visible) {
+      await destroyWindowSafely(window, 'open-cancelled')
+      return
+    }
+
     await window.show()
+    if (!lifecycle.isCurrent(instance.id, generation) || !instance.visible) {
+      await destroyWindowSafely(window, 'open-cancelled')
+      return
+    }
+
     await emitTo(label, LISTEN_KEY.SET_SUB_MODEL_RENDERING, true)
+    if (!lifecycle.isCurrent(instance.id, generation) || !instance.visible) {
+      await destroyWindowSafely(window, 'open-cancelled')
+      return
+    }
+
     await logWindowState(window, 'opened new window', instance)
 
     return window
@@ -173,16 +227,20 @@ async function openSubModelWindowNow(instance: SubModelInstance) {
     logError('[sub-model-window] failed to open new window', { ...getInstanceContext(instance), error })
     throw error
   } finally {
-    runtimeReady.dispose()
+    cancellation.dispose()
+    runtimeReady?.dispose()
   }
 }
 
 export async function hideSubModelWindow(instanceId: string) {
+  lifecycle.begin(instanceId)
   return enqueueWindowOperation(instanceId, () => hideSubModelWindowNow(instanceId))
 }
 
 async function hideSubModelWindowNow(instanceId: string) {
   const label = getSubModelWindowLabel(instanceId)
+  const previousGeneration = runtimeStates.get(instanceId)?.generation ?? 0
+  runtimeStates.set(instanceId, { modelReady: false, renderingEnabled: false, generation: previousGeneration + 1 })
   const window = await getWindowSafely(instanceId)
 
   if (!window) {
@@ -191,8 +249,6 @@ async function hideSubModelWindowNow(instanceId: string) {
   }
 
   logStep('sub-model-window', 'begin hide', { instanceId, label })
-  const previousGeneration = runtimeStates.get(instanceId)?.generation ?? 0
-  runtimeStates.set(instanceId, { modelReady: false, renderingEnabled: false, generation: previousGeneration + 1 })
   await makeWindowNonInteractive(window, 'hide').catch(() => undefined)
   await emitTo(label, LISTEN_KEY.SET_SUB_MODEL_RENDERING, false).catch((error) => {
     logWarn('[sub-model-window] failed to disable rendering before hide', { instanceId, label, error })
@@ -201,6 +257,7 @@ async function hideSubModelWindowNow(instanceId: string) {
 }
 
 export async function destroySubModelWindow(instanceId: string) {
+  lifecycle.begin(instanceId)
   return enqueueWindowOperation(instanceId, () => destroySubModelWindowNow(instanceId))
 }
 
@@ -233,6 +290,10 @@ export async function cleanupOrphanSubModelWindows(instances: readonly Pick<SubM
   const orphanWindows = windows.filter((window) => {
     return window.label.startsWith(SUB_MODEL_WINDOW_PREFIX) && !configuredLabels.has(window.label)
   })
+
+  for (const window of orphanWindows) {
+    lifecycle.begin(window.label.slice(SUB_MODEL_WINDOW_PREFIX.length))
+  }
 
   for (const instanceId of runtimeStates.keys()) {
     if (!configuredLabels.has(getSubModelWindowLabel(instanceId))) runtimeStates.delete(instanceId)
@@ -296,7 +357,7 @@ async function syncSubModelWindowNow(instance: SubModelInstance, existingWindow?
   }
 
   if (!instance.visible) {
-    logWarn('[sub-model-window] destroying hidden window during sync', getInstanceContext(instance))
+    logTrace('[sub-model-window] destroying hidden window during sync', getInstanceContext(instance))
     const previousGeneration = runtimeStates.get(instance.id)?.generation ?? 0
     runtimeStates.set(instance.id, { modelReady: false, renderingEnabled: false, generation: previousGeneration + 1 })
     await destroyWindowSafely(window, 'sync-hidden')
@@ -403,18 +464,35 @@ async function makeWindowNonInteractive(window: WebviewWindow, reason: string) {
 async function destroyWindowSafely(window: WebviewWindow | undefined, reason: string) {
   if (!window) return true
 
-  await makeWindowNonInteractive(window, `${reason}-before-destroy`).catch(() => undefined)
-  await window.hide().catch((error) => {
-    logWarn('[sub-model-window] failed to hide window before destroy', { label: window.label, reason, error })
-  })
+  const label = window.label
+  if (destroyedWindowLabels.has(label)) return true
+
+  const existingTask = destroyingWindowTasks.get(label)
+  if (existingTask) return existingTask
+
+  const task = (async () => {
+    await makeWindowNonInteractive(window, `${reason}-before-destroy`).catch(() => undefined)
+    await window.hide().catch((error) => {
+      logWarn('[sub-model-window] failed to hide window before destroy', { label, reason, error })
+    })
+
+    try {
+      await window.destroy()
+      logInfo('[sub-model-window] destroyed window', { label, reason })
+      return true
+    } catch (error) {
+      logError('[sub-model-window] failed to destroy window', { label, reason, error })
+      return false
+    }
+  })()
+  destroyingWindowTasks.set(label, task)
 
   try {
-    await window.destroy()
-    logInfo('[sub-model-window] destroyed window', { label: window.label, reason })
-    return true
-  } catch (error) {
-    logError('[sub-model-window] failed to destroy window', { label: window.label, reason, error })
-    return false
+    const result = await task
+    if (result) destroyedWindowLabels.add(label)
+    return result
+  } finally {
+    if (destroyingWindowTasks.get(label) === task) destroyingWindowTasks.delete(label)
   }
 }
 
@@ -465,6 +543,8 @@ function enqueueWindowOperation<T>(instanceId: string, operation: () => Promise<
 
 async function getWindowSafely(instanceId: string) {
   const label = getSubModelWindowLabel(instanceId)
+
+  if (destroyedWindowLabels.has(label)) return null
 
   try {
     return await WebviewWindow.getByLabel(label)

--- a/src/utils/subModelWindowLifecycle.test.ts
+++ b/src/utils/subModelWindowLifecycle.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import { describe, it } from 'node:test'
+
+import { SubModelWindowLifecycle } from './subModelWindowLifecycle'
+
+describe('SubModelWindowLifecycle', () => {
+  it('invalidates an older lifecycle generation', () => {
+    const lifecycle = new SubModelWindowLifecycle()
+    const firstGeneration = lifecycle.begin('instance')
+    const secondGeneration = lifecycle.begin('instance')
+
+    assert.equal(lifecycle.isCurrent('instance', firstGeneration), false)
+    assert.equal(lifecycle.isCurrent('instance', secondGeneration), true)
+  })
+
+  it('cancels a pending operation when a newer lifecycle operation begins', async () => {
+    const lifecycle = new SubModelWindowLifecycle()
+    const generation = lifecycle.begin('instance')
+    const cancellation = lifecycle.onChange('instance', generation)
+    const cancelled = cancellation.promise.then(() => true)
+
+    lifecycle.begin('instance')
+
+    assert.equal(await cancelled, true)
+  })
+
+  it('does not retain disposed cancellation listeners', async () => {
+    const lifecycle = new SubModelWindowLifecycle()
+    const generation = lifecycle.begin('instance')
+    const cancellation = lifecycle.onChange('instance', generation)
+
+    cancellation.dispose()
+    lifecycle.begin('instance')
+
+    const result = await Promise.race([
+      cancellation.promise.then(() => 'cancelled'),
+      new Promise(resolve => setTimeout(() => resolve('pending'), 0)),
+    ])
+
+    assert.equal(result, 'pending')
+  })
+})

--- a/src/utils/subModelWindowLifecycle.ts
+++ b/src/utils/subModelWindowLifecycle.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+export interface LifecycleCancellation {
+  promise: Promise<void>
+  dispose: () => void
+}
+
+export class SubModelWindowLifecycle {
+  private readonly generations = new Map<string, number>()
+  private readonly cancellationResolvers = new Map<string, Set<() => void>>()
+
+  begin(instanceId: string) {
+    const generation = (this.generations.get(instanceId) ?? 0) + 1
+    this.generations.set(instanceId, generation)
+
+    const resolvers = this.cancellationResolvers.get(instanceId)
+    if (resolvers) {
+      for (const resolve of resolvers) resolve()
+      this.cancellationResolvers.delete(instanceId)
+    }
+
+    return generation
+  }
+
+  isCurrent(instanceId: string, generation: number) {
+    return this.generations.get(instanceId) === generation
+  }
+
+  onChange(instanceId: string, generation: number): LifecycleCancellation {
+    if (!this.isCurrent(instanceId, generation)) {
+      return {
+        promise: Promise.resolve(),
+        dispose() {},
+      }
+    }
+
+    let resolveCancellation!: () => void
+    const promise = new Promise<void>((resolve) => {
+      resolveCancellation = resolve
+    })
+    const resolvers = this.cancellationResolvers.get(instanceId) ?? new Set<() => void>()
+    resolvers.add(resolveCancellation)
+    this.cancellationResolvers.set(instanceId, resolvers)
+
+    return {
+      promise,
+      dispose: () => {
+        const currentResolvers = this.cancellationResolvers.get(instanceId)
+        if (!currentResolvers) return
+
+        currentResolvers.delete(resolveCancellation)
+        if (!currentResolvers.size) this.cancellationResolvers.delete(instanceId)
+      },
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Prevent redundant hidden-window synchronization and repeated destruction for submodel instances.
- Cancel stale window-open operations when a newer show, hide, or destroy request arrives.
- Make window destruction idempotent and add lifecycle regression coverage.

## Verification

- `pnpm test` (169/169)
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src --max-warnings 1` (one pre-existing UnoCSS ordering warning)
- `pnpm build:vite`
- `cargo test --workspace --all-targets --locked` (45 passed)
- `cargo check --workspace --all-targets --locked`
- `git diff --check`

The PR is intentionally left open for review and is not to be merged in this task.