### PR TITLE
fix(live2d): play motion-bound voice assets

### DIFF
--- a/src/vendor/easy-live2d/model/EffectController.ts
+++ b/src/vendor/easy-live2d/model/EffectController.ts
@@ -11,6 +11,8 @@ import { csmVector as CsmVector } from '@Framework/type/csmvector'
 import { sound } from '@pixi/sound'
 import { SoundLoader } from '../loader/SoundLoader'
 
+let nextVoiceAliasId = 0
+
 /**
  * 效果控制器
  * 管理眨眼、呼吸、唇形同步、拖拽跟随
@@ -21,6 +23,8 @@ export class EffectController {
   private _eyeBlinkIds = new CsmVector<CubismIdHandle>()
   private _lipSyncIds = new CsmVector<CubismIdHandle>()
   private _soundLoader = new SoundLoader()
+  private _voiceGeneration = 0
+  private _voiceAliases = new Set<string>()
 
   // 拖拽相关参数 ID
   private _idParamAngleX: CubismIdHandle
@@ -120,16 +124,53 @@ export class EffectController {
       return
     if (immediate)
       this.stopVoice()
-    sound.add('voice', voicePath)
-    await this._soundLoader.start(voicePath)
-    await sound.play('voice')
+
+    const generation = this._voiceGeneration
+    const alias = `voice-${++nextVoiceAliasId}`
+    this._voiceAliases.add(alias)
+    sound.add(alias, voicePath)
+
+    const pcmPromise = this._soundLoader.start(voicePath)
+
+    try {
+      const instance = await sound.play(alias)
+      const cleanup = () => this.cleanupVoice(alias)
+      instance.once('end', cleanup)
+      instance.once('stop', cleanup)
+
+      await pcmPromise
+
+      if (generation !== this._voiceGeneration) {
+        cleanup()
+      }
+    } catch (error) {
+      void pcmPromise.catch(() => false)
+      this.cleanupVoice(alias)
+
+      if (generation === this._voiceGeneration)
+        throw error
+    }
   }
 
   stopVoice(): void {
-    if (sound.exists('voice')) {
-      sound.stop('voice')
-      sound.remove('voice')
+    this._voiceGeneration += 1
+
+    for (const alias of this._voiceAliases) {
+      if (sound.exists(alias)) {
+        sound.stop(alias)
+        if (sound.exists(alias))
+          sound.remove(alias)
+      }
     }
+
+    this._voiceAliases.clear()
     this._soundLoader.releasePcmData()
+  }
+
+  private cleanupVoice(alias: string): void {
+    if (sound.exists(alias)) {
+      sound.remove(alias)
+    }
+    this._voiceAliases.delete(alias)
   }
 }

--- a/src/vendor/easy-live2d/model/Live2DModel.ts
+++ b/src/vendor/easy-live2d/model/Live2DModel.ts
@@ -143,6 +143,11 @@ export class Live2DModel extends CubismUserModel {
     this._initialized = value
   }
 
+  override release(): void {
+    this.effectCtrl.stopVoice()
+    super.release()
+  }
+
   update(deltaTime: number): void {
     if (!this._ready)
       return

--- a/src/vendor/easy-live2d/model/MotionController.test.ts
+++ b/src/vendor/easy-live2d/model/MotionController.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test -- Project tests use the Node test runner through tsx.
+import test from 'node:test'
+
+import type { ICubismModelSetting } from '@Framework/icubismmodelsetting'
+
+import { Priority, Config } from '../utils/config'
+import { MotionController } from './MotionController'
+
+function createSetting(soundFile = 'voice.wav') {
+  return {
+    getMotionFileName: () => 'motion.motion3.json',
+    getMotionSoundFileName: () => soundFile,
+  } as unknown as ICubismModelSetting
+}
+
+function createMotion() {
+  return {
+    setEffectIds: () => {},
+    setBeganMotionHandler: () => {},
+    setFinishedMotionHandler: () => {},
+  }
+}
+
+function createController(playVoice: (path: string, immediate: boolean) => Promise<void>) {
+  const started: unknown[] = []
+  const manager = {
+    reserveMotion: () => true,
+    setReservePriority: () => {},
+    startMotionPriority: (motion: unknown) => {
+      started.push(motion)
+      return 1
+    },
+  }
+  const vector = { toArray: () => [] }
+  const controller = new MotionController(
+    manager as never,
+    vector as never,
+    vector as never,
+    () => createMotion() as never,
+    playVoice,
+  )
+
+  return { controller, started }
+}
+
+test('plays the Sound entry using a redirected URL when a motion starts', async () => {
+  const played: Array<{ path: string, immediate: boolean }> = []
+  const { controller, started } = createController(async (path, immediate) => {
+    played.push({ path, immediate })
+  })
+
+  controller.setContext(createSetting(), 'file:///models/', {
+    Moc: '',
+    Textures: [],
+    Physics: '',
+    Pose: '',
+    Expressions: [],
+    Motions: {},
+    MotionSounds: { CAT: ['file:///redirected/voice.wav'] },
+    UserData: '',
+  })
+  controller.loadMotionData('CAT', 0, new ArrayBuffer(0), createSetting())
+
+  const previous = Config.MotionSound
+  Config.MotionSound = true
+  try {
+    await controller.startMotion('CAT', 0, Priority.Normal)
+  } finally {
+    Config.MotionSound = previous
+  }
+
+  assert.equal(started.length, 1)
+  assert.deepEqual(played, [{ path: 'file:///redirected/voice.wav', immediate: true }])
+})
+
+test('does not play motion audio when the feature is disabled or Sound is absent', async () => {
+  const played: string[] = []
+  const { controller } = createController(async path => {
+    played.push(path)
+  })
+  const setting = createSetting('')
+  controller.setContext(setting, 'file:///models/', {
+    Moc: '',
+    Textures: [],
+    Physics: '',
+    Pose: '',
+    Expressions: [],
+    Motions: {},
+    MotionSounds: {},
+    UserData: '',
+  })
+  controller.loadMotionData('CAT', 0, new ArrayBuffer(0), setting)
+
+  const previous = Config.MotionSound
+  try {
+    Config.MotionSound = false
+    await controller.startMotion('CAT', 0, Priority.Normal)
+    Config.MotionSound = true
+    await controller.startMotion('CAT', 0, Priority.Normal)
+  } finally {
+    Config.MotionSound = previous
+  }
+
+  assert.deepEqual(played, [])
+})

--- a/src/vendor/easy-live2d/utils/cubismSetting.test.ts
+++ b/src/vendor/easy-live2d/utils/cubismSetting.test.ts
@@ -54,3 +54,30 @@ test('treats optional model resources as absent without breaking path redirectio
   assert.equal(setting.getHitAreasCount(), 0)
   assert.doesNotThrow(() => setting.redirectPath(({ file }) => `/models/${file}`))
 })
+
+test('redirects motion sounds alongside motion files without inventing missing sounds', () => {
+  const setting = new CubismSetting({
+    modelJSON: {
+      Version: 3,
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: [],
+        Motions: {
+          CAT: [
+            { File: 'wave.motion3.json', Sound: 'wave.flac' },
+            { File: 'idle.motion3.json' },
+          ],
+        },
+      },
+    },
+  })
+
+  setting.redirectPath(({ file }) => `/models/${file}`)
+
+  assert.deepEqual(setting.redirPath.Motions, {
+    CAT: ['/models/wave.motion3.json', '/models/idle.motion3.json'],
+  })
+  assert.deepEqual(setting.redirPath.MotionSounds, {
+    CAT: ['/models/wave.flac'],
+  })
+})


### PR DESCRIPTION
## Summary

- play audio declared by FileReferences.Motions[*].Sound when a motion starts
- resolve redirected model asset URLs and keep playback aliases unique across windows
- cancel stale immediate voice loads and clean audio when playback ends or the model is released
- add regression coverage for motion dispatch, feature toggles, missing sounds, and redirected paths

## Verification

- pnpm test (178 passed)
- pnpm exec tsc --noEmit -p tsconfig.json
- pnpm build:vite
- pnpm exec eslint src --max-warnings 1 (one existing UnoCSS ordering warning)
- git diff --check

Closes #94

This PR is intentionally left open for review and is not being merged in this task.
