### PR TITLE
chore(release): prepare v1.2.2-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.2.2-1"
+version = "1.2.2-2"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.2.2-1",
+  "version": "1.2.2-2",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "mochi-paw"
 default-run = "mochi-paw"
-version = "1.2.2-1"
+version = "1.2.2-2"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary

- Bump package, Cargo manifest, and Cargo.lock to v1.2.2-2.
- Publish the follow-up Windows preview containing the startup renderer recovery fix from v1.2.2-1.

## Verification

- pnpm exec tsx scripts/checkReleaseVersion.ts v1.2.2-2
- pnpm test (175 passed)
- pnpm exec tsc --noEmit -p tsconfig.json