### PR TITLE
feat(input): add mouse look modes and smoothing

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -202,3 +202,6 @@ BongoCat 是一个基于 Vue 3 + Vite + Tauri 2 的跨平台桌面宠物应用�
 - 用户导入的旧版键鼠模型 JSON 本身包含 `Expressions` 和对应 `exp3.json` 文件；本次现象的根因是编辑页未在运行时列表为空时读取模型 JSON，不是导入复制阶段丢失文件。
 - 2026-08-26 预发布准备：`release/v1.2.1-3` 将本次表情编辑页修复与 `1.2.1-3` 版本元数据合并，目标 GitHub Release 为 `MochiPaw v1.2.1-3`，沿用上一预览版的 `## What's New` 说明格式。
 - 2026-08-27 已发布 `MochiPaw v1.2.1-3` prerelease：PR #104（表情修复）与 PR #105（发布 workflow 手动触发入口）均已 squash merge；发布 run `32986267571` 成功，Release 包含 24 个资产，`latest-v2.json` 已验证为 `1.2.1-3`。
+- 2026-08-27 已实现鼠标视角算法切换与平滑度：`windowRelativeMouseLook` 默认 `true`，`mouseLookSmoothing` 与 `legacyMouseLookSmoothing` 默认均为 `75`；窗口模式使用宠物窗口边界，关闭后恢复显示器边界，两套平滑度独立持久化。
+- 平滑度支持 `0-100%`，`0%` 直接响应，`75%` 保持原 `DAMPING_DECAY = 0.75` 手感，`100%` 使用最高平滑阻尼；已补齐五种语言和相关测试，未修改版本号。
+- 已创建 PR #107（`feat/mouse-look-smoothing`），当前保持 open，尚未合并或发布版本。

--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -20,6 +20,10 @@ import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
 import { logError, logInfo } from '@/utils/diagnostics'
 import { inBetween } from '@/utils/is'
+import {
+  getActiveMouseLookSmoothing,
+  getMouseLookInterpolationAlpha,
+} from '@/utils/mouseLookSmoothing'
 import { isMac, isWindows } from '@/utils/platform'
 import { mergeRelativeMouseMovement } from '@/utils/relativeMouse'
 import { reportRuntimeEventQuietly } from '@/utils/runtimeTelemetry'
@@ -44,7 +48,6 @@ export interface UseDeviceOptions extends ModelRuntimeOptions {
   onInputEvent?: (event: DeviceInputEvent) => void
 }
 
-const DAMPING_DECAY = 0.75
 const RUNTIME_USED_REPORT_INTERVAL = 5 * 60 * 1000
 const appWindow = getCurrentWebviewWindow()
 
