### PR TITLE
ci(release): allow manual release dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}


### PR DESCRIPTION
## Summary

- add a manual dispatch entry to the existing release workflow
- preserve the existing `v*` tag trigger and release behavior

## Verification

- `git diff --check`

## Context

The `v1.2.1-3` tag is already on the merged release commit, but its tag push did not create a release workflow run. This small workflow-only change allows the same tag to be dispatched explicitly after the PR is merged.