### PR TITLE
chore(release): prepare v1.2.2-3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "mochi-paw"
-version = "1.2.2-2"
+version = "1.2.2-3"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mochi-paw",
   "type": "module",
-  "version": "1.2.2-2",
+  "version": "1.2.2-3",
   "private": false,
   "author": {
     "name": "CatStack / InfinityXCat",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "mochi-paw"
 default-run = "mochi-paw"
-version = "1.2.2-2"
+version = "1.2.2-3"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
 edition = "2024"


### PR DESCRIPTION
## Summary\n- bump package and Tauri versions to 1.2.2-3\n- prepare the tag-driven prerelease packaging workflow\n\n## Validation\n- pnpm test (178 passed)\n- pnpm exec tsc --noEmit -p tsconfig.json\n- pnpm build:vite\n- cargo check --workspace --all-targets --locked\n- pnpm exec tsx scripts/checkReleaseVersion.ts v1.2.2-3\n\nRelated: #116 and #94