### PR TITLE
chore(release): prepare v1.2.1-3

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -193,3 +193,11 @@ BongoCat 是一个基于 Vue 3 + Vite + Tauri 2 的跨平台桌面宠物应用�
 - 模型文件读取依赖 Tauri `assetProtocol` 和 `convertFileSrc()`，不要直接把本地路径当浏览器 URL。
 - 新增 UI 文案时同步所有 `src/locales/*.json`，否则语言切换可能出现缺失 key。
 - 涉及发布或更新地址时检查 `src-tauri/tauri.conf.json` 的 updater endpoints 和 `.github/workflows/*`。
+
+## 当前项目状态
+
+- 2026-08-26 修复模型编辑页表情列表为空：偏好窗口中的 `currentExpressions` 属于未持久化的运行时状态，首次打开编辑弹窗时可能为空；`src/utils/live2d.ts` 现在会从当前模型 JSON 的 `FileReferences.Expressions` 回退构建表情条目，`behavior-modal` 会始终执行解析。
+- 表情条目解析抽到 `src/utils/modelExpressions.ts`，并由 `src/utils/modelExpressions.test.ts` 覆盖带名称、仅文件名和缺少表情引用的模型 JSON。
+- 已验证：`pnpm test`（173/173）、`pnpm exec tsc --noEmit -p tsconfig.json`、相关文件 ESLint、`pnpm build:vite` 均通过。
+- 用户导入的旧版键鼠模型 JSON 本身包含 `Expressions` 和对应 `exp3.json` 文件；本次现象的根因是编辑页未在运行时列表为空时读取模型 JSON，不是导入复制阶段丢失文件。
+- 2026-08-26 预发布准备：`release/v1.2.1-3` 将本次表情编辑页修复与 `1.2.1-3` 版本元数据合并，目标 GitHub Release 为 `MochiPaw v1.2.1-3`，沿用上一预览版的 `## What's New` 说明格式。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.2.1-2"
+version = "1.2.1-3"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.2.1-2",
+  "version": "1.2.1-3",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "mochi-paw"
 default-run = "mochi-paw"
-version = "1.2.1-2"
+version = "1.2.1-3"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"

--- a/src/pages/preference/components/model/components/behavior-modal/index.vue
+++ b/src/pages/preference/components/model/components/behavior-modal/index.vue
@@ -244,12 +244,10 @@ watch(modelValue, async (open) => {
 
   modelStore.currentMotions = Object.entries(groupBy(motions, 'group'))
 
-  if (!isEmpty(modelStore.currentExpressions)) {
-    modelStore.currentExpressions = await resolveModelExpressions(
-      modelStore.currentModel.path,
-      modelStore.currentExpressions,
-    )
-  }
+  modelStore.currentExpressions = await resolveModelExpressions(
+    modelStore.currentModel.path,
+    modelStore.currentExpressions,
+  )
 
   ensureBehaviorNames()
 

--- a/src/utils/live2d.ts
+++ b/src/utils/live2d.ts
@@ -19,6 +19,7 @@ import { logError, logInfo, logStep, logTrace } from '@/utils/diagnostics'
 import { RenderDiagnostics } from '@/utils/renderDiagnostics'
 import { Config, CubismSetting, Live2DSprite, Priority } from '@/vendor/easy-live2d'
 
+import { readExpressionsFromModelJSON } from './modelExpressions'
 import { join } from './path'
 import { withTimeout } from './promise'
 
@@ -156,11 +157,16 @@ export async function resolveModelMotions(path: string, motions: MotionInfo[]) {
 }
 
 export async function resolveModelExpressions(path: string, expressions: ExpressionInfo[]) {
-  logStep('live2d-resource', 'resolve expressions', { path, expressionCount: expressions.length })
   const modelJSON = await readCubismModelJSON(path)
   const parameterNames = await getParameterNames(path, modelJSON)
+  const sourceExpressions = expressions.length ? expressions : readExpressionsFromModelJSON(modelJSON)
+  logStep('live2d-resource', 'resolve expressions', {
+    path,
+    inputExpressionCount: expressions.length,
+    expressionCount: sourceExpressions.length,
+  })
 
-  return Promise.all(expressions.map(async (expression, index): Promise<ModelExpressionInfo> => {
+  return Promise.all(sourceExpressions.map(async (expression, index): Promise<ModelExpressionInfo> => {
     const expressionConfig = modelJSON.FileReferences?.Expressions?.[index]
 
     if (!expressionConfig?.File) return expression

--- a/src/utils/modelExpressions.test.ts
+++ b/src/utils/modelExpressions.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Project tests use the Node test runner through tsx.
+import test from 'node:test'
+
+import { readExpressionsFromModelJSON } from './modelExpressions'
+
+test('reads expression entries from a model JSON document', () => {
+  assert.deepEqual(
+    readExpressionsFromModelJSON({
+      FileReferences: {
+        Expressions: [
+          { Name: 'Happy', File: 'happy.exp3.json' },
+          { File: 'sad.exp3.json' },
+          {},
+        ],
+      },
+    }),
+    [
+      { name: 'Happy' },
+      { name: 'sad' },
+      { name: 'Expression 3' },
+    ],
+  )
+})
+
+test('returns no expressions when the model JSON has no expression references', () => {
+  assert.deepEqual(readExpressionsFromModelJSON({}), [])
+})

--- a/src/utils/modelExpressions.ts
+++ b/src/utils/modelExpressions.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+export interface ModelExpressionReference {
+  Name?: string
+  File?: string
+}
+
+export interface ModelExpressionDocument {
+  FileReferences?: {
+    Expressions?: ModelExpressionReference[]
+  }
+}
+
+export interface ModelExpressionEntry {
+  name: string
+}
+
+export function readExpressionsFromModelJSON(modelJSON: ModelExpressionDocument): ModelExpressionEntry[] {
+  return (modelJSON.FileReferences?.Expressions ?? []).map((expression, index) => {
+    return {
+      name: expression.Name?.trim() || removeExpressionFileExtension(expression.File) || `Expression ${index + 1}`,
+    }
+  })
+}
+
+function removeExpressionFileExtension(file: string | undefined) {
+  if (!file) return
+
+  return file
+    .replace(/\.exp3\.json$/i, '')
+    .replace(/\.[^.]+$/, '')
+}


### PR DESCRIPTION
## Summary

- restore model expression discovery in the preference editor when runtime expression state is empty
- keep imported Live2D expression metadata available across the main and preference windows
- prepare the `v1.2.1-3` prerelease metadata

## Verification

- `pnpm test` (173/173)
- `pnpm exec tsc --noEmit -p tsconfig.json`
- focused ESLint
- `pnpm build:vite`
- `pnpm exec tsx scripts/checkReleaseVersion.ts v1.2.1-3`
- `git diff --check`

## Release

This PR prepares the `v1.2.1-3` GitHub prerelease for manual testing of expression visibility in the model editor. The release description follows the `v1.2.1-2` preview format.