### PR TITLE
fix(input): align mouse look with pet window

### DIFF
--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -11,6 +11,7 @@ import { isNil } from 'es-toolkit'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import type { ModelRuntimeOptions } from '@/composables/useModel'
+import type { CursorBounds } from '@/utils/relativeMouse'
 import type { DeviceInputEvent } from '@/utils/subModelRuntime'
 
 import { setPassThrough } from '@/plugins/window'
@@ -57,6 +58,9 @@ export function useDevice(options: UseDeviceOptions = {}) {
   const smoothedCursorPoint = ref<CursorPoint>()
   const relativeMouseMove = ref<RelativeMouseMove>()
   const scaleFactor = ref(1)
+  let windowBounds: CursorBounds | undefined
+  let windowBoundsRefresh: Promise<void> | undefined
+  let stopWindowBoundsListeners: (() => void)[] = []
   const listeners = options.listeners ?? computed<DeviceListenerOptions>(() => ({
     keyboard: true,
     mouse: true,
@@ -67,6 +71,30 @@ export function useDevice(options: UseDeviceOptions = {}) {
   let cursorSmoothingFrame = 0
   let lastCursorSmoothingAt = 0
   let relativeMouseFrame = 0
+
+  const refreshWindowBounds = () => {
+    if (windowBoundsRefresh) return windowBoundsRefresh
+
+    windowBoundsRefresh = Promise.all([
+      appWindow.outerPosition(),
+      appWindow.outerSize(),
+    ]).then(([position, size]) => {
+      if (size.width <= 0 || size.height <= 0) return
+
+      windowBounds = {
+        x: position.x,
+        y: position.y,
+        width: size.width,
+        height: size.height,
+      }
+    }).catch((error) => {
+      logError('[device] failed to refresh window bounds', { windowLabel: appWindow.label, error })
+    }).finally(() => {
+      windowBoundsRefresh = undefined
+    })
+
+    return windowBoundsRefresh
+  }
 
   const updateMainWindowPassThrough = (passThrough: boolean) => {
     if (isWindows) return setPassThrough(passThrough)
@@ -144,18 +172,53 @@ export function useDevice(options: UseDeviceOptions = {}) {
   onMounted(async () => {
     try {
       scaleFactor.value = isMac ? await appWindow.scaleFactor() : 1
+      await refreshWindowBounds()
 
-      await appWindow.onScaleChanged(({ payload }) => {
-        if (!isMac) return
+      const [stopMoved, stopResized, stopScaleChanged] = await Promise.all([
+        appWindow.onMoved(({ payload }) => {
+          if (!windowBounds) {
+            void refreshWindowBounds()
+            return
+          }
 
-        scaleFactor.value = payload.scaleFactor
-      })
+          windowBounds = { ...windowBounds, x: payload.x, y: payload.y }
+        }),
+        appWindow.onResized(({ payload }) => {
+          if (!windowBounds) {
+            void refreshWindowBounds()
+            return
+          }
+
+          windowBounds = { ...windowBounds, width: payload.width, height: payload.height }
+        }),
+        appWindow.onScaleChanged(({ payload }) => {
+          if (isMac) scaleFactor.value = payload.scaleFactor
+
+          if (!windowBounds) {
+            void refreshWindowBounds()
+            return
+          }
+
+          windowBounds = {
+            ...windowBounds,
+            width: payload.size.width,
+            height: payload.size.height,
+          }
+        }),
+      ])
+
+      stopWindowBoundsListeners = [stopMoved, stopResized, stopScaleChanged]
     } catch (error) {
       logError('[device] failed to initialize window scale listener', { windowLabel: appWindow.label, error })
     }
   })
 
   onUnmounted(() => {
+    for (const stopListening of stopWindowBoundsListeners) {
+      stopListening()
+    }
+
+    stopWindowBoundsListeners = []
     stopCursorSmoothing()
 
     for (const timer of releaseTimers.values()) {
@@ -277,11 +340,16 @@ export function useDevice(options: UseDeviceOptions = {}) {
     }
   })()
 
-  const handleCursorMove = async (cursorPoint: CursorPoint) => {
+  const handleCursorMove = (cursorPoint: CursorPoint) => {
     const x = cursorPoint.x * scaleFactor.value
     const y = cursorPoint.y * scaleFactor.value
+    const physicalCursorPoint = new PhysicalPosition(x, y)
 
-    handleMouseMove(new PhysicalPosition(x, y))
+    if (windowBounds) {
+      handleMouseMove(physicalCursorPoint, windowBounds)
+    } else {
+      void refreshWindowBounds()
+    }
 
     if (!options.enableWindowHover || !catStore.window.hideOnHover) return
 

--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -11,11 +11,11 @@ import { isNil, round } from 'es-toolkit'
 import { computed, ref } from 'vue'
 
 import type { Model, ModelBehaviorGroup, ModelBehaviorRef, ModelMotionInfo } from '@/stores/model'
+import type { CursorBounds } from '@/utils/relativeMouse'
 
 import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
 import { logError, logStep, logTrace } from '@/utils/diagnostics'
-import { getCursorMonitor } from '@/utils/monitor'
 import { applyMouseSensitivity } from '@/utils/mouseSensitivity'
 import { isMac } from '@/utils/platform'
 import { applyRelativeMouseMovement, normalizeCursorPosition } from '@/utils/relativeMouse'
@@ -580,19 +580,10 @@ export function useModel(runtimeOptions: ModelRuntimeOptions = {}) {
     live2d.setLookTarget(lookTargetX, lookTargetY)
   }
 
-  async function handleMouseMove(cursorPoint: PhysicalPosition) {
-    const monitor = await getCursorMonitor(cursorPoint)
+  function handleMouseMove(cursorPoint: PhysicalPosition, windowBounds?: CursorBounds) {
+    if (!windowBounds) return
 
-    if (!monitor) return
-
-    const { size, position } = monitor
-
-    relativeLookPosition = normalizeCursorPosition(cursorPoint, {
-      x: position.x,
-      y: position.y,
-      width: size.width,
-      height: size.height,
-    })
+    relativeLookPosition = normalizeCursorPosition(cursorPoint, windowBounds)
 
     applyMouseLook(relativeLookPosition.x, relativeLookPosition.y)
   }

--- a/src/utils/relativeMouse.test.ts
+++ b/src/utils/relativeMouse.test.ts
@@ -7,15 +7,29 @@ import test from 'node:test'
 
 import { applyRelativeMouseMovement, mergeRelativeMouseMovement, normalizeCursorPosition } from './relativeMouse'
 
-test('normalizes an absolute cursor position for relative input handoff', () => {
+test('normalizes an absolute cursor position relative to the pet window', () => {
   assert.deepEqual(normalizeCursorPosition(
-    { x: 960, y: 540 },
-    { x: 0, y: 0, width: 1920, height: 1080 },
+    { x: 1250, y: 750 },
+    { x: 1000, y: 500, width: 500, height: 500 },
   ), { x: 0.5, y: 0.5 })
 
   assert.deepEqual(normalizeCursorPosition(
     { x: -960, y: 540 },
     { x: -1920, y: 0, width: 1920, height: 1080 },
+  ), { x: 0.5, y: 0.5 })
+})
+
+test('clamps cursor positions outside a window spanning a negative monitor', () => {
+  assert.deepEqual(normalizeCursorPosition(
+    { x: -2200, y: 1400 },
+    { x: -1920, y: 0, width: 1920, height: 1080 },
+  ), { x: 0, y: 1 })
+})
+
+test('uses physical window dimensions for mixed-DPI layouts', () => {
+  assert.deepEqual(normalizeCursorPosition(
+    { x: 2880, y: 900 },
+    { x: 2400, y: 600, width: 960, height: 600 },
   ), { x: 0.5, y: 0.5 })
 })
 


### PR DESCRIPTION
## Summary
- normalize absolute cursor input against the pet window's physical bounds instead of the active monitor
- refresh bounds when the window moves, resizes, or changes DPI
- preserve relative Raw Input tracking and add negative-monitor/mixed-DPI regression coverage

## Verification
- pnpm test (168/168)
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src --max-warnings 1 (one existing UnoCSS warning)
- pnpm build:vite
- cargo test --workspace --all-targets --locked
- cargo check --workspace --all-targets --locked
- cargo check --target x86_64-pc-windows-msvc --workspace --all-targets --locked
- git diff --check

Manual Windows multi-monitor acceptance remains pending. This PR is intentionally left open for review and is not being merged.