@@ -146,7 +149,10 @@ export function useDevice(options: UseDeviceOptions = {}) {
 
     lastCursorSmoothingAt = timestamp
 
-    const alpha = 1 - DAMPING_DECAY ** (deltaMS / (1000 / 60))
+    const alpha = getMouseLookInterpolationAlpha(
+      getActiveMouseLookSmoothing(catStore.model),
+      deltaMS,
+    )
 
     const interpolated = {
       x: current.x + (destination.x - current.x) * alpha,
@@ -345,10 +351,10 @@ export function useDevice(options: UseDeviceOptions = {}) {
     const y = cursorPoint.y * scaleFactor.value
     const physicalCursorPoint = new PhysicalPosition(x, y)
 
-    if (windowBounds) {
-      handleMouseMove(physicalCursorPoint, windowBounds)
-    } else {
+    if (catStore.model.windowRelativeMouseLook && !windowBounds) {
       void refreshWindowBounds()
+    } else {
+      void handleMouseMove(physicalCursorPoint, windowBounds)
     }
 
     if (!options.enableWindowHover || !catStore.window.hideOnHover) return

--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -16,9 +16,13 @@ import type { CursorBounds } from '@/utils/relativeMouse'
 import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
 import { logError, logStep, logTrace } from '@/utils/diagnostics'
+import { getCursorMonitor } from '@/utils/monitor'
 import { applyMouseSensitivity } from '@/utils/mouseSensitivity'
 import { isMac } from '@/utils/platform'
-import { applyRelativeMouseMovement, normalizeCursorPosition } from '@/utils/relativeMouse'
+import {
+  applyRelativeMouseMovement,
+  normalizeMouseLookPosition,
+} from '@/utils/relativeMouse'
 
 import live2d, { isLive2dLoadCancelledError } from '../utils/live2d'
 
@@ -580,10 +584,34 @@ export function useModel(runtimeOptions: ModelRuntimeOptions = {}) {
     live2d.setLookTarget(lookTargetX, lookTargetY)
   }
 
-  function handleMouseMove(cursorPoint: PhysicalPosition, windowBounds?: CursorBounds) {
-    if (!windowBounds) return
+  async function handleMouseMove(cursorPoint: PhysicalPosition, windowBounds?: CursorBounds) {
+    let monitorBounds: CursorBounds | undefined
 
-    relativeLookPosition = normalizeCursorPosition(cursorPoint, windowBounds)
+    if (!catStore.model.windowRelativeMouseLook) {
+      const monitor = await getCursorMonitor(cursorPoint)
+
+      if (monitor) {
+        const { size, position } = monitor
+
+        monitorBounds = {
+          x: position.x,
+          y: position.y,
+          width: size.width,
+          height: size.height,
+        }
+      }
+    }
+
+    const nextPosition = normalizeMouseLookPosition(
+      cursorPoint,
+      catStore.model.windowRelativeMouseLook,
+      windowBounds,
+      monitorBounds,
+    )
+
+    if (!nextPosition) return
+
+    relativeLookPosition = nextPosition
 
     applyMouseLook(relativeLookPosition.x, relativeLookPosition.y)
   }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -80,9 +80,11 @@
         "title": "Cat",
         "labels": {
           "modelSettings": "Model Settings",
+          "windowRelativeMouseLook": "Window-relative Mouse Look",
           "mirrorMode": "Mirror Mode",
           "mouseMirror": "Mouse Mirror",
           "mouseSensitivity": "Mouse Follow Sensitivity",
+          "mouseLookSmoothing": "Mouse Look Smoothing",
           "ignoreMouse": "Ignore Mouse Events",
           "windowSettings": "Window Settings",
           "passThrough": "Cat Lock",
@@ -102,9 +104,11 @@
           "typingBehaviorGroup": "Random Group"
         },
         "hints": {
+          "windowRelativeMouseLook": "When enabled, mouse look uses the pet window bounds; when disabled, it uses the monitor bounds.",
           "mirrorMode": "When enabled, the model will be mirrored horizontally.",
           "mouseMirror": "When enabled, the mouse will mirror the hand movement.",
           "mouseSensitivity": "Adjust how strongly the model follows mouse movement. 100% keeps the default response.",
+          "mouseLookSmoothing": "Adjust mouse-look follow smoothing: 0% is most responsive, 75% keeps the current feel, and 100% is smoothest with more visible follow delay.",
           "ignoreMouse": "When enabled, the model will not respond to mouse events. Useful for keyboard mode or gamepad mode.",
           "motionSound": "When enabled, the model will play corresponding sound effects when performing actions (if they exist).",
           "behavior": "When enabled, motions and expressions can be configured and triggered.",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -80,9 +80,11 @@
         "title": "Gato",
         "labels": {
           "modelSettings": "Configurações do Modelo",
+          "windowRelativeMouseLook": "Visão do mouse relativa à janela",
           "mirrorMode": "Modo Espelho",
           "mouseMirror": "Espelho do Mouse",
           "mouseSensitivity": "Sensibilidade ao movimento do mouse",
+          "mouseLookSmoothing": "Suavização da visão do mouse",
           "ignoreMouse": "Ignorar Eventos do Mouse",
           "windowSettings": "Configurações da Janela",
           "passThrough": "Bloqueio do Gato",
@@ -102,9 +104,11 @@
           "typingBehaviorGroup": "Grupo aleat?rio"
         },
         "hints": {
+          "windowRelativeMouseLook": "Quando ativado, a visão do mouse usa os limites da janela do pet; quando desativado, usa os limites do monitor.",
           "mirrorMode": "Quando ativado, o modelo será invertido horizontalmente.",
           "mouseMirror": "Quando ativado, o mouse espelhará o movimento da mão.",
           "mouseSensitivity": "Ajusta a intensidade com que o modelo acompanha o movimento do mouse. 100% mantém a resposta padrão.",
+          "mouseLookSmoothing": "Ajusta a suavidade do acompanhamento do mouse: 0% é mais responsivo, 75% mantém a sensação atual e 100% é mais suave, com atraso mais perceptível.",
           "ignoreMouse": "Quando ativado, o modelo não responderá a eventos do mouse. Útil para o modo teclado ou modo controle.",
           "motionSound": "Quando ativado, o modelo reproduzirá efeitos sonoros correspondentes ao executar ações (se existirem).",
           "behavior": "Quando ativado, movimentos e expressões podem ser configurados e acionados.",

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -80,9 +80,11 @@
         "title": "Mèo",
         "labels": {
           "modelSettings": "Cài đặt Mô hình",
+          "windowRelativeMouseLook": "Góc nhìn chuột theo cửa sổ",
           "mirrorMode": "Chế độ gương",
           "mouseMirror": "Phản chiếu chuột",
           "mouseSensitivity": "Độ nhạy theo chuột",
+          "mouseLookSmoothing": "Độ mượt góc nhìn chuột",
           "ignoreMouse": "Bỏ qua sự kiện chuột",
           "windowSettings": "Cài đặt Cửa sổ",
           "passThrough": "Khóa mèo",
@@ -102,9 +104,11 @@
           "typingBehaviorGroup": "Nh?m ng?u nhi?n"
         },
         "hints": {
+          "windowRelativeMouseLook": "Khi bật, góc nhìn chuột được tính theo ranh giới cửa sổ mèo; khi tắt, góc nhìn được tính theo ranh giới màn hình.",
           "mirrorMode": "Bật để lật ngang mô hình.",
           "mouseMirror": "Khi bật, chuột của mô hình sẽ phản chiếu theo chuyển động chuột thực tế.",
           "mouseSensitivity": "Điều chỉnh mức độ mô hình phản hồi theo chuyển động chuột. 100% giữ nguyên phản hồi mặc định.",
+          "mouseLookSmoothing": "Điều chỉnh độ mượt khi góc nhìn bám theo chuột: 0% phản hồi nhanh nhất, 75% giữ cảm giác hiện tại và 100% mượt nhất nhưng có độ trễ rõ hơn.",
           "ignoreMouse": "Khi bật, mô hình sẽ không phản hồi sự kiện chuột. Hữu ích cho chế độ bàn phím hoặc chế độ tay cầm.",
           "motionSound": "Khi bật, mô hình sẽ phát các âm thanh tương ứng khi thực hiện hành động (nếu tồn tại).",
           "behavior": "Khi bật, các hành động và biểu cảm có thể được cấu hình và kích hoạt.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -80,9 +80,11 @@
         "title": "猫咪设置",
         "labels": {
           "modelSettings": "模型设置",
+          "windowRelativeMouseLook": "窗口相对鼠标视角",
           "mirrorMode": "镜像模式",
           "mouseMirror": "鼠标镜像",
           "mouseSensitivity": "鼠标跟随灵敏度",
+          "mouseLookSmoothing": "鼠标视角平滑度",
           "ignoreMouse": "忽略鼠标事件",
           "windowSettings": "窗口设置",
           "passThrough": "猫咪锁定",
@@ -102,9 +104,11 @@
           "typingBehaviorGroup": "随机组"
         },
         "hints": {
+          "windowRelativeMouseLook": "开启后，鼠标视角将根据宠物窗口边界计算；关闭后恢复按显示器边界计算。",
           "mirrorMode": "启用后，模型将水平镜像翻转。",
           "mouseMirror": "启用后，鼠标将镜像跟随手部移动。",
           "mouseSensitivity": "调整模型跟随鼠标移动的响应幅度，100% 保持默认响应。",
+          "mouseLookSmoothing": "调整鼠标视角的跟随平滑度，0% 最跟手，75% 保持当前手感，100% 平滑度最高但跟随延迟更明显。",
           "ignoreMouse": "启用后，模型将不再响应鼠标事件，适用于键盘模式或手柄模式。",
           "motionSound": "启用后，模型执行动作时会播放对应音效（如果存在）。",
           "behavior": "启用后，可以配置和触发模型的动作与表情。",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -80,9 +80,11 @@
         "title": "貓咪設定",
         "labels": {
           "modelSettings": "模型設定",
+          "windowRelativeMouseLook": "視窗相對滑鼠視角",
           "mirrorMode": "鏡像模式",
           "mouseMirror": "滑鼠游標鏡像",
           "mouseSensitivity": "滑鼠跟隨靈敏度",
+          "mouseLookSmoothing": "滑鼠視角平滑度",
           "ignoreMouse": "忽略滑鼠事件",
           "windowSettings": "視窗設定",
           "passThrough": "貓咪鎖定",
@@ -102,9 +104,11 @@
           "typingBehaviorGroup": "隨機組"
         },
         "hints": {
+          "windowRelativeMouseLook": "啟用後，滑鼠視角會根據貓咪視窗邊界計算；關閉後恢復依螢幕邊界計算。",
           "mirrorMode": "啟用後，模型將水平鏡像翻轉。",
           "mouseMirror": "啟用後，滑鼠游標將鏡像跟隨手部移動。",
           "mouseSensitivity": "調整模型跟隨滑鼠移動的回應幅度，100% 保持預設回應。",
+          "mouseLookSmoothing": "調整滑鼠視角的跟隨平滑度，0% 最即時，75% 保持目前手感，100% 平滑度最高但跟隨延遲更明顯。",
           "ignoreMouse": "啟用後，模型將不再回應滑鼠事件，適用於鍵盤模式或手柄模式。",
           "motionSound": "啟用後，模型執行動作時會播放對應音效（如果存在）。",
           "behavior": "啟用後，可以配置和觸發模型的動作與表情。",

--- a/src/pages/preference/components/cat/index.vue
+++ b/src/pages/preference/components/cat/index.vue
@@ -13,12 +13,23 @@ import { useDeviceInputStatus } from '@/composables/useDeviceInputStatus'
 import { returnMainWindowToScreen } from '@/composables/useWindowState'
 import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
+import {
+  getActiveMouseLookSmoothing,
+  MOUSE_LOOK_SMOOTHING_MAX,
+  MOUSE_LOOK_SMOOTHING_MIN,
+  setActiveMouseLookSmoothing,
+} from '@/utils/mouseLookSmoothing'
 import { MOUSE_SENSITIVITY_MAX, MOUSE_SENSITIVITY_MIN } from '@/utils/mouseSensitivity'
 import { isWindows } from '@/utils/platform'
 
 const catStore = useCatStore()
 const modelStore = useModelStore()
 const { status: inputStatus } = useDeviceInputStatus()
+
+const mouseLookSmoothing = computed<number>({
+  get: () => getActiveMouseLookSmoothing(catStore.model),
+  set: value => setActiveMouseLookSmoothing(catStore.model, value),
+})
 
 const hideOnHoverSupported = computed(() => inputStatus.value?.hoverSupported !== false)
 
@@ -49,6 +60,13 @@ const typingBehaviorGroupOptions = computed(() => {
 
 <template>
   <ProList :title="$t('pages.preference.cat.labels.modelSettings')">
+    <ProListItem
+      :description="$t('pages.preference.cat.hints.windowRelativeMouseLook')"
+      :title="$t('pages.preference.cat.labels.windowRelativeMouseLook')"
+    >
+      <Switch v-model:checked="catStore.model.windowRelativeMouseLook" />
+    </ProListItem>
+
     <ProListItem
       :description="$t('pages.preference.cat.hints.mirrorMode')"
       :title="$t('pages.preference.cat.labels.mirrorMode')"
@@ -90,6 +108,40 @@ const typingBehaviorGroupOptions = computed(() => {
             class="w-24"
             :max="MOUSE_SENSITIVITY_MAX"
             :min="MOUSE_SENSITIVITY_MIN"
+          />
+
+          <SpaceAddon>%</SpaceAddon>
+        </SpaceCompact>
+      </Flex>
+    </ProListItem>
+
+    <ProListItem
+      :description="$t('pages.preference.cat.hints.mouseLookSmoothing')"
+      :title="$t('pages.preference.cat.labels.mouseLookSmoothing')"
+      vertical
+    >
+      <Flex
+        align="center"
+        class="gap-4"
+      >
+        <Slider
+          v-model:value="mouseLookSmoothing"
+          class="flex-1 m-0!"
+          :max="MOUSE_LOOK_SMOOTHING_MAX"
+          :min="MOUSE_LOOK_SMOOTHING_MIN"
+          :tooltip="{
+            formatter(value) {
+              return `${value}%`
+            },
+          }"
+        />
+
+        <SpaceCompact>
+          <InputNumber
+            v-model:value="mouseLookSmoothing"
+            class="w-24"
+            :max="MOUSE_LOOK_SMOOTHING_MAX"
+            :min="MOUSE_LOOK_SMOOTHING_MIN"
           />
 
           <SpaceAddon>%</SpaceAddon>

--- a/src/stores/cat.ts
+++ b/src/stores/cat.ts
@@ -5,6 +5,10 @@
 import { defineStore } from 'pinia'
 import { reactive, ref } from 'vue'
 
+import {
+  MOUSE_LOOK_SMOOTHING_DEFAULT,
+  normalizeMouseLookSmoothing,
+} from '@/utils/mouseLookSmoothing'
 import { MOUSE_SENSITIVITY_DEFAULT, normalizeMouseSensitivity } from '@/utils/mouseSensitivity'
 import { persistStateWhenWritable } from '@/utils/persistence'
 
@@ -21,6 +25,9 @@ export interface CatStore {
     autoReleaseDelay: number
     maxFPS: number
     ignoreMouse: boolean
+    windowRelativeMouseLook: boolean
+    mouseLookSmoothing: number
+    legacyMouseLookSmoothing: number
     mouseSensitivity: number
   }
   window: {
@@ -75,6 +82,9 @@ export const useCatStore = defineStore('cat', () => {
     autoReleaseDelay: 3,
     maxFPS: 60,
     ignoreMouse: false,
+    windowRelativeMouseLook: true,
+    mouseLookSmoothing: MOUSE_LOOK_SMOOTHING_DEFAULT,
+    legacyMouseLookSmoothing: MOUSE_LOOK_SMOOTHING_DEFAULT,
     mouseSensitivity: MOUSE_SENSITIVITY_DEFAULT,
   })
 
@@ -94,6 +104,12 @@ export const useCatStore = defineStore('cat', () => {
   })
 
   const init = () => {
+    if (typeof model.windowRelativeMouseLook !== 'boolean') {
+      model.windowRelativeMouseLook = true
+    }
+
+    model.mouseLookSmoothing = normalizeMouseLookSmoothing(model.mouseLookSmoothing)
+    model.legacyMouseLookSmoothing = normalizeMouseLookSmoothing(model.legacyMouseLookSmoothing)
     model.mouseSensitivity = normalizeMouseSensitivity(model.mouseSensitivity)
 
     if (!window.gameMode || !Array.isArray(window.gameMode.processes)) {

--- a/src/utils/mouseLookSmoothing.test.ts
+++ b/src/utils/mouseLookSmoothing.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
+import test from 'node:test'
+
+import {
+  getActiveMouseLookSmoothing,
+  getMouseLookDampingDecay,
+  getMouseLookInterpolationAlpha,
+  normalizeMouseLookSmoothing,
+  setActiveMouseLookSmoothing,
+} from './mouseLookSmoothing'
+
+test('normalizes mouse-look smoothing values within the supported range', () => {
+  assert.equal(normalizeMouseLookSmoothing(0), 0)
+  assert.equal(normalizeMouseLookSmoothing(75), 75)
+  assert.equal(normalizeMouseLookSmoothing(100), 100)
+  assert.equal(normalizeMouseLookSmoothing(-10), 0)
+  assert.equal(normalizeMouseLookSmoothing(110), 100)
+  assert.equal(normalizeMouseLookSmoothing('75'), 75)
+  assert.equal(normalizeMouseLookSmoothing(Number.NaN), 75)
+})
+
+test('maps smoothing values to the direct, current, and strongest response levels', () => {
+  assert.equal(getMouseLookDampingDecay(0), 0)
+  assert.equal(getMouseLookDampingDecay(75), 0.75)
+  assert.equal(getMouseLookDampingDecay(100), 0.95)
+
+  const frameMS = 1000 / 60
+  assert.equal(getMouseLookInterpolationAlpha(0, frameMS), 1)
+  assert.ok(Math.abs(getMouseLookInterpolationAlpha(75, frameMS) - 0.25) < Number.EPSILON)
+  assert.ok(Math.abs(getMouseLookInterpolationAlpha(100, frameMS) - 0.05) < Number.EPSILON)
+})
+
+test('keeps malformed smoothing input defensive when calculating interpolation', () => {
+  assert.equal(getMouseLookDampingDecay(-10), 0)
+  assert.equal(getMouseLookDampingDecay(110), 0.95)
+  assert.equal(getMouseLookDampingDecay('invalid'), 0.75)
+  assert.ok(getMouseLookInterpolationAlpha(Number.NaN, 1000 / 60) > 0)
+})
+
+test('reads and writes smoothing for the active mouse-look algorithm only', () => {
+  const settings = {
+    windowRelativeMouseLook: true,
+    mouseLookSmoothing: 25,
+    legacyMouseLookSmoothing: 85,
+  }
+
+  assert.equal(getActiveMouseLookSmoothing(settings), 25)
+  assert.equal(setActiveMouseLookSmoothing(settings, 40), 40)
+  assert.equal(settings.mouseLookSmoothing, 40)
+  assert.equal(settings.legacyMouseLookSmoothing, 85)
+
+  settings.windowRelativeMouseLook = false
+
+  assert.equal(getActiveMouseLookSmoothing(settings), 85)
+  assert.equal(setActiveMouseLookSmoothing(settings, 60), 60)
+  assert.equal(settings.mouseLookSmoothing, 40)
+  assert.equal(settings.legacyMouseLookSmoothing, 60)
+})

--- a/src/utils/mouseLookSmoothing.ts
+++ b/src/utils/mouseLookSmoothing.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 InfinityXCat
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+export const MOUSE_LOOK_SMOOTHING_MIN = 0
+export const MOUSE_LOOK_SMOOTHING_MAX = 100
+export const MOUSE_LOOK_SMOOTHING_DEFAULT = 75
+export const MOUSE_LOOK_DAMPING_DECAY_DEFAULT = 0.75
+export const MOUSE_LOOK_DAMPING_DECAY_MAX = 0.95
+
+const MOUSE_LOOK_SMOOTHING_REFERENCE = 75
+const FRAME_DURATION_MS = 1000 / 60
+
+export interface MouseLookSmoothingSettings {
+  windowRelativeMouseLook: boolean
+  mouseLookSmoothing: number
+  legacyMouseLookSmoothing: number
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function normalizeMouseLookSmoothing(value: unknown) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return MOUSE_LOOK_SMOOTHING_DEFAULT
+
+  return clamp(value, MOUSE_LOOK_SMOOTHING_MIN, MOUSE_LOOK_SMOOTHING_MAX)
+}
+
+export function getMouseLookDampingDecay(value: unknown) {
+  const smoothing = normalizeMouseLookSmoothing(value)
+
+  if (smoothing <= MOUSE_LOOK_SMOOTHING_REFERENCE) {
+    return smoothing / 100
+  }
+
+  const extraSmoothing = (smoothing - MOUSE_LOOK_SMOOTHING_REFERENCE)
+    / (MOUSE_LOOK_SMOOTHING_MAX - MOUSE_LOOK_SMOOTHING_REFERENCE)
+
+  return MOUSE_LOOK_DAMPING_DECAY_DEFAULT
+    + extraSmoothing * (MOUSE_LOOK_DAMPING_DECAY_MAX - MOUSE_LOOK_DAMPING_DECAY_DEFAULT)
+}
+
+export function getMouseLookInterpolationAlpha(value: unknown, deltaMS: number) {
+  const dampingDecay = getMouseLookDampingDecay(value)
+  const frameDelta = Number.isFinite(deltaMS)
+    ? Math.max(0, deltaMS) / FRAME_DURATION_MS
+    : 1
+
+  if (dampingDecay === 0) return 1
+
+  return 1 - dampingDecay ** frameDelta
+}
+
+export function getActiveMouseLookSmoothing(settings: MouseLookSmoothingSettings) {
+  const value = settings.windowRelativeMouseLook
+    ? settings.mouseLookSmoothing
+    : settings.legacyMouseLookSmoothing
+
+  return normalizeMouseLookSmoothing(value)
+}
+
+export function setActiveMouseLookSmoothing(settings: MouseLookSmoothingSettings, value: unknown) {
+  const normalized = normalizeMouseLookSmoothing(value)
+
+  if (settings.windowRelativeMouseLook) {
+    settings.mouseLookSmoothing = normalized
+  } else {
+    settings.legacyMouseLookSmoothing = normalized
+  }
+
+  return normalized
+}

--- a/src/utils/relativeMouse.test.ts
+++ b/src/utils/relativeMouse.test.ts
@@ -5,7 +5,35 @@ import assert from 'node:assert/strict'
 // eslint-disable-next-line test/no-import-node-test -- Vitest is not installed; this test runs through tsx's Node test runner.
 import test from 'node:test'
 
-import { applyRelativeMouseMovement, mergeRelativeMouseMovement, normalizeCursorPosition } from './relativeMouse'
+import {
+  applyRelativeMouseMovement,
+  mergeRelativeMouseMovement,
+  normalizeCursorPosition,
+  normalizeMouseLookPosition,
+} from './relativeMouse'
+
+test('selects window or monitor bounds for the corresponding mouse-look algorithm', () => {
+  const windowBounds = { x: 1000, y: 500, width: 500, height: 500 }
+  const monitorBounds = { x: 0, y: 0, width: 2000, height: 1000 }
+
+  assert.deepEqual(
+    normalizeMouseLookPosition({ x: 1250, y: 750 }, true, windowBounds, monitorBounds),
+    { x: 0.5, y: 0.5 },
+  )
+  assert.deepEqual(
+    normalizeMouseLookPosition({ x: 1000, y: 500 }, false, windowBounds, monitorBounds),
+    { x: 0.5, y: 0.5 },
+  )
+})
+
+test('keeps mouse-look normalization defensive when the selected bounds are missing', () => {
+  const windowBounds = { x: 1000, y: 500, width: 500, height: 500 }
+  const monitorBounds = { x: 0, y: 0, width: 2000, height: 1000 }
+
+  assert.equal(normalizeMouseLookPosition({ x: 1250, y: 750 }, true, undefined, monitorBounds), undefined)
+  assert.equal(normalizeMouseLookPosition({ x: 1000, y: 500 }, false, windowBounds, undefined), undefined)
+  assert.equal(normalizeMouseLookPosition({ x: 0, y: 0 }, true, { x: 0, y: 0, width: 0, height: 100 }, monitorBounds), undefined)
+})
 
 test('normalizes an absolute cursor position relative to the pet window', () => {
   assert.deepEqual(normalizeCursorPosition(

--- a/src/utils/relativeMouse.ts
+++ b/src/utils/relativeMouse.ts
@@ -29,6 +29,37 @@ export function normalizeCursorPosition(
   }
 }
 
+export function selectMouseLookBounds(
+  windowRelativeMouseLook: boolean,
+  windowBounds: CursorBounds | undefined,
+  monitorBounds: CursorBounds | undefined,
+) {
+  return windowRelativeMouseLook ? windowBounds : monitorBounds
+}
+
+export function normalizeMouseLookPosition(
+  cursor: { x: number, y: number },
+  windowRelativeMouseLook: boolean,
+  windowBounds: CursorBounds | undefined,
+  monitorBounds: CursorBounds | undefined,
+): NormalizedCursorPosition | undefined {
+  const bounds = selectMouseLookBounds(windowRelativeMouseLook, windowBounds, monitorBounds)
+
+  if (!bounds
+    || !Number.isFinite(cursor.x)
+    || !Number.isFinite(cursor.y)
+    || !Number.isFinite(bounds.x)
+    || !Number.isFinite(bounds.y)
+    || !Number.isFinite(bounds.width)
+    || !Number.isFinite(bounds.height)
+    || bounds.width <= 0
+    || bounds.height <= 0) {
+    return undefined
+  }
+
+  return normalizeCursorPosition(cursor, bounds)
+}
+
 export function applyRelativeMouseMovement(
   position: NormalizedCursorPosition,
   dx: number,


### PR DESCRIPTION
## Summary
- add a window-relative mouse-look toggle with the legacy monitor-relative fallback
- persist independent smoothing values for both algorithms
- localize the settings and cover normalization, interpolation, coordinate selection, and persistence mapping

## Validation
- pnpm test
- pnpm exec tsc --noEmit -p tsconfig.json
- related ESLint checks
- pnpm build:vite
- git diff --check

Version metadata is unchanged. This PR is intentionally left open for review.