### PR TITLE
chore(release): prepare v1.2.1

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -212,3 +212,4 @@ BongoCat 是一个基于 Vue 3 + Vite + Tauri 2 的跨平台桌面宠物应用�
 - 修复后重新构建 Windows x64 便捷包：`target/release/bundle/portable/MochiPaw_1.2.1-3_windows_x64_portable.zip`，大小 `9007466` 字节；已验证包含主程序、便携标记和模型资源；SHA-256：`B878EDDCF265912609CC204C99E0E2AEF5B594EEA5734B0B4DA9CC2385A35FDE`。
 - 2026-08-27 根据新日志定位到动态 WebView2 创建错误 `0x8007139F`；对照 `v1.1.9` 移除后续版本给静态窗口和动态子模型窗口注入的 `additionalBrowserArgs` / `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`，避免多 WebView 环境参数冲突。
 - 修复后再次构建 Windows x64 便捷包：`target/release/bundle/portable/MochiPaw_1.2.1-3_windows_x64_portable.zip`，大小 `9007464` 字节；已验证包含主程序、便携标记和模型资源；SHA-256：`9A1A90AAA3B05603893FE19702EF424E64194157EFE892E93F9B638CC15B49E8`。
+- 2026-08-27 已合并 PR #107（鼠标视角算法与平滑度）及 PR #108（按 `v1.1.9` 恢复子模型窗口管道并移除 WebView2 环境参数冲突）；现准备 `v1.2.1` 正式版，正式说明沿用 `v1.2.0` 的 `## What's New` 格式。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.2.1-3"
+version = "1.2.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.2.1-3",
+  "version": "1.2.1",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "mochi-paw"
 default-run = "mochi-paw"
-version = "1.2.1-3"
+version = "1.2.1"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary

- prepare package, Cargo manifest, and Cargo.lock for v1.2.1
- consolidate the v1.2.1 preview improvements for the stable release

## What's New

- **Windows Raw Input compatibility:** Added a Windows Raw Input backend using `RIDEV_INPUTSINK` for signed relative mouse movement, while retaining keyboard and mouse-button handling. (#101)
- **Window-relative mouse look:** Eye tracking now normalizes absolute cursor positions against the pet window's physical bounds, including secondary monitors with negative coordinates and mixed-DPI layouts. (#103)
- **Configurable mouse-look modes:** Added a monitor-relative fallback and independent smoothing settings for each algorithm, with smoothing from 0% direct response through 100% maximum damping. (#107)
- **Model editor expression recovery:** The preference editor now reads expression entries directly from the model JSON when runtime expression state is empty, so imported models retain their expressions in the editor. (#104)
- **Reliable submodel window startup:** Restored the v1.1.9 submodel creation/runtime-ready pipeline and removed conflicting WebView2 environment arguments that could block additional windows with `0x8007139F`. (#108)
- **Regression coverage:** Added focused tests for Raw Input, relative mouse movement, mixed-DPI/window bounds, smoothing, model expressions, and submodel window labels. (#101, #103, #104, #107, #108)

This is the stable v1.2.1 release. It consolidates the v1.2.1 preview improvements for Windows input, mouse-look tracking, model editing, and submodel window startup. Stable clients receive it through the signed `latest-v2.json` automatic-update channel.

Clients on the 1.1.x updater channel use a retired signing key and must install v1.2.0 manually once. After the manual bridge installation, v1.2.1 and later releases use the current signed `latest-v2.json` channel for automatic updates.

## Validation

- `pnpm test` (174/174)
- `pnpm exec tsc --noEmit -p tsconfig.json`
- `pnpm exec tsx scripts/checkReleaseVersion.ts v1.2.1`
- `git diff --check`

## Release

This PR prepares the stable v1.2.1 release